### PR TITLE
Add total number of remaining vacation days to turn of year mail

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/account/TurnOfTheYearAccountUpdaterService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/account/TurnOfTheYearAccountUpdaterService.java
@@ -8,6 +8,7 @@ import org.synyx.urlaubsverwaltung.mail.MailService;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
 
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.Year;
@@ -86,6 +87,7 @@ public class TurnOfTheYearAccountUpdaterService {
 
         Map<String, Object> model = new HashMap<>();
         model.put("accounts", updatedAccounts);
+        model.put("totalRemainingVacationDays", updatedAccounts.stream().map(Account::getRemainingVacationDays).reduce(BigDecimal::add).orElse(BigDecimal.ZERO));
         model.put("today", LocalDate.now(clock));
 
         final String subjectMessageKey = "subject.account.updatedRemainingDays";

--- a/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/updated_accounts.ftl
+++ b/src/main/resources/org/synyx/urlaubsverwaltung/core/mail/updated_accounts.ftl
@@ -5,3 +5,5 @@ Stand Resturlaubstage zum 1. Januar ${today.format("yyyy")} (mitgenommene Restur
 <#list accounts as account>
 ${account.person.niceName}: ${account.remainingVacationDays}
 </#list>
+
+Gesamtzahl an Resturlaubstagen aus dem Vorjahr: ${totalRemainingVacationDays}

--- a/src/test/java/org/synyx/urlaubsverwaltung/TestDataCreator.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/TestDataCreator.java
@@ -17,7 +17,6 @@ import org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNote;
 import org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteCategory;
 import org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteStatus;
 import org.synyx.urlaubsverwaltung.sicknote.sicknotetype.SickNoteType;
-import org.synyx.urlaubsverwaltung.util.DateUtil;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTime;
 
 import java.math.BigDecimal;
@@ -37,6 +36,7 @@ import static java.time.DayOfWeek.THURSDAY;
 import static java.time.DayOfWeek.TUESDAY;
 import static java.time.DayOfWeek.WEDNESDAY;
 import static java.time.ZoneOffset.UTC;
+import static java.time.temporal.TemporalAdjusters.lastDayOfYear;
 import static org.synyx.urlaubsverwaltung.application.vacationtype.VacationCategory.HOLIDAY;
 import static org.synyx.urlaubsverwaltung.application.vacationtype.VacationCategory.OVERTIME;
 import static org.synyx.urlaubsverwaltung.application.vacationtype.VacationCategory.SPECIALLEAVE;
@@ -169,7 +169,7 @@ public final class TestDataCreator {
                                                 BigDecimal remainingVacationDays, BigDecimal remainingVacationDaysNotExpiring, String comment) {
 
         final LocalDate firstDayOfYear = Year.of(year).atDay(1);
-        final LocalDate lastDayOfYear = DateUtil.getLastDayOfYear(year);
+        final LocalDate lastDayOfYear = firstDayOfYear.with(lastDayOfYear());
         final LocalDate expiryDate = LocalDate.of(year, Month.APRIL, 1);
 
         return new Account(person, firstDayOfYear, lastDayOfYear, true, expiryDate,

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/TurnOfTheYearAccountUpdaterServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/TurnOfTheYearAccountUpdaterServiceTest.java
@@ -98,11 +98,15 @@ class TurnOfTheYearAccountUpdaterServiceTest {
         final ArgumentCaptor<Mail> argument = ArgumentCaptor.forClass(Mail.class);
         verify(mailService, times(2)).send(argument.capture());
         final List<Mail> mails = argument.getAllValues();
-        assertThat(mails.get(0).getMailNotificationRecipients()).hasValue(NOTIFICATION_OFFICE);
-        assertThat(mails.get(0).getSubjectMessageKey()).isEqualTo("subject.account.updatedRemainingDays");
-        assertThat(mails.get(0).getTemplateName()).isEqualTo("updated_accounts");
-        assertThat(mails.get(1).isSendToTechnicalMail()).isTrue();
-        assertThat(mails.get(1).getSubjectMessageKey()).isEqualTo("subject.account.updatedRemainingDays");
-        assertThat(mails.get(1).getTemplateName()).isEqualTo("updated_accounts");
+        final Mail mail0 = mails.get(0);
+        assertThat(mail0.getMailNotificationRecipients()).hasValue(NOTIFICATION_OFFICE);
+        assertThat(mail0.getSubjectMessageKey()).isEqualTo("subject.account.updatedRemainingDays");
+        assertThat(mail0.getTemplateName()).isEqualTo("updated_accounts");
+        assertThat(mail0.getTemplateModel()).containsEntry("totalRemainingVacationDays", BigDecimal.valueOf(30));
+        final Mail mail1 = mails.get(1);
+        assertThat(mail1.isSendToTechnicalMail()).isTrue();
+        assertThat(mail1.getSubjectMessageKey()).isEqualTo("subject.account.updatedRemainingDays");
+        assertThat(mail1.getTemplateName()).isEqualTo("updated_accounts");
+        assertThat(mail1.getTemplateModel()).containsEntry("totalRemainingVacationDays", BigDecimal.valueOf(30));
     }
 }


### PR DESCRIPTION
closes #3422

Why is this mail [sent](https://github.com/synyx/urlaubsverwaltung/blob/8fc8e587da2679873bba23affe3794eb3656cc6e/src/main/java/org/synyx/urlaubsverwaltung/account/TurnOfTheYearAccountUpdaterService.java#L105) to configured technical contact based on [`administrator`-Property](https://github.com/synyx/urlaubsverwaltung/blob/8fc8e587da2679873bba23affe3794eb3656cc6e/src/main/java/org/synyx/urlaubsverwaltung/mail/MailProperties.java#L23)? Bug or Feature?