### PR TITLE
Zugriff auf Urlaubsverwaltung nur für bestimmte OIDC-User erlauben

### DIFF
--- a/.examples/docker-compose/with-keycloak/keycloak/import/urlaubsverwaltung-realm.json
+++ b/.examples/docker-compose/with-keycloak/keycloak/import/urlaubsverwaltung-realm.json
@@ -29,7 +29,7 @@
   "oauth2DevicePollingInterval" : 5,
   "enabled" : true,
   "sslRequired" : "external",
-  "registrationAllowed" : false,
+  "registrationAllowed" : true,
   "registrationEmailAsUsername" : true,
   "rememberMe" : false,
   "verifyEmail" : true,
@@ -72,6 +72,14 @@
       "id" : "06b1e454-f3e5-4d78-85ea-4e0f7769ce34",
       "name" : "uma_authorization",
       "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "urlaubsverwaltung",
+      "attributes" : { }
+    }, {
+      "id" : "9b770d1e-90cd-49d9-8ec0-f89e6e39e38e",
+      "name" : "urlaubsverwaltung_user",
+      "description" : "",
       "composite" : false,
       "clientRole" : false,
       "containerId" : "urlaubsverwaltung",
@@ -336,7 +344,15 @@
       } ]
     }
   },
-  "groups" : [ ],
+  "groups" : [ {
+    "id" : "654f23c0-ae3b-412b-b627-dc77ccbaa5e0",
+    "name" : "urlaubsverwaltung access",
+    "path" : "/urlaubsverwaltung access",
+    "attributes" : { },
+    "realmRoles" : [ "urlaubsverwaltung_user" ],
+    "clientRoles" : { },
+    "subGroups" : [ ]
+  } ],
   "defaultRole" : {
     "id" : "ddc246e0-d094-468b-9ad3-6cd2301bb8a2",
     "name" : "default-roles-urlaubsverwaltung",
@@ -353,7 +369,7 @@
   "otpPolicyLookAheadWindow" : 1,
   "otpPolicyPeriod" : 30,
   "otpPolicyCodeReusable" : false,
-  "otpSupportedApplications" : [ "totpAppGoogleName", "totpAppFreeOTPName" ],
+  "otpSupportedApplications" : [ "totpAppFreeOTPName", "totpAppGoogleName" ],
   "webAuthnPolicyRpEntityName" : "keycloak",
   "webAuthnPolicySignatureAlgorithms" : [ "ES256" ],
   "webAuthnPolicyRpId" : "",
@@ -1171,7 +1187,7 @@
       "subType" : "anonymous",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "saml-user-property-mapper", "oidc-address-mapper", "oidc-usermodel-property-mapper", "saml-role-list-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper", "oidc-usermodel-attribute-mapper", "saml-user-attribute-mapper" ]
+        "allowed-protocol-mapper-types" : [ "oidc-sha256-pairwise-sub-mapper", "saml-role-list-mapper", "oidc-usermodel-property-mapper", "saml-user-attribute-mapper", "oidc-usermodel-attribute-mapper", "oidc-full-name-mapper", "oidc-address-mapper", "saml-user-property-mapper" ]
       }
     }, {
       "id" : "08ab9858-507e-4d69-8625-e7697c0f25b2",
@@ -1208,7 +1224,7 @@
       "subType" : "authenticated",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "saml-role-list-mapper", "saml-user-property-mapper", "saml-user-attribute-mapper", "oidc-full-name-mapper", "oidc-address-mapper", "oidc-usermodel-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-sha256-pairwise-sub-mapper" ]
+        "allowed-protocol-mapper-types" : [ "saml-user-property-mapper", "saml-user-attribute-mapper", "oidc-usermodel-attribute-mapper", "saml-role-list-mapper", "oidc-full-name-mapper", "oidc-address-mapper", "oidc-usermodel-property-mapper", "oidc-sha256-pairwise-sub-mapper" ]
       }
     }, {
       "id" : "987c9751-059b-4516-9271-3c23bd026168",
@@ -1221,7 +1237,7 @@
       }
     } ],
     "org.keycloak.userprofile.UserProfileProvider" : [ {
-      "id" : "ead415ed-ded4-4332-a3e7-2ddcec7f829d",
+      "id" : "34c7e437-0180-45a7-9be5-07bde7f47e24",
       "providerId" : "declarative-user-profile",
       "subComponents" : { },
       "config" : { }
@@ -1263,7 +1279,7 @@
   "supportedLocales" : [ "de", "en" ],
   "defaultLocale" : "de",
   "authenticationFlows" : [ {
-    "id" : "74e1b826-3b37-4631-b5ba-e1abda6408fd",
+    "id" : "c89803f8-21ae-4e1c-875a-6487eea3d709",
     "alias" : "Handle Existing Account",
     "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
     "providerId" : "basic-flow",
@@ -1285,7 +1301,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "6bdf0b26-9e0f-4871-9799-61c66c55158e",
+    "id" : "edd023c0-1b5f-4a6f-b0c3-ba87def6017b",
     "alias" : "Handle Existing Account - Alternatives - 0",
     "description" : "Subflow of Handle Existing Account with alternative executions",
     "providerId" : "basic-flow",
@@ -1307,7 +1323,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "4ff93a70-10d8-4cec-b039-88e53bdc8072",
+    "id" : "b61fd402-5e05-4607-93a2-d524b73d19c3",
     "alias" : "Verify Existing Account by Re-authentication",
     "description" : "Reauthentication of existing account",
     "providerId" : "basic-flow",
@@ -1329,7 +1345,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "9b2d0e5c-1679-40ba-a42e-04124488e86e",
+    "id" : "54eb0621-5557-4317-8a48-68472f549df7",
     "alias" : "Verify Existing Account by Re-authentication - auth-otp-form - Conditional",
     "description" : "Flow to determine if the auth-otp-form authenticator should be used or not.",
     "providerId" : "basic-flow",
@@ -1351,7 +1367,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "866439d8-21eb-40fd-a29a-abf2feb3d76f",
+    "id" : "852c5f44-2355-4bba-b44d-83a1e25c5800",
     "alias" : "browser",
     "description" : "browser based authentication",
     "providerId" : "basic-flow",
@@ -1387,7 +1403,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "70df3097-e0bf-431c-af5e-f89ae189b7b6",
+    "id" : "c1292eac-679e-4907-951b-b8bab2c8fb01",
     "alias" : "clients",
     "description" : "Base authentication for clients",
     "providerId" : "client-flow",
@@ -1423,7 +1439,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "3671d377-5fed-4a56-a159-0f976722dbf8",
+    "id" : "a8a92b04-2098-481e-8e70-6ea1cfd3fc23",
     "alias" : "direct grant",
     "description" : "OpenID Connect Resource Owner Grant",
     "providerId" : "basic-flow",
@@ -1452,7 +1468,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "b9a5a3f4-8db2-4fb2-875d-274ccbafd15a",
+    "id" : "efa4dd26-3b26-4915-8611-233d1c0fb4c0",
     "alias" : "direct grant - direct-grant-validate-otp - Conditional",
     "description" : "Flow to determine if the direct-grant-validate-otp authenticator should be used or not.",
     "providerId" : "basic-flow",
@@ -1474,7 +1490,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "96bf6aad-988c-4824-9d78-be63eeefdbe4",
+    "id" : "c9b2d8a5-9102-479c-8f6a-3d93ac3f8e13",
     "alias" : "docker auth",
     "description" : "Used by Docker clients to authenticate against the IDP",
     "providerId" : "basic-flow",
@@ -1489,7 +1505,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "bacd2bd3-e053-4434-bb6e-7b5c35423aa9",
+    "id" : "aba73f84-d14c-4edc-a948-82d686046da0",
     "alias" : "first broker login",
     "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
     "providerId" : "basic-flow",
@@ -1512,7 +1528,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "29ada38e-ee89-4172-b763-0f8522d9c4db",
+    "id" : "3d25b3ad-3d50-4d1e-937c-d3e6f589aae0",
     "alias" : "first broker login - Alternatives - 0",
     "description" : "Subflow of first broker login with alternative executions",
     "providerId" : "basic-flow",
@@ -1535,7 +1551,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "466a8066-d398-409d-8c83-e8ba38ece132",
+    "id" : "edf13404-596f-449d-a130-b036b77e7e25",
     "alias" : "forms",
     "description" : "Username, password, otp and other auth forms.",
     "providerId" : "basic-flow",
@@ -1557,7 +1573,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "a3301cdb-5a54-4bba-af6b-4001ff0721e4",
+    "id" : "b1553967-e4bb-4aab-90de-3509c5935a21",
     "alias" : "forms - auth-otp-form - Conditional",
     "description" : "Flow to determine if the auth-otp-form authenticator should be used or not.",
     "providerId" : "basic-flow",
@@ -1579,7 +1595,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "0d6e64d8-7b8f-4b42-85b1-a57a86cfda5a",
+    "id" : "ba433457-53ad-426e-beb4-7b6fe3499742",
     "alias" : "http challenge",
     "description" : "An authentication flow based on challenge-response HTTP Authentication Schemes",
     "providerId" : "basic-flow",
@@ -1615,7 +1631,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "181f11dd-2840-4d4b-9d7b-2f4abb315d86",
+    "id" : "66aaf22d-ed68-43e1-9f4e-f0518775d865",
     "alias" : "registration",
     "description" : "registration flow",
     "providerId" : "basic-flow",
@@ -1631,7 +1647,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "b8a56c87-3c8f-4204-a685-7a5f8d735866",
+    "id" : "dcc51311-0070-4527-9db7-2a3b7dc6bac9",
     "alias" : "registration form",
     "description" : "registration form",
     "providerId" : "form-flow",
@@ -1667,7 +1683,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "11584afc-fe3a-4837-b355-a97ac5a86aa6",
+    "id" : "da73cc0b-7e4f-49cb-a516-08f5af20098e",
     "alias" : "reset credentials",
     "description" : "Reset credentials for a user if they forgot their password or something",
     "providerId" : "basic-flow",
@@ -1703,7 +1719,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "c2bc7494-e014-4458-be3d-a0050b24250f",
+    "id" : "a61c45a1-0ea7-4587-bc20-50cf945c445d",
     "alias" : "reset credentials - reset-otp - Conditional",
     "description" : "Flow to determine if the reset-otp authenticator should be used or not.",
     "providerId" : "basic-flow",
@@ -1725,7 +1741,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "d236c174-936c-4145-8eb5-02017ef4c628",
+    "id" : "f2e24cc4-f853-45d2-ab63-11d7ab5a2f80",
     "alias" : "saml ecp",
     "description" : "SAML ECP Profile Authentication Flow",
     "providerId" : "basic-flow",
@@ -1741,13 +1757,13 @@
     } ]
   } ],
   "authenticatorConfig" : [ {
-    "id" : "b7c73389-7c0c-4b72-bd18-6ba060e7d42a",
+    "id" : "ae015beb-3e80-4797-973c-52cac4770879",
     "alias" : "create unique user config",
     "config" : {
       "require.password.update.after.registration" : "false"
     }
   }, {
-    "id" : "9926c84d-4e8a-4679-8b1c-29b0bd22cf9d",
+    "id" : "773d62a0-c23a-4a6a-b8fb-30eb80af999d",
     "alias" : "review profile config",
     "config" : {
       "update.profile.on.first.login" : "missing"

--- a/.examples/docker-compose/with-keycloak/keycloak/import/urlaubsverwaltung-users-0.json
+++ b/.examples/docker-compose/with-keycloak/keycloak/import/urlaubsverwaltung-users-0.json
@@ -24,7 +24,7 @@
       "account" : [ "view-profile", "manage-account" ]
     },
     "notBefore" : 0,
-    "groups" : [ ]
+    "groups" : [ "/urlaubsverwaltung access" ]
   }, {
     "id" : "244d5644-246c-4e2e-a0bf-ef4fabc95acd",
     "createdTimestamp" : 1608289897631,
@@ -49,7 +49,7 @@
       "account" : [ "view-profile", "manage-account" ]
     },
     "notBefore" : 0,
-    "groups" : [ ]
+    "groups" : [ "/urlaubsverwaltung access" ]
   }, {
     "id" : "9e7f6ab0-7075-4a17-853b-9a76fd063381",
     "createdTimestamp" : 1608290049557,
@@ -74,7 +74,7 @@
       "account" : [ "view-profile", "manage-account" ]
     },
     "notBefore" : 0,
-    "groups" : [ ]
+    "groups" : [ "/urlaubsverwaltung access" ]
   }, {
     "id" : "893e54e2-a8ad-45bf-ae40-c14e7392dda6",
     "createdTimestamp" : 1608289918785,
@@ -99,7 +99,7 @@
       "account" : [ "view-profile", "manage-account" ]
     },
     "notBefore" : 0,
-    "groups" : [ ]
+    "groups" : [ "/urlaubsverwaltung access" ]
   }, {
     "id" : "65c9e89f-7c92-45e8-b39f-2cfedf1883bc",
     "createdTimestamp" : 1608290144220,
@@ -124,7 +124,7 @@
       "account" : [ "view-profile", "manage-account" ]
     },
     "notBefore" : 0,
-    "groups" : [ ]
+    "groups" : [ "/urlaubsverwaltung access" ]
   }, {
     "id" : "4cffef90-1068-42be-b5fa-ba0b8edbac81",
     "createdTimestamp" : 1608289815022,
@@ -149,7 +149,7 @@
       "account" : [ "view-profile", "manage-account" ]
     },
     "notBefore" : 0,
-    "groups" : [ ]
+    "groups" : [ "/urlaubsverwaltung access" ]
   }, {
     "id" : "9a11eb12-2b0f-4ba1-9943-3aaf3dde3de6",
     "createdTimestamp" : 1608289946800,
@@ -173,6 +173,29 @@
     "clientRoles" : {
       "account" : [ "view-profile", "manage-account" ]
     },
+    "notBefore" : 0,
+    "groups" : [ "/urlaubsverwaltung access" ]
+  }, {
+    "id" : "d8d61467-1f6e-4c7d-8e4a-fc42293d780b",
+    "createdTimestamp" : 1669996481619,
+    "username" : "fee",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : true,
+    "firstName" : "Fabienne",
+    "lastName" : "Fee",
+    "email" : "fabienne.fee@urlaubsverwaltung.cloud",
+    "credentials" : [ {
+      "id" : "86944bad-47ab-4f24-b487-8681639d3585",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1669996497324,
+      "secretData" : "{\"value\":\"vTo+4Qh0mc+ZYCxoj56IWP6TNZzkCN9A2THoZRyf2evUM3/PfX9LIwFcYE4znxFOH+5UeATBGfgkf65LHwFemA==\",\"salt\":\"bAgzTLlMqx64aQ9lKO2kag==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-urlaubsverwaltung" ],
     "notBefore" : 0,
     "groups" : [ ]
   }, {
@@ -199,7 +222,7 @@
       "account" : [ "view-profile", "manage-account" ]
     },
     "notBefore" : 0,
-    "groups" : [ ]
+    "groups" : [ "/urlaubsverwaltung access" ]
   }, {
     "id" : "8682331e-5555-48dd-989c-0bc589d9da0d",
     "createdTimestamp" : 1608290077734,
@@ -224,7 +247,7 @@
       "account" : [ "view-profile", "manage-account" ]
     },
     "notBefore" : 0,
-    "groups" : [ ]
+    "groups" : [ "/urlaubsverwaltung access" ]
   }, {
     "id" : "b50b27cc-5768-4ba9-a4c6-bbdba9796342",
     "createdTimestamp" : 1608289863522,
@@ -249,7 +272,7 @@
       "account" : [ "view-profile", "manage-account" ]
     },
     "notBefore" : 0,
-    "groups" : [ ]
+    "groups" : [ "/urlaubsverwaltung access" ]
   }, {
     "id" : "f45e3262-d738-4f1e-8a9a-e142c1633731",
     "createdTimestamp" : 1608290099219,
@@ -274,7 +297,7 @@
       "account" : [ "view-profile", "manage-account" ]
     },
     "notBefore" : 0,
-    "groups" : [ ]
+    "groups" : [ "/urlaubsverwaltung access" ]
   }, {
     "id" : "3d07ae0d-90a1-4dfd-9393-172c0c9e7c10",
     "createdTimestamp" : 1608289984833,

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/MissingGroupsClaimAuthorityException.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/MissingGroupsClaimAuthorityException.java
@@ -1,0 +1,26 @@
+package org.synyx.urlaubsverwaltung.security.oidc;
+
+import org.springframework.security.authentication.AccountStatusException;
+
+/**
+ * Thrown when a user doesn't have the required authority from the groups claim.
+ */
+public class MissingGroupsClaimAuthorityException extends AccountStatusException {
+    /**
+     * Constructs a <code>MissingAuthorityException</code> with the specified message.
+     * @param msg the detail message
+     */
+    public MissingGroupsClaimAuthorityException(String msg) {
+        super(msg);
+    }
+
+    /**
+     * Constructs a <code>MissingAuthorityException</code> with the specified message and root
+     * cause.
+     * @param msg the detail message
+     * @param cause root cause
+     */
+    public MissingGroupsClaimAuthorityException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/MissingGroupsClaimAuthorityException.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/MissingGroupsClaimAuthorityException.java
@@ -10,17 +10,7 @@ public class MissingGroupsClaimAuthorityException extends AccountStatusException
      * Constructs a <code>MissingAuthorityException</code> with the specified message.
      * @param msg the detail message
      */
-    public MissingGroupsClaimAuthorityException(String msg) {
+    MissingGroupsClaimAuthorityException(String msg) {
         super(msg);
-    }
-
-    /**
-     * Constructs a <code>MissingAuthorityException</code> with the specified message and root
-     * cause.
-     * @param msg the detail message
-     * @param cause root cause
-     */
-    public MissingGroupsClaimAuthorityException(String msg, Throwable cause) {
-        super(msg, cause);
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/OidcSecurityConfiguration.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/OidcSecurityConfiguration.java
@@ -73,6 +73,7 @@ public class OidcSecurityConfiguration {
     }
 
     @Bean
+    @ConditionalOnProperty(value = "uv.security.oidc.group-claim.enabled", havingValue = "true")
     public UrlaubsverwaltungOAuth2UserService urlaubsverwaltungOAuth2UserService(OidcSecurityProperties oidcSecurityProperties) {
         OidcSecurityProperties.GroupClaim groupClaim = oidcSecurityProperties.getGroupClaim();
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/OidcSecurityConfiguration.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/OidcSecurityConfiguration.java
@@ -74,7 +74,9 @@ public class OidcSecurityConfiguration {
 
     @Bean
     public UrlaubsverwaltungOAuth2UserService urlaubsverwaltungOAuth2UserService(OidcSecurityProperties oidcSecurityProperties) {
-        return new UrlaubsverwaltungOAuth2UserService(new OidcUserService(), oidcSecurityProperties.getGroupClaim().getClaimName());
+        OidcSecurityProperties.GroupClaim groupClaim = oidcSecurityProperties.getGroupClaim();
+
+        return new UrlaubsverwaltungOAuth2UserService(new OidcUserService(), groupClaim.getClaimName(), groupClaim.getPermittedGroup());
     }
 
     @Bean

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/OidcSecurityConfiguration.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/OidcSecurityConfiguration.java
@@ -73,8 +73,8 @@ public class OidcSecurityConfiguration {
     }
 
     @Bean
-    public UrlaubsverwaltungOAuth2UserService urlaubsverwaltungOAuth2UserService() {
-        return new UrlaubsverwaltungOAuth2UserService(new OidcUserService());
+    public UrlaubsverwaltungOAuth2UserService urlaubsverwaltungOAuth2UserService(OidcSecurityProperties oidcSecurityProperties) {
+        return new UrlaubsverwaltungOAuth2UserService(new OidcUserService(), oidcSecurityProperties.getGroupClaim().getClaimName());
     }
 
     @Bean

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/OidcSecurityConfiguration.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/OidcSecurityConfiguration.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
 import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
@@ -69,6 +70,11 @@ public class OidcSecurityConfiguration {
     @Bean
     OidcPersonAuthoritiesMapper oidcPersonAuthoritiesMapper(PersonService personService) {
         return new OidcPersonAuthoritiesMapper(personService);
+    }
+
+    @Bean
+    public UrlaubsverwaltungOAuth2UserService urlaubsverwaltungOAuth2UserService() {
+        return new UrlaubsverwaltungOAuth2UserService(new OidcUserService());
     }
 
     @Bean

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/OidcSecurityProperties.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/OidcSecurityProperties.java
@@ -5,6 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 /**
@@ -60,6 +61,9 @@ public class OidcSecurityProperties {
     @NotEmpty
     private String postLogoutRedirectUri = "{baseUrl}";
 
+    @NotNull
+    private GroupClaim groupClaim = new GroupClaim();
+
     public String getIssuerUri() {
         return issuerUri;
     }
@@ -106,5 +110,48 @@ public class OidcSecurityProperties {
 
     public void setPostLogoutRedirectUri(String postLogoutRedirectUri) {
         this.postLogoutRedirectUri = postLogoutRedirectUri;
+    }
+
+    public GroupClaim getGroupClaim() {
+        return groupClaim;
+    }
+
+    public void setGroupClaim(GroupClaim groupClaim) {
+        this.groupClaim = groupClaim;
+    }
+
+    public static class GroupClaim {
+
+        private boolean enabled = false;
+
+        @NotEmpty
+        private String claimName = "groups";
+
+        @NotEmpty
+        private String permittedGroup = "urlaubsverwaltung-user";
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getClaimName() {
+            return claimName;
+        }
+
+        public void setClaimName(String claimName) {
+            this.claimName = claimName;
+        }
+
+        public String getPermittedGroup() {
+            return permittedGroup;
+        }
+
+        public void setPermittedGroup(String permittedGroup) {
+            this.permittedGroup = permittedGroup;
+        }
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/OidcSecurityProperties.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/OidcSecurityProperties.java
@@ -128,7 +128,7 @@ public class OidcSecurityProperties {
         private String claimName = "groups";
 
         @NotEmpty
-        private String permittedGroup = "urlaubsverwaltung-user";
+        private String permittedGroup = "urlaubsverwaltung_user";
 
         public boolean isEnabled() {
             return enabled;

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/UrlaubsverwaltungOAuth2UserService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/UrlaubsverwaltungOAuth2UserService.java
@@ -16,12 +16,12 @@ import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
 
-public class UrlaubsverwaltungOAuth2UserService implements OAuth2UserService<OidcUserRequest, OidcUser> {
+class UrlaubsverwaltungOAuth2UserService implements OAuth2UserService<OidcUserRequest, OidcUser> {
     private final OidcUserService delegate;
     private final String claimName;
     private final String permittedGroup;
 
-    public UrlaubsverwaltungOAuth2UserService(OidcUserService delegate, String claimName, String permittedGroup) {
+    UrlaubsverwaltungOAuth2UserService(OidcUserService delegate, String claimName, String permittedGroup) {
         this.delegate = delegate;
         this.claimName = claimName;
         this.permittedGroup = permittedGroup;
@@ -43,15 +43,15 @@ public class UrlaubsverwaltungOAuth2UserService implements OAuth2UserService<Oid
         return new DefaultOidcUser(combinedAuthorities, oidcUser.getIdToken(), oidcUser.getUserInfo());
     }
 
-    private List<GrantedAuthority> parseAuthoritiesFromGroupsClaim(Map<String, Object> claims) {
+    private List<GrantedAuthority> parseAuthoritiesFromGroupsClaim(final Map<String, Object> claims) {
         return extractFromList(claims, claimName)
             .stream()
             .map(role -> new SimpleGrantedAuthority(String.valueOf(role)))
             .collect(toList());
     }
 
-    private List<String> extractFromList(Map<String, Object> myMap, String key) {
-        Object roles = myMap.get(key);
+    private List<String> extractFromList(final Map<String, Object> myMap, final String key) {
+        final Object roles = myMap.get(key);
         if (roles instanceof List) {
             return (List<String>) roles;
         }

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/UrlaubsverwaltungOAuth2UserService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/UrlaubsverwaltungOAuth2UserService.java
@@ -1,0 +1,55 @@
+package org.synyx.urlaubsverwaltung.security.oidc;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
+public class UrlaubsverwaltungOAuth2UserService implements OAuth2UserService<OidcUserRequest, OidcUser> {
+
+    // TODO make this constants configurable from application.properties
+    private static final String PERMISSION_CLAIM = "groups";
+    private final OidcUserService delegate;
+
+    public UrlaubsverwaltungOAuth2UserService(OidcUserService delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public OidcUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
+
+        final OidcUser oidcUser = delegate.loadUser(userRequest);
+
+        final List<GrantedAuthority> fromGroupsClaim = parseAuthoritiesFromGroupsClaim(oidcUser.getClaims());
+
+        final List<GrantedAuthority> combinedAuthorities = Stream.concat(oidcUser.getAuthorities().stream(), fromGroupsClaim.stream()).collect(toList());
+
+        return new DefaultOidcUser(combinedAuthorities, oidcUser.getIdToken(), oidcUser.getUserInfo());
+    }
+
+    private List<GrantedAuthority> parseAuthoritiesFromGroupsClaim(Map<String, Object> claims) {
+        return extractFromList(claims, PERMISSION_CLAIM)
+            .stream()
+            .map(role -> new SimpleGrantedAuthority(String.valueOf(role)))
+            .collect(toList());
+    }
+
+    private List<String> extractFromList(Map<String, Object> myMap, String key) {
+        Object roles = myMap.get(key);
+        if (roles instanceof List) {
+            return (List<String>) roles;
+        }
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/UrlaubsverwaltungOAuth2UserService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/UrlaubsverwaltungOAuth2UserService.java
@@ -17,13 +17,12 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.toList;
 
 public class UrlaubsverwaltungOAuth2UserService implements OAuth2UserService<OidcUserRequest, OidcUser> {
-
-    // TODO make this constants configurable from application.properties
-    private static final String PERMISSION_CLAIM = "groups";
     private final OidcUserService delegate;
+    private final String claimName;
 
-    public UrlaubsverwaltungOAuth2UserService(OidcUserService delegate) {
+    public UrlaubsverwaltungOAuth2UserService(OidcUserService delegate, String claimName) {
         this.delegate = delegate;
+        this.claimName = claimName;
     }
 
     @Override
@@ -39,7 +38,7 @@ public class UrlaubsverwaltungOAuth2UserService implements OAuth2UserService<Oid
     }
 
     private List<GrantedAuthority> parseAuthoritiesFromGroupsClaim(Map<String, Object> claims) {
-        return extractFromList(claims, PERMISSION_CLAIM)
+        return extractFromList(claims, claimName)
             .stream()
             .map(role -> new SimpleGrantedAuthority(String.valueOf(role)))
             .collect(toList());

--- a/src/main/resources/application-keycloak.properties
+++ b/src/main/resources/application-keycloak.properties
@@ -7,6 +7,8 @@ uv.security.oidc.issuer-uri=http://localhost:8090/auth/realms/urlaubsverwaltung
 uv.security.oidc.client-id=urlaubsverwaltung
 uv.security.oidc.client-secret=51964fe9-8509-419d-9ee8-d2450822b7c9
 uv.security.oidc.logout-uri=http://localhost:8090/auth/realms/urlaubsverwaltung/protocol/openid-connect/logout
+uv.security.oidc.group-claim.enabled=true
+
 management.health.ldap.enabled=false
 
 # Calendar -------------------------------------------------------------------------------------------------------------

--- a/src/test/java/org/synyx/urlaubsverwaltung/security/oidc/UrlaubsverwaltungOAuth2UserServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/security/oidc/UrlaubsverwaltungOAuth2UserServiceTest.java
@@ -1,0 +1,77 @@
+package org.synyx.urlaubsverwaltung.security.oidc;
+
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UrlaubsverwaltungOAuth2UserServiceTest {
+
+    private UrlaubsverwaltungOAuth2UserService sut;
+
+    @Mock
+    private OidcUserService oidcUserService;
+
+    @BeforeEach
+    void setUp() {
+        sut = new UrlaubsverwaltungOAuth2UserService(oidcUserService, "groups", "urlaubsverwaltung_user");
+    }
+
+    @Test
+    void ensuresCorrectClaimAndOidcUserWasGeneratedCorrectly() {
+
+        final OidcIdToken idToken = new OidcIdToken("fake-token-value", null, null, Map.of("groups", List.of("urlaubsverwaltung_user", "offline_access"), "sub", "9f074702-aebc-4072-94cb-df22dfb28368"));
+        final OidcUserRequest userRequest = mock(OidcUserRequest.class);
+        final OidcUser currentUser = new DefaultOidcUser(List.of(new SimpleGrantedAuthority("USER")), idToken);
+        when(oidcUserService.loadUser(userRequest)).thenReturn(currentUser);
+
+        final OidcUser oidcUser = sut.loadUser(userRequest);
+        assertThat(oidcUser).isNotNull();
+        assertThat(oidcUser.getAuthorities().toArray()).contains(new SimpleGrantedAuthority("urlaubsverwaltung_user"));
+        assertThat(oidcUser.getIdToken()).isEqualTo(currentUser.getIdToken());
+        assertThat(oidcUser.getUserInfo()).isEqualTo(currentUser.getUserInfo());
+    }
+
+    @Test
+    void exceptionIsThrownForOidcUserWithoutPermission() {
+
+        final OidcIdToken idToken = new OidcIdToken("fake-token-value", null, null, Map.of("groups", List.of("offline_access"), "sub", "9f074702-aebc-4072-94cb-df22dfb28368", "name", "Fabienne Fee"));
+        final OidcUserRequest userRequest = mock(OidcUserRequest.class);
+        final OidcUser currentUser = new DefaultOidcUser(List.of(new SimpleGrantedAuthority("USER")), idToken);
+        when(oidcUserService.loadUser(userRequest)).thenReturn(currentUser);
+
+        assertThatThrownBy(() -> sut.loadUser(userRequest))
+            .isInstanceOf(MissingGroupsClaimAuthorityException.class)
+            .hasMessage("User 'Fabienne Fee' has not required permission to access urlaubsverwaltung!");
+    }
+
+    @Test
+    void exceptionIsThrownMissingGroupsClaim() {
+
+        final OidcIdToken idToken = new OidcIdToken("fake-token-value", null, null, Map.of("sub", "9f074702-aebc-4072-94cb-df22dfb28368", "name", "Fabienne Fee"));
+        final OidcUserRequest userRequest = mock(OidcUserRequest.class);
+        final OidcUser currentUser = new DefaultOidcUser(List.of(new SimpleGrantedAuthority("USER")), idToken);
+        when(oidcUserService.loadUser(userRequest)).thenReturn(currentUser);
+
+        assertThatThrownBy(() -> sut.loadUser(userRequest))
+            .isInstanceOf(MissingGroupsClaimAuthorityException.class)
+            .hasMessage("User 'Fabienne Fee' has not required permission to access urlaubsverwaltung!");
+    }
+}


### PR DESCRIPTION
Without this change, all users of a given oidc provider can access urlaubsverwaltung application.

To restrict this access to a subset of the oidc users, an oidc user requires a oidc provider managed permission.

Technical details:
This change expects that the `OidcUser` contains a `claim` with name `groups` and includes a group called "urlaubsverwaltung_users".

Both expectations have to be met, otherwise the access to urlaubsverwaltung is forbidden

Added config options to configure claim name, expected group and enable / disable flag to use this feature.


closes #1348 
<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to urlaubsverwaltung@synyx.de with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
