### PR TITLE
Move opencsv to be non-shaded via liquibase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <opentelemetry-agent.version>1.14.0</opentelemetry-agent.version>
     <docker.name>synyx/urlaubsverwaltung</docker.name>
     <shedlock.version>4.42.0</shedlock.version>
+    <opencsv.version>5.6</opencsv.version>
     <packaging.layout>jar</packaging.layout>
   </properties>
 
@@ -33,6 +34,16 @@
     <connection>scm:git:git@github.com:urlaubsverwaltung/urlaubsverwaltung.git</connection>
     <tag>HEAD</tag>
   </scm>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.opencsv</groupId>
+        <artifactId>opencsv</artifactId>
+        <version>${opencsv.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
 
@@ -127,7 +138,6 @@
     <dependency>
       <groupId>com.opencsv</groupId>
       <artifactId>opencsv</artifactId>
-      <version>5.6</version>
     </dependency>
 
     <!-- Shedlock -->

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,13 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- csv file export -->
+    <dependency>
+      <groupId>com.opencsv</groupId>
+      <artifactId>opencsv</artifactId>
+      <version>5.6</version>
+    </dependency>
+
     <!-- Shedlock -->
     <dependency>
       <groupId>net.javacrumbs.shedlock</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
     <opentelemetry-agent.version>1.14.0</opentelemetry-agent.version>
     <docker.name>synyx/urlaubsverwaltung</docker.name>
     <shedlock.version>4.42.0</shedlock.version>
-    <opencsv.version>5.6</opencsv.version>
     <packaging.layout>jar</packaging.layout>
   </properties>
 
@@ -34,16 +33,6 @@
     <connection>scm:git:git@github.com:urlaubsverwaltung/urlaubsverwaltung.git</connection>
     <tag>HEAD</tag>
   </scm>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.opencsv</groupId>
-        <artifactId>opencsv</artifactId>
-        <version>${opencsv.version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
 
@@ -138,6 +127,7 @@
     <dependency>
       <groupId>com.opencsv</groupId>
       <artifactId>opencsv</artifactId>
+      <version>5.6</version>
     </dependency>
 
     <!-- Shedlock -->

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsCsvExportService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsCsvExportService.java
@@ -1,6 +1,7 @@
 package org.synyx.urlaubsverwaltung.application.statistics;
 
-import liquibase.util.csv.CSVWriter;
+
+import com.opencsv.CSVWriter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Service;

--- a/src/main/java/org/synyx/urlaubsverwaltung/csv/CsvExportService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/csv/CsvExportService.java
@@ -1,6 +1,7 @@
 package org.synyx.urlaubsverwaltung.csv;
 
-import liquibase.util.csv.CSVWriter;
+
+import com.opencsv.CSVWriter;
 import net.fortuna.ical4j.validate.ValidationException;
 import org.springframework.core.io.ByteArrayResource;
 import org.synyx.urlaubsverwaltung.web.FilterPeriod;
@@ -10,9 +11,10 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.List;
 
+import static com.opencsv.ICSVWriter.DEFAULT_LINE_END;
+import static com.opencsv.ICSVWriter.DEFAULT_QUOTE_CHARACTER;
+import static com.opencsv.ICSVWriter.NO_QUOTE_CHARACTER;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static liquibase.util.csv.CSVReader.DEFAULT_QUOTE_CHARACTER;
-import static liquibase.util.csv.opencsv.CSVWriter.NO_QUOTE_CHARACTER;
 
 public interface CsvExportService<T> {
 
@@ -77,7 +79,7 @@ public interface CsvExportService<T> {
             byteArrayOutputStream.write(bom());
 
             try (final OutputStreamWriter outputStreamWriter = new OutputStreamWriter(byteArrayOutputStream, UTF_8)) {
-                try (final CSVWriter csvWriter = new CSVWriter(outputStreamWriter, separator(), NO_QUOTE_CHARACTER, DEFAULT_QUOTE_CHARACTER)) {
+                try (final CSVWriter csvWriter = new CSVWriter(outputStreamWriter, separator(), NO_QUOTE_CHARACTER, DEFAULT_QUOTE_CHARACTER, DEFAULT_LINE_END)) {
                     write(period, data, csvWriter);
                 }
             }

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/statistics/SickNoteDetailedStatisticsCsvExportService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/statistics/SickNoteDetailedStatisticsCsvExportService.java
@@ -1,6 +1,7 @@
 package org.synyx.urlaubsverwaltung.sicknote.statistics;
 
-import liquibase.util.csv.CSVWriter;
+
+import com.opencsv.CSVWriter;
 import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Service;
 import org.synyx.urlaubsverwaltung.csv.CsvExportService;

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsCsvExportServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsCsvExportServiceTest.java
@@ -1,6 +1,6 @@
 package org.synyx.urlaubsverwaltung.application.statistics;
 
-import liquibase.util.csv.CSVWriter;
+import com.opencsv.CSVWriter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/org/synyx/urlaubsverwaltung/csv/CsvExportServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/csv/CsvExportServiceTest.java
@@ -1,6 +1,6 @@
 package org.synyx.urlaubsverwaltung.csv;
 
-import liquibase.util.csv.CSVWriter;
+import com.opencsv.CSVWriter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Spy;

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/statistics/SickNoteDetailedStatisticsCsvExportServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/statistics/SickNoteDetailedStatisticsCsvExportServiceTest.java
@@ -1,6 +1,6 @@
 package org.synyx.urlaubsverwaltung.sicknote.statistics;
 
-import liquibase.util.csv.CSVWriter;
+import com.opencsv.CSVWriter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
use the upstream com.opencsv dependency instead of shipped one via liquibase. so we can update liquibase later hassle free.

for details see https://github.com/liquibase/liquibase/pull/2903



<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@urlaubsverwaltung.cloud with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
