### PR TITLE
Vereinheitlichung der Thymeleaf-Fragment-Struktur

### DIFF
--- a/src/main/resources/templates/_navigation.html
+++ b/src/main/resources/templates/_navigation.html
@@ -35,37 +35,37 @@
               <ul class="navigation-list tw-list-none tw-m-0 tw-px-0 tw-py-8 lg:tw-py-3 lg:tw-px-2 xl:tw-px-0">
                 <li>
                   <a
-                    th:replace="::navigation-item(id='home-link', href=@{/web/overview}, text=#{nav.home.title}, icon=~{icon/home::svg})"
+                    th:replace="~{::navigation-item(id='home-link', href=@{/web/overview}, text=#{nav.home.title}, icon=~{icon/home::svg})}"
                   ></a>
                 </li>
                 <li>
                   <a
-                    th:replace="::navigation-item(id='application-new-link', href=@{/web/application/new}, text=#{nav.apply.title}, icon=~{icon/plus-circle::svg})"
+                    th:replace="~{::navigation-item(id='application-new-link', href=@{/web/application/new}, text=#{nav.apply.title}, icon=~{icon/plus-circle::svg})}"
                   ></a>
                 </li>
                 <li>
                   <a
-                    th:replace="::navigation-item(id='application-link', href=@{/web/application}, text=#{nav.vacation.title}, icon=~{icon/calendar::svg})"
+                    th:replace="~{::navigation-item(id='application-link', href=@{/web/application}, text=#{nav.vacation.title}, icon=~{icon/calendar::svg})}"
                   ></a>
                 </li>
                 <li th:if="${navigationSickNoteStatisticsAccess}">
                   <a
-                    th:replace="::navigation-item(id='sicknote-link', href=@{/web/sicknote}, text=#{nav.sicknote.title}, icon=~{icon/medkit::svg}, dataTestId='navigation-sick-notes-link')"
+                    th:replace="~{::navigation-item(id='sicknote-link', href=@{/web/sicknote}, text=#{nav.sicknote.title}, icon=~{icon/medkit::svg}, dataTestId='navigation-sick-notes-link')}"
                   ></a>
                 </li>
                 <li th:if="${navigationPersonListAccess}">
                   <a
-                    th:replace="::navigation-item(id='person-link', href=@{/web/person(active=true)}, text=#{nav.person.title}, icon=~{icon/user::svg})"
+                    th:replace="~{::navigation-item(id='person-link', href=@{/web/person(active=true)}, text=#{nav.person.title}, icon=~{icon/user::svg})}"
                   ></a>
                 </li>
                 <li th:if="${navigationDepartmentAccess}">
                   <a
-                    th:replace="::navigation-item(id='department-link', href=@{/web/department}, text=#{nav.department.title}, icon=~{icon/user-group::svg})"
+                    th:replace="~{::navigation-item(id='department-link', href=@{/web/department}, text=#{nav.department.title}, icon=~{icon/user-group::svg})}"
                   ></a>
                 </li>
                 <li th:if="${navigationSettingsAccess}">
                   <a
-                    th:replace="::navigation-item(id='settings-link', href=@{/web/settings}, text=#{nav.settings.title}, icon=~{icon/cog::svg}, dataTestId='navigation-settings-link')"
+                    th:replace="~{::navigation-item(id='settings-link', href=@{/web/settings}, text=#{nav.settings.title}, icon=~{icon/cog::svg}, dataTestId='navigation-settings-link')}"
                   ></a>
                 </li>
               </ul>
@@ -81,7 +81,7 @@
                     tabindex="-1"
                   >
                     <svg
-                      th:replace="icon/plus::svg(className='nav-popup-menu-button_icon tw-w-8 tw-h-8 lg:tw-w-9 lg:tw-h-9')"
+                      th:replace="~{icon/plus::svg(className='nav-popup-menu-button_icon tw-w-8 tw-h-8 lg:tw-w-9 lg:tw-h-9')}"
                     ></svg>
                     <span class="tw-sr-only" th:text="#{nav.add.button.text}"></span>
                     <span class="dropdown-caret"></span>
@@ -92,33 +92,33 @@
                         <li>
                           <a
                             href="#"
-                            th:replace="::nav-popup-menu-link(href=@{/web/application/new}, icon=~{::menu-add-application-icon}, text=#{nav.add.vacation}, dataTestId='quick-add-new-application')"
+                            th:replace="~{::nav-popup-menu-link(href=@{/web/application/new}, icon=~{::menu-add-application-icon}, text=#{nav.add.vacation}, dataTestId='quick-add-new-application')}"
                           >
                             <svg
                               th:ref="menu-add-application-icon"
-                              th:replace="icon/document-text::svg(className='tw-w-6 tw-h-6')"
+                              th:replace="~{icon/document-text::svg(className='tw-w-6 tw-h-6')}"
                             ></svg>
                           </a>
                         </li>
                         <li th:if="${navigationSickNoteAddAccess}">
                           <a
                             href="#"
-                            th:replace="::nav-popup-menu-link(href=@{/web/sicknote/new}, icon=~{::menu-add-sicknote-icon}, text=#{nav.add.sicknote}, dataTestId='quick-add-new-sicknote')"
+                            th:replace="~{::nav-popup-menu-link(href=@{/web/sicknote/new}, icon=~{::menu-add-sicknote-icon}, text=#{nav.add.sicknote}, dataTestId='quick-add-new-sicknote')}"
                           >
                             <svg
                               th:ref="menu-add-sicknote-icon"
-                              th:replace="icon/medkit::svg(className='tw-w-6 tw-h-6')"
+                              th:replace="~{icon/medkit::svg(className='tw-w-6 tw-h-6')}"
                             ></svg>
                           </a>
                         </li>
                         <li th:if="${navigationOvertimeItemEnabled}">
                           <a
                             href="#"
-                            th:replace="::nav-popup-menu-link(href=@{/web/overtime/new}, icon=~{::menu-add-overtime-icon}, text=#{nav.add.overtime}, dataTestId='quick-add-new-overtime')"
+                            th:replace="~{::nav-popup-menu-link(href=@{/web/overtime/new}, icon=~{::menu-add-overtime-icon}, text=#{nav.add.overtime}, dataTestId='quick-add-new-overtime')}"
                           >
                             <svg
                               th:ref="menu-add-overtime-icon"
-                              th:replace="icon/clock::svg(className='tw-w-6 tw-h-6')"
+                              th:replace="~{icon/clock::svg(className='tw-w-6 tw-h-6')}"
                             ></svg>
                           </a>
                         </li>
@@ -134,7 +134,7 @@
                   th:if="${not navigationRequestPopupEnabled}"
                 >
                   <svg
-                    th:replace="icon/plus::svg(className='nav-popup-menu-button_icon tw-w-8 tw-h-8 lg:tw-w-9 lg:tw-h-9')"
+                    th:replace="~{icon/plus::svg(className='nav-popup-menu-button_icon tw-w-8 tw-h-8 lg:tw-w-9 lg:tw-h-9')}"
                   ></svg>
                   <span class="tw-sr-only" th:text="#{nav.add.vacation}"></span>
                 </a>
@@ -149,7 +149,7 @@
                   >
                     <span class="tw-inline-flex tw-text-blue-200 dark:tw-text-sky-800">
                       <img
-                        th:replace="fragments/avatar::avatar(className='tw-w-8 tw-h-8 lg:tw-w-9 lg:tw-h-9',url=${menuGravatarUrl + '?d=404'},niceName=${userFirstName + ' ' + userLastName},width='40px',height='40px')"
+                        th:replace="~{fragments/avatar::avatar(className='tw-w-8 tw-h-8 lg:tw-w-9 lg:tw-h-9',url=${menuGravatarUrl + '?d=404'},niceName=${userFirstName + ' ' + userLastName},width='40px',height='40px')}"
                         alt=""
                       />
                     </span>
@@ -166,7 +166,7 @@
                           >
                             <span class="tw-text-blue-200 dark:tw-text-sky-800">
                               <img
-                                th:replace="fragments/avatar::avatar(url=${menuGravatarUrl + '?d=404&s=128'},niceName=${userFirstName + ' ' + userLastName},width='64px',height='64px')"
+                                th:replace="~{fragments/avatar::avatar(url=${menuGravatarUrl + '?d=404&s=128'},niceName=${userFirstName + ' ' + userLastName},width='64px',height='64px')}"
                                 alt=""
                               />
                             </span>
@@ -187,33 +187,33 @@
                         <li class="tw-mb-1">
                           <a
                             href="#"
-                            th:replace="::nav-popup-menu-link-external(href=${menuHelpUrl}, icon=~{::menu-help-icon}, text=#{nav.help.title})"
+                            th:replace="~{::nav-popup-menu-link-external(href=${menuHelpUrl}, icon=~{::menu-help-icon}, text=#{nav.help.title})}"
                           >
                             <svg
                               th:ref="menu-help-icon"
-                              th:replace="icon/question-mark-circle::svg(className='tw-w-6 tw-h-6')"
+                              th:replace="~{icon/question-mark-circle::svg(className='tw-w-6 tw-h-6')}"
                             ></svg>
                           </a>
                         </li>
                         <li class="tw-mb-1">
                           <a
                             href="#"
-                            th:replace="::nav-popup-menu-link(href=@{/web/person/{userId}(userId=${userId})}, icon=~{::menu-person-icon}, text=#{nav.account.title})"
+                            th:replace="~{::nav-popup-menu-link(href=@{/web/person/{userId}(userId=${userId})}, icon=~{::menu-person-icon}, text=#{nav.account.title})}"
                           >
                             <svg
                               th:ref="menu-person-icon"
-                              th:replace="icon/user-circle::svg(className='tw-w-6 tw-h-6')"
+                              th:replace="~{icon/user-circle::svg(className='tw-w-6 tw-h-6')}"
                             ></svg>
                           </a>
                         </li>
                         <li class="tw-mb-1">
                           <a
                             href="#"
-                            th:replace="::nav-popup-menu-link(href=@{/web/person/{userId}/settings(userId=${userId})}, icon=~{::menu-user-settings-icon}, text=#{nav.user-settings.title})"
+                            th:replace="~{::nav-popup-menu-link(href=@{/web/person/{userId}/settings(userId=${userId})}, icon=~{::menu-user-settings-icon}, text=#{nav.user-settings.title})}"
                           >
                             <svg
                               th:ref="menu-user-settings-icon"
-                              th:replace="icon/adjustments::svg(className='tw-w-6 tw-h-6')"
+                              th:replace="~{icon/adjustments::svg(className='tw-w-6 tw-h-6')}"
                             ></svg>
                           </a>
                         </li>
@@ -223,7 +223,7 @@
                             <button type="submit" class="nav-popup-menu_link tw-rounded-b-2xl" data-test-id="logout">
                               <span class="tw-flex tw-items-center">
                                 <span class="tw-px-2 tw-py-1 tw-rounded tw-flex tw-items-center tw-ml-2.5">
-                                  <svg th:replace="icon/logout::svg(className='tw-w-6 tw-h-6')"></svg>
+                                  <svg th:replace="~{icon/logout::svg(className='tw-w-6 tw-h-6')}"></svg>
                                 </span>
                                 <span class="tw-ml-4" th:text="#{nav.signout.title}"></span>
                               </span>
@@ -300,7 +300,7 @@
         style="min-width: 0"
         th:text="${text}"
       ></span>
-      <svg th:replace="icon/external-link::svg(className='tw-ml-1.5 tw-h-4 tw-w-4')"></svg>
+      <svg th:replace="~{icon/external-link::svg(className='tw-ml-1.5 tw-h-4 tw-w-4')}"></svg>
     </a>
   </body>
 </html>

--- a/src/main/resources/templates/fragments/avatar.html
+++ b/src/main/resources/templates/fragments/avatar.html
@@ -28,7 +28,7 @@
       th:fragment="avatar-bordered(url,niceName,width,height)"
       class="tw-bg-gradient-to-br tw-from-blue-50 tw-to-blue-200 dark:tw-from-sky-800 dark:tw-to-zinc-800 tw-rounded-full tw-p-1 tw-inline-flex"
     >
-      <img src="#" alt="" th:replace="::avatar(${url},${niceName},${width},${height})" />
+      <img src="#" alt="" th:replace="~{::avatar(${url},${niceName},${width},${height})}" />
     </span>
   </body>
 </html>

--- a/src/main/resources/templates/fragments/filter-modal.html
+++ b/src/main/resources/templates/fragments/filter-modal.html
@@ -18,7 +18,7 @@
         <div class="modal-content">
           <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-hidden="true">
-              <svg th:replace="icon/x-circle::svg(className='tw-w-8 tw-h-8')"></svg>
+              <svg th:replace="~{icon/x-circle::svg(className='tw-w-8 tw-h-8')}"></svg>
             </button>
             <h4 class="tw-text-2xl" th:text="#{filter.title}" id="filterModalLabel"></h4>
           </div>

--- a/src/main/resources/templates/fragments/print.html
+++ b/src/main/resources/templates/fragments/print.html
@@ -11,7 +11,7 @@
       th:data-title="#{action.print}"
       onclick="window.print(); return false;"
     >
-      <svg th:replace="icon/printer::svg(className='tw-w-5 tw-h-5')"></svg>
+      <svg th:replace="~{icon/printer::svg(className='tw-w-5 tw-h-5')}"></svg>
       <span class="tw-sr-only" th:text="#{action.print}"></span>
     </button>
   </body>

--- a/src/main/resources/templates/fragments/privacy-box.html
+++ b/src/main/resources/templates/fragments/privacy-box.html
@@ -11,7 +11,7 @@
     >
       <div class="tw-mb-4 sm:tw-mb-0 sm:tw-mr-4 lg:tw-mr-14 tw-flex tw-items-center sm:tw-items-start">
         <svg
-          th:replace="icon/information-circle::svg(className='tw-text-amber-300 dark:tw-text-yellow-500 tw-w-6 tw-h-6 tw-mr-2')"
+          th:replace="~{icon/information-circle::svg(className='tw-text-amber-300 dark:tw-text-yellow-500 tw-w-6 tw-h-6 tw-mr-2')}"
         ></svg>
         <span
           class="tw-text-black tw-text-opacity-75 dark:tw-text-opacity-100 tw-font-bold tw-text-sm sm:tw-mt-px"

--- a/src/main/resources/templates/fragments/select.html
+++ b/src/main/resources/templates/fragments/select.html
@@ -38,7 +38,7 @@
       class="select-with-addon tw-w-full tw-flex tw-items-center"
       th:fragment="one-with-addon(id, name, options, addon)"
     >
-      <span th:replace="::one(${id}, ${name}, ${options})"></span>
+      <span th:replace="~{::one(${id}, ${name}, ${options})}"></span>
       <span class="tw-h-full tw-flex select-addon" th:insert="${addon}"></span>
     </span>
 

--- a/src/main/resources/templates/thymeleaf/absences/absences-overview.html
+++ b/src/main/resources/templates/thymeleaf/absences/absences-overview.html
@@ -6,7 +6,7 @@
   xmlns:th="http://www.thymeleaf.org"
   xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
 >
-  <head th:replace="_layout::head(~{::title}, ~{::styles}, ~{::scripts})">
+  <head th:replace="~{_layout::head(~{::title}, ~{::styles}, ~{::scripts})}">
     <title th:text="#{absences.overview.header.title}">Absence Overview</title>
     <th:block th:fragment="styles">
       <link rel="stylesheet" type="text/css" asset:href="absences_overview.css" />
@@ -16,11 +16,11 @@
       <script defer asset:src="absences_overview.js"></script>
     </th:block>
   </head>
-  <body th:replace="_layout::body(~{::main}, ~{})">
+  <body th:replace="~{_layout::body(~{::main}, ~{})}">
     <main th:fragment="main">
       <div class="tw-max-w-6xl tw-mx-auto tw-px-4 lg:tw-px-12 xl:tw-px-0">
         <div
-          th:replace="fragments/section-heading::section-heading(~{::person-basedata-heading-body}, ~{::person-basedata-heading-actions})"
+          th:replace="~{fragments/section-heading::section-heading(~{::person-basedata-heading-body}, ~{::person-basedata-heading-actions})}"
         >
           <th:block th:ref="person-basedata-heading-body">
             <h1 th:text="#{absences.overview.title}">Absence Overview</h1>
@@ -44,7 +44,7 @@
               </label>
               <span class="tw-col-start-2 tw-col-end-2 tw-row-start-1">
                 <select
-                  th:replace="fragments/select::one(id='yearSelect', name='year', options=~{::year-select-options})"
+                  th:replace="~{fragments/select::one(id='yearSelect', name='year', options=~{::year-select-options})}"
                   id="yearSelect"
                 >
                   <th:block th:fragment="year-select-options">
@@ -77,7 +77,7 @@
               </label>
               <span class="md:tw-mt-0 tw-col-start-2 tw-col-end-2 tw-row-start-2">
                 <select
-                  th:replace="fragments/select::one(id='monthSelect', name='month', options=~{::month-select-options})"
+                  th:replace="~{fragments/select::one(id='monthSelect', name='month', options=~{::month-select-options})}"
                   id="monthSelect"
                 >
                   <th:block th:fragment="month-select-options">
@@ -119,7 +119,7 @@
                   Department
                 </label>
                 <select
-                  th:replace="fragments/select::multi(id='departmentSelect', name='department', options=~{::department-select-options}, className='tw-row-start-3')"
+                  th:replace="~{fragments/select::multi(id='departmentSelect', name='department', options=~{::department-select-options}, className='tw-row-start-3')}"
                   id="departmentSelect"
                 >
                   <th:block th:fragment="department-select-options">
@@ -133,7 +133,7 @@
                   </th:block>
                 </select>
                 <span class="help-block tw-hidden md:tw-inline tw-text-sm tw-col-start-3 tw-row-start-3">
-                  <svg th:replace="icon/information-circle::svg(className='tw-w-4 tw-h-4')"></svg>
+                  <svg th:replace="~{icon/information-circle::svg(className='tw-w-4 tw-h-4')}"></svg>
                   <th:block th:text="#{absences.overview.department.help}"></th:block>
                 </span>
               </th:block>

--- a/src/main/resources/templates/thymeleaf/application/application-form.html
+++ b/src/main/resources/templates/thymeleaf/application/application-form.html
@@ -26,7 +26,7 @@
           <div class="tw-flex">
             <div class="tw-mr-4 tw-mt-1 tw-text-blue-50 dark:tw-text-sky-800">
               <img
-                th:replace="fragments/avatar::avatar(url=${holidayReplacement.person.gravatarURL + '?d=404&s=40'},niceName=${holidayReplacement.person.niceName},width='40px',height='40px')"
+                th:replace="~{fragments/avatar::avatar(url=${holidayReplacement.person.gravatarURL + '?d=404&s=40'},niceName=${holidayReplacement.person.niceName},width='40px',height='40px')}"
                 alt=""
               />
             </div>
@@ -56,7 +56,7 @@
                   <span
                     class="tw-flex tw-items-center tw-text-sm tw-text-black tw-text-opacity-50 hover:tw-text-opacity-100 focus:tw-text-opacity-100 dark:tw-text-zinc-200 tw-transition-colors"
                   >
-                    <svg th:replace="icon/trash :: svg(className='tw-w-4 tw-h-4 tw-mr-0.5')"></svg>
+                    <svg th:replace="~{icon/trash :: svg(className='tw-w-4 tw-h-4 tw-mr-0.5')}"></svg>
                     <th:block th:text="#{application.data.holidayReplacement.remove-button.text}"></th:block>
                   </span>
                 </button>

--- a/src/main/resources/templates/thymeleaf/application/application-overview.html
+++ b/src/main/resources/templates/thymeleaf/application/application-overview.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en" th:lang="${language}" th:class="|tw-${theme}|" xmlns:th="http://www.thymeleaf.org">
-  <head th:replace="_layout::head(~{::title}, ~{}, ~{::scripts})">
+  <head th:replace="~{_layout::head(~{::title}, ~{}, ~{::scripts})}">
     <title th:text="#{applications.header.title}"></title>
     <th:block th:fragment="scripts">
       <script defer asset:src="app_list.js"></script>
     </th:block>
   </head>
-  <body th:replace="_layout::body(~{::main}, ~{})">
+  <body th:replace="~{_layout::body(~{::main}, ~{})}">
     <main th:fragment="main" class="tw-max-w-6xl tw-mx-auto tw-px-4 lg:tw-px-12 xl:tw-px-0">
       <h1 class="tw-sr-only" th:text="#{applications.title}"></h1>
 
@@ -23,7 +23,7 @@
       </div>
 
       <div
-        th:replace="fragments/section-heading::section-heading-paddingless(~{::user-applications-heading-body}, ~{::user-applications-heading-actions})"
+        th:replace="~{fragments/section-heading::section-heading-paddingless(~{::user-applications-heading-body}, ~{::user-applications-heading-actions})}"
       >
         <th:block th:ref="user-applications-heading-actions">
           <a
@@ -33,7 +33,7 @@
             th:data-title="#{action.apply.vacation}"
             th:if="${canAddApplicationForAnotherUser}"
           >
-            <svg th:replace="icon/plus-circle::svg(className='tw-w-5 tw-h-5')"></svg>
+            <svg th:replace="~{icon/plus-circle::svg(className='tw-w-5 tw-h-5')}"></svg>
             <span class="tw-sr-only" th:text="#{action.apply.vacation}"></span>
           </a>
           <a
@@ -42,7 +42,7 @@
             class="icon-link tw-px-1"
             th:data-title="#{action.applications.absences_overview}"
           >
-            <svg th:replace="icon/calendar::svg(className='tw-w-5 tw-h-5')"></svg>
+            <svg th:replace="~{icon/calendar::svg(className='tw-w-5 tw-h-5')}"></svg>
             <span class="tw-sr-only" th:text="#{action.applications.absences_overview}"></span>
           </a>
           <a
@@ -52,7 +52,7 @@
             th:data-title="#{action.applications.statistics}"
             th:if="${canAccessApplicationStatistics}"
           >
-            <svg th:replace="icon/presentation-chart-bar::svg(className='tw-w-5 tw-h-5')"></svg>
+            <svg th:replace="~{icon/presentation-chart-bar::svg(className='tw-w-5 tw-h-5')}"></svg>
             <span class="tw-sr-only" th:text="#{action.applications.statistics}"></span>
           </a>
           <button th:replace="fragments/print::button"></button>
@@ -115,7 +115,7 @@
             <div class="tw-flex tw-space-x-5 lg:tw-space-x-6">
               <span class="print:tw-hidden tw-text-blue-50 dark:tw-text-sky-800">
                 <img
-                  th:replace="fragments/avatar::avatar-bordered(url=${signedInUser.gravatarURL + '?d=404&s=104'},niceName=${signedInUser.niceName},width='52px',height='52px')"
+                  th:replace="~{fragments/avatar::avatar-bordered(url=${signedInUser.gravatarURL + '?d=404&s=104'},niceName=${signedInUser.niceName},width='52px',height='52px')}"
                   alt=""
                 />
               </span>
@@ -164,7 +164,7 @@
                   th:href="@{/web/application/{applicationId}/edit (applicationId=${userRequestForLeave.id})}"
                   th:if="${userRequestForLeave.editAllowed}"
                 >
-                  <svg th:replace="icon/pencil::svg(className='tw-w-5 tw-h-5 xs:tw-w-4 xs:tw-h-4 xs:tw-mr-1')"></svg>
+                  <svg th:replace="~{icon/pencil::svg(className='tw-w-5 tw-h-5 xs:tw-w-4 xs:tw-h-4 xs:tw-mr-1')}"></svg>
                   <span class="sr-only xs:tw-not-sr-only">
                     <th:block th:text="#{action.edit}"></th:block>
                   </span>
@@ -174,7 +174,7 @@
                   th:href="@{/web/application/{applicationId} (applicationId=${userRequestForLeave.id}, action='allow', shortcut=true)}"
                   th:if="${userRequestForLeave.approveAllowed}"
                 >
-                  <svg th:replace="icon/check::svg(className='tw-w-5 tw-h-5 xs:tw-w-4 xs:tw-h-4 xs:tw-mr-1')"></svg>
+                  <svg th:replace="~{icon/check::svg(className='tw-w-5 tw-h-5 xs:tw-w-4 xs:tw-h-4 xs:tw-mr-1')}"></svg>
                   <span class="sr-only xs:tw-not-sr-only">
                     <th:block
                       th:text="${userRequestForLeave.temporaryApproveAllowed ? #messages.msg('action.temporary_allow') : #messages.msg('action.allow')}"
@@ -186,7 +186,7 @@
                   th:href="@{/web/application/{applicationId} (applicationId=${userRequestForLeave.id}, action='reject', shortcut=true)}"
                   th:if="${userRequestForLeave.rejectAllowed}"
                 >
-                  <svg th:replace="icon/ban::svg(className='tw-w-5 tw-h-5 xs:tw-w-4 xs:tw-h-4 xs:tw-mr-1')"></svg>
+                  <svg th:replace="~{icon/ban::svg(className='tw-w-5 tw-h-5 xs:tw-w-4 xs:tw-h-4 xs:tw-mr-1')}"></svg>
                   <span class="sr-only xs:tw-not-sr-only">
                     <th:block th:text="#{action.reject}"></th:block>
                   </span>
@@ -196,7 +196,7 @@
                   th:href="@{/web/application/{applicationId} (applicationId=${userRequestForLeave.id}, action='cancel', shortcut=true)}"
                   th:if="${userRequestForLeave.cancelAllowed}"
                 >
-                  <svg th:replace="icon/trash::svg(className='tw-w-5 tw-h-5 xs:tw-w-4 xs:tw-h-4 xs:tw-mr-1')"></svg>
+                  <svg th:replace="~{icon/trash::svg(className='tw-w-5 tw-h-5 xs:tw-w-4 xs:tw-h-4 xs:tw-mr-1')}"></svg>
                   <span class="sr-only xs:tw-not-sr-only">
                     <th:block th:text="#{action.delete}"></th:block>
                   </span>
@@ -224,7 +224,7 @@
             <div class="tw-flex tw-space-x-5 md:tw-space-x-6">
               <span class="print:tw-hidden tw-text-blue-50 dark:tw-text-sky-800">
                 <img
-                  th:replace="fragments/avatar::avatar-bordered(url=${signedInUser.gravatarURL + '?d=404&s=104'},niceName=${signedInUser.niceName},width='52px',height='52px')"
+                  th:replace="~{fragments/avatar::avatar-bordered(url=${signedInUser.gravatarURL + '?d=404&s=104'},niceName=${signedInUser.niceName},width='52px',height='52px')}"
                   alt=""
                 />
               </span>
@@ -244,7 +244,7 @@
               <div class="tw-flex tw-flex-row-reverse tw-gap-4">
                 <div class="tw-self-center print:tw-hidden tw-text-blue-50 dark:tw-text-sky-800">
                   <img
-                    th:replace="fragments/avatar::avatar-bordered(url=${replacementInfo.person.avatarUrl + '?d=404&s=104'},niceName=${replacementInfo.person.name},width='52px',height='52px')"
+                    th:replace="~{fragments/avatar::avatar-bordered(url=${replacementInfo.person.avatarUrl + '?d=404&s=104'},niceName=${replacementInfo.person.name},width='52px',height='52px')}"
                     alt=""
                   />
                 </div>
@@ -284,7 +284,7 @@
       </div>
 
       <div
-        th:replace="fragments/section-heading::section-heading(~{::other-applications-heading-body}, ~{::other-applications-heading-actions})"
+        th:replace="~{fragments/section-heading::section-heading(~{::other-applications-heading-body}, ~{::other-applications-heading-actions})}"
       >
         <th:block th:ref="other-applications-heading-body">
           <h2 class="tw-text-xl tw-font-medium" th:text="#{applications.other.waiting}"></h2>
@@ -306,7 +306,7 @@
                 class="tw-absolute tw-left-0 tw-top-0 md:tw-static print:tw-hidden tw-text-blue-50 dark:tw-text-sky-800"
               >
                 <img
-                  th:replace="fragments/avatar::avatar-bordered(url=${otherRequestForLeave.person.avatarUrl + '?d=404&s=104'},niceName=${otherRequestForLeave.person.name},width='52px',height='52px')"
+                  th:replace="~{fragments/avatar::avatar-bordered(url=${otherRequestForLeave.person.avatarUrl + '?d=404&s=104'},niceName=${otherRequestForLeave.person.name},width='52px',height='52px')}"
                   alt=""
                 />
               </span>
@@ -349,7 +349,7 @@
                     href="#"
                     th:href="@{/web/application/{applicationId}/edit (applicationId=${otherRequestForLeave.id})}"
                   >
-                    <svg th:replace="icon/pencil::svg(className='tw-w-5 tw-h-5 xs:tw-w-4 xs:tw-h-4 tw-mr-1')"></svg>
+                    <svg th:replace="~{icon/pencil::svg(className='tw-w-5 tw-h-5 xs:tw-w-4 xs:tw-h-4 tw-mr-1')}"></svg>
                     <span class="tw-sr-only xs:tw-not-sr-only">
                       <th:block th:text="#{action.edit}" />
                     </span>
@@ -360,7 +360,7 @@
                     href="#"
                     th:href="@{/web/application/{applicationId} (applicationId=${otherRequestForLeave.id}, action='allow', shortcut=true)}"
                   >
-                    <svg th:replace="icon/check::svg(className='tw-w-5 tw-h-5 xs:tw-w-4 xs:tw-h-4 tw-mr-1')"></svg>
+                    <svg th:replace="~{icon/check::svg(className='tw-w-5 tw-h-5 xs:tw-w-4 xs:tw-h-4 tw-mr-1')}"></svg>
                     <span class="tw-sr-only xs:tw-not-sr-only">
                       <th:block
                         th:text="${otherRequestForLeave.temporaryApproveAllowed ? #messages.msg('action.temporary_allow') : #messages.msg('action.allow')}"
@@ -373,7 +373,7 @@
                     href="#"
                     th:href="@{/web/application/{applicationId} (applicationId=${otherRequestForLeave.id}, action='reject', shortcut=true)}"
                   >
-                    <svg th:replace="icon/ban::svg(className='tw-w-5 tw-h-5 xs:tw-w-4 xs:tw-h-4 tw-mr-1')"></svg>
+                    <svg th:replace="~{icon/ban::svg(className='tw-w-5 tw-h-5 xs:tw-w-4 xs:tw-h-4 tw-mr-1')}"></svg>
                     <span class="tw-sr-only xs:tw-not-sr-only">
                       <th:block th:text="#{action.reject}" />
                     </span>
@@ -383,7 +383,9 @@
                     th:href="@{/web/application/{applicationId} (applicationId=${otherRequestForLeave.id}, action='cancel', shortcut=true)}"
                     th:if="${otherRequestForLeave.cancelAllowed}"
                   >
-                    <svg th:replace="icon/trash::svg(className='tw-w-5 tw-h-5 xs:tw-w-4 xs:tw-h-4 xs:tw-mr-1')"></svg>
+                    <svg
+                      th:replace="~{icon/trash::svg(className='tw-w-5 tw-h-5 xs:tw-w-4 xs:tw-h-4 xs:tw-mr-1')}"
+                    ></svg>
                     <span class="sr-only xs:tw-not-sr-only">
                       <th:block th:text="#{action.delete}"></th:block>
                     </span>
@@ -397,7 +399,7 @@
 
       <th:block th:if="${applications_cancellation_request != null}">
         <div
-          th:replace="fragments/section-heading::section-heading(~{::cancellation-requests-heading-body}, ~{::cancellation-requests-heading-actions})"
+          th:replace="~{fragments/section-heading::section-heading(~{::cancellation-requests-heading-body}, ~{::cancellation-requests-heading-actions})}"
         >
           <th:block th:ref="cancellation-requests-heading-body">
             <h2
@@ -426,7 +428,7 @@
                   class="tw-absolute tw-left-0 tw-top-0 md:tw-static print:tw-hidden tw-text-blue-50 dark:tw-text-sky-800"
                 >
                   <img
-                    th:replace="fragments/avatar::avatar-bordered(url=${cancellationRequest.person.avatarUrl + '?d=404&s=104'},niceName=${cancellationRequest.person.name},width='52px',height='52px')"
+                    th:replace="~{fragments/avatar::avatar-bordered(url=${cancellationRequest.person.avatarUrl + '?d=404&s=104'},niceName=${cancellationRequest.person.name},width='52px',height='52px')}"
                     alt=""
                   />
                 </span>
@@ -472,7 +474,7 @@
                       href="#"
                       th:href="@{/web/application/{applicationId} (applicationId=${cancellationRequest.id}, action='cancel', shortcut=true)}"
                     >
-                      <svg th:replace="icon/trash::svg(className='tw-w-5 tw-h-5 lg:tw-w-4 lg:tw-h-4 tw-mr-1')" />
+                      <svg th:replace="~{icon/trash::svg(className='tw-w-5 tw-h-5 lg:tw-w-4 lg:tw-h-4 tw-mr-1')}" />
                       <span class="tw-sr-only xs:tw-not-sr-only">
                         <th:block th:text="#{action.delete}" />
                       </span>
@@ -482,7 +484,7 @@
                       href="#"
                       th:href="@{/web/application/{applicationId} (applicationId=${cancellationRequest.id}, action='decline-cancellation-request', shortcut=true)}"
                     >
-                      <svg th:replace="icon/ban::svg(className='tw-w-5 tw-h-5 lg:tw-w-4 lg:tw-h-4 tw-mr-1')" />
+                      <svg th:replace="~{icon/ban::svg(className='tw-w-5 tw-h-5 lg:tw-w-4 lg:tw-h-4 tw-mr-1')}" />
                       <span class="tw-sr-only xs:tw-not-sr-only">
                         <th:block th:text="#{action.cancellationRequest}" />
                       </span>

--- a/src/main/resources/templates/thymeleaf/error.html
+++ b/src/main/resources/templates/thymeleaf/error.html
@@ -61,7 +61,7 @@
         class="tw-text-6xl md:tw-text-10rem tw-leading-normal dark:tw-text-zinc-900"
         style="background-color: #b2c900"
       >
-        <svg th:replace="icon/emoji-sad::svg(className='tw-w-40 tw-h-40')"></svg>
+        <svg th:replace="~{icon/emoji-sad::svg(className='tw-w-40 tw-h-40')}"></svg>
       </h1>
       <p class="md:tw-text-2xl" th:text="#{errorPage.other}"></p>
       <p class="error-link md:tw-text-xl">

--- a/src/main/resources/templates/thymeleaf/login/login.html
+++ b/src/main/resources/templates/thymeleaf/login/login.html
@@ -88,7 +88,7 @@
         <div class="tw-mb-4">
           <button class="button-main tw-w-full" type="submit">
             <span class="tw-flex tw-items-center tw-justify-center">
-              <svg th:replace="icon/login::svg(className='tw-w-5 tw-h-5')"></svg>
+              <svg th:replace="~{icon/login::svg(className='tw-w-5 tw-h-5')}"></svg>
               &nbsp;<th:block th:text="#{login.form.submit}">Login</th:block>
             </span>
           </button>

--- a/src/main/resources/templates/thymeleaf/person/box.html
+++ b/src/main/resources/templates/thymeleaf/person/box.html
@@ -43,7 +43,7 @@
     </th:block>
 
     <th:block th:fragment="person-box-with-departments(person, departments)">
-      <th:block th:replace="::person-box(person=${person}, departments=${departments})"></th:block>
+      <th:block th:replace="~{::person-box(person=${person}, departments=${departments})}"></th:block>
     </th:block>
   </body>
 </html>

--- a/src/main/resources/templates/thymeleaf/person/person-basedata.html
+++ b/src/main/resources/templates/thymeleaf/person/person-basedata.html
@@ -6,16 +6,16 @@
   xmlns:th="http://www.thymeleaf.org"
   xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
 >
-  <head th:replace="_layout::head(~{::title}, ~{}, ~{::scripts})">
+  <head th:replace="~{_layout::head(~{::title}, ~{}, ~{::scripts})}">
     <title th:text="#{person.form.basedata.title(${personBasedata.niceName})}"></title>
     <th:block th:fragment="scripts">
       <script defer asset:src="person_basedata.js"></script>
     </th:block>
   </head>
-  <body th:replace="_layout::body(~{::main}, ~{})">
+  <body th:replace="~{_layout::body(~{::main}, ~{})}">
     <main th:fragment="main" class="tw-max-w-6xl tw-mx-auto tw-px-4 lg:tw-px-12 xl:tw-px-1.5">
       <div
-        th:replace="fragments/section-heading::section-heading(~{::person-basedata-heading-body}, ~{::person-basedata-heading-actions})"
+        th:replace="~{fragments/section-heading::section-heading(~{::person-basedata-heading-body}, ~{::person-basedata-heading-actions})}"
       >
         <th:block th:ref="person-basedata-heading-body">
           <h1 th:text="#{person.form.basedata.title(${personBasedata.niceName})}">Person Base data</h1>
@@ -26,7 +26,7 @@
         <div class="tw-flex tw-items-center tw-gap-4 sm:tw-gap-6 tw-mb-4 md:tw-mb-12">
           <div class="tw-p-1 tw-text-blue-50 dark:tw-text-sky-800">
             <img
-              th:replace="fragments/avatar::avatar-bordered(url=${personBasedata.gravatarURL + '?d=404&s=60'},niceName=${personBasedata.niceName},width='60px',height='60px')"
+              th:replace="~{fragments/avatar::avatar-bordered(url=${personBasedata.gravatarURL + '?d=404&s=60'},niceName=${personBasedata.niceName},width='60px',height='60px')}"
               alt=""
             />
           </div>
@@ -46,7 +46,7 @@
               th:href="${'mailto:' + personBasedata.email}"
               class="icon-link tw-text-sm print:no-link"
             >
-              <svg th:replace="icon/mail::svg(className='tw-w-4 tw-h-4')"></svg>
+              <svg th:replace="~{icon/mail::svg(className='tw-w-4 tw-h-4')}"></svg>
               &nbsp;<th:block th:text="${personBasedata.email}">john.doe@example.org</th:block>
             </a>
           </div>

--- a/src/main/resources/templates/thymeleaf/person/person-basedata.html
+++ b/src/main/resources/templates/thymeleaf/person/person-basedata.html
@@ -108,7 +108,7 @@
                     onkeyup="count(this.value, 'text-additional-info');"
                     onkeydown="maxChars(this,500); count(this.value, 'text-additional-info');"
                     th:field="*{additionalInfo}"
-                  />
+                  ></textarea>
                   <small class="tw-self-end">
                     <span id="text-additional-info"></span
                     ><th:block th:text="#{person.form.basedata.additionalInformation.maxChars}"></th:block>

--- a/src/main/resources/templates/thymeleaf/settings/absence-types/special-leave.html
+++ b/src/main/resources/templates/thymeleaf/settings/absence-types/special-leave.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <th:block th:fragment="section">
-      <div th:replace="fragments/section-heading::section-heading(~{::special-leave-heading-body}, ~{})">
+      <div th:replace="~{fragments/section-heading::section-heading(~{::special-leave-heading-body}, ~{})}">
         <th:block th:fragment="special-leave-heading-body">
           <h2 th:text="#{settings.specialleave.title}"></h2>
         </th:block>
@@ -14,7 +14,7 @@
       <div>
         <aside class="help-block tw-flex tw-flex-auto tw-justify-left tw-items-start tw-pt-2 tw-text-sm">
           <div>
-            <svg th:replace="icon/information-circle::svg(className='tw-w-4 tw-h-4')"></svg>
+            <svg th:replace="~{icon/information-circle::svg(className='tw-w-4 tw-h-4')}"></svg>
           </div>
           <div class="tw-flex tw-flex-col">
             <p th:text="#{settings.specialleave.help}"></p>
@@ -24,7 +24,7 @@
                 class="tw-flex tw-items-center"
                 href="mailto:info@urlaubsverwaltung.cloud?subject=Missing%20special%20leaves"
               >
-                <svg th:replace="icon/mail::svg(className='tw-w-4 tw-h-4 tw-mr-1')"></svg>
+                <svg th:replace="~{icon/mail::svg(className='tw-w-4 tw-h-4 tw-mr-1')}"></svg>
                 <th:block th:text="#{settings.specialleave.description.2}" />
               </a>
             </p>

--- a/src/main/resources/templates/thymeleaf/settings/absence/reminder-holiday-replacement.html
+++ b/src/main/resources/templates/thymeleaf/settings/absence/reminder-holiday-replacement.html
@@ -5,7 +5,9 @@
   </head>
   <body>
     <th:block th:fragment="section">
-      <div th:replace="fragments/section-heading::section-heading(~{::reminder-holiday-replacement-heading-body}, ~{})">
+      <div
+        th:replace="~{fragments/section-heading::section-heading(~{::reminder-holiday-replacement-heading-body}, ~{})}"
+      >
         <th:block th:fragment="reminder-holiday-replacement-heading-body">
           <h2 th:text="#{settings.vacation.remindForUpcomingHolidayReplacement.title}"></h2>
         </th:block>
@@ -14,7 +16,7 @@
       <div class="row">
         <aside class="col-md-4 col-md-push-8">
           <p class="help-block tw-text-sm">
-            <svg th:replace="icon/information-circle::svg(className='tw-w-4 tw-h-4')"></svg>
+            <svg th:replace="~{icon/information-circle::svg(className='tw-w-4 tw-h-4')}"></svg>
             <th:block th:text="#{settings.vacation.remindForUpcomingHolidayReplacement.description}" />
           </p>
         </aside>

--- a/src/main/resources/templates/thymeleaf/settings/absence/reminder-upcoming-application.html
+++ b/src/main/resources/templates/thymeleaf/settings/absence/reminder-upcoming-application.html
@@ -6,7 +6,7 @@
   <body>
     <th:block th:fragment="section">
       <div
-        th:replace="fragments/section-heading::section-heading(~{::reminder-upcoming-application-heading-body}, ~{})"
+        th:replace="~{fragments/section-heading::section-heading(~{::reminder-upcoming-application-heading-body}, ~{})}"
       >
         <th:block th:fragment="reminder-upcoming-application-heading-body">
           <h2 th:text="#{settings.vacation.remindForUpcomingApplications.title}"></h2>
@@ -16,7 +16,7 @@
       <div class="row">
         <aside class="col-md-4 col-md-push-8">
           <p class="help-block tw-text-sm">
-            <svg th:replace="icon/information-circle::svg(className='tw-w-4 tw-h-4')"></svg>
+            <svg th:replace="~{icon/information-circle::svg(className='tw-w-4 tw-h-4')}"></svg>
             <th:block th:text="#{settings.vacation.remindForUpcomingApplications.description}" />
           </p>
         </aside>

--- a/src/main/resources/templates/thymeleaf/settings/absence/reminder-waiting-application.html
+++ b/src/main/resources/templates/thymeleaf/settings/absence/reminder-waiting-application.html
@@ -5,7 +5,9 @@
   </head>
   <body>
     <th:block th:fragment="section">
-      <div th:replace="fragments/section-heading::section-heading(~{::reminder-waiting-application-heading-body}, ~{})">
+      <div
+        th:replace="~{fragments/section-heading::section-heading(~{::reminder-waiting-application-heading-body}, ~{})}"
+      >
         <th:block th:fragment="reminder-waiting-application-heading-body">
           <h2 th:text="#{settings.vacation.remindForWaitingApplications.title}"></h2>
         </th:block>
@@ -14,7 +16,7 @@
       <div class="row">
         <aside class="col-md-4 col-md-push-8">
           <p class="help-block tw-text-sm">
-            <svg th:replace="icon/information-circle::svg(className='tw-w-4 tw-h-4')"></svg>
+            <svg th:replace="~{icon/information-circle::svg(className='tw-w-4 tw-h-4')}"></svg>
             <th:block th:text="#{settings.vacation.daysBeforeRemindForWaitingApplications.description}" />
           </p>
         </aside>

--- a/src/main/resources/templates/thymeleaf/settings/absence/sick-days.html
+++ b/src/main/resources/templates/thymeleaf/settings/absence/sick-days.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <th:block th:fragment="section">
-      <div th:replace="fragments/section-heading::section-heading(~{::sick-days-heading-body}, ~{})">
+      <div th:replace="~{fragments/section-heading::section-heading(~{::sick-days-heading-body}, ~{})}">
         <th:block th:fragment="sick-days-heading-body">
           <h2 th:text="#{settings.sickDays.title}"></h2>
         </th:block>
@@ -14,7 +14,7 @@
       <div class="row">
         <aside class="col-md-4 col-md-push-8">
           <p class="help-block tw-text-sm">
-            <svg th:replace="icon/information-circle::svg(className='tw-w-4 tw-h-4')"></svg>
+            <svg th:replace="~{icon/information-circle::svg(className='tw-w-4 tw-h-4')}"></svg>
             <th:block th:text="#{settings.sickDays.description}" />
           </p>
         </aside>

--- a/src/main/resources/templates/thymeleaf/settings/absence/vacation.html
+++ b/src/main/resources/templates/thymeleaf/settings/absence/vacation.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <th:block th:fragment="section">
-      <div th:replace="fragments/section-heading::section-heading(~{::vacation-heading-body}, ~{})">
+      <div th:replace="~{fragments/section-heading::section-heading(~{::vacation-heading-body}, ~{})}">
         <th:block th:fragment="vacation-heading-body">
           <h2 th:text="#{settings.vacation.title}"></h2>
         </th:block>
@@ -14,7 +14,7 @@
       <div class="row">
         <aside class="col-md-4 col-md-push-8">
           <p class="help-block tw-text-sm">
-            <svg th:replace="icon/information-circle::svg(className='tw-w-4 tw-h-4')"></svg>
+            <svg th:replace="~{icon/information-circle::svg(className='tw-w-4 tw-h-4')}"></svg>
             <th:block th:text="#{settings.vacation.description}" />
           </p>
         </aside>

--- a/src/main/resources/templates/thymeleaf/settings/calendar/exchange.html
+++ b/src/main/resources/templates/thymeleaf/settings/calendar/exchange.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <th:block th:fragment="section">
-      <div th:replace="fragments/section-heading::section-heading(~{::exchange-heading-body}, ~{})">
+      <div th:replace="~{fragments/section-heading::section-heading(~{::exchange-heading-body}, ~{})}">
         <th:block th:fragment="exchange-heading-body">
           <h2 th:text="#{settings.calendar.ews.title}"></h2>
         </th:block>
@@ -14,7 +14,7 @@
       <div class="row">
         <aside class="col-md-4 col-md-push-8">
           <p class="help-block tw-text-sm">
-            <svg th:replace="icon/information-circle::svg(className='tw-w-4 tw-h-4')"></svg>
+            <svg th:replace="~{icon/information-circle::svg(className='tw-w-4 tw-h-4')}"></svg>
             <th:block th:utext="#{settings.calendar.ews.description}" />
           </p>
         </aside>

--- a/src/main/resources/templates/thymeleaf/settings/calendar/google.html
+++ b/src/main/resources/templates/thymeleaf/settings/calendar/google.html
@@ -15,22 +15,22 @@
           <p th:text="#{settings.calendar.google.description}"></p>
           <dl class="tw-mt-4">
             <dt class="tw-mb-0.5 tw-flex tw-items-center tw-gap-2">
-              <svg th:replace="icon/information-circle::svg(className='tw-w-4 tw-h-4')"></svg>
+              <svg th:replace="~{icon/information-circle::svg(className='tw-w-4 tw-h-4')}"></svg>
               <th:block th:text="#{settings.calendar.google.oauth-client-id.title}"></th:block>
             </dt>
             <dd th:utext="#{settings.calendar.google.oauth-client-id.description}"></dd>
             <dt class="tw-mb-0.5 tw-mt-4 tw-flex tw-items-center tw-gap-2">
-              <svg th:replace="icon/information-circle::svg(className='tw-w-4 tw-h-4')"></svg>
+              <svg th:replace="~{icon/information-circle::svg(className='tw-w-4 tw-h-4')}"></svg>
               <th:block th:text="#{settings.calendar.google.oauth-client-secret.title}"></th:block>
             </dt>
             <dd th:text="#{settings.calendar.google.oauth-client-secret.description}"></dd>
             <dt class="tw-mb-0.5 tw-mt-4 tw-flex tw-items-center tw-gap-2">
-              <svg th:replace="icon/information-circle::svg(className='tw-w-4 tw-h-4')"></svg>
+              <svg th:replace="~{icon/information-circle::svg(className='tw-w-4 tw-h-4')}"></svg>
               <th:block th:text="#{settings.calendar.google.calendar-id.title}"></th:block>
             </dt>
             <dd th:text="#{settings.calendar.google.calendar-id.description}"></dd>
             <dt class="tw-mb-0.5 tw-mt-4 tw-flex tw-items-center tw-gap-2">
-              <svg th:replace="icon/information-circle::svg(className='tw-w-4 tw-h-4')"></svg>
+              <svg th:replace="~{icon/information-circle::svg(className='tw-w-4 tw-h-4')}"></svg>
               <th:block th:text="#{settings.calendar.google.redirect-url.title}"></th:block>
             </dt>
             <dd th:text="#{settings.calendar.google.redirect-url.description}"></dd>

--- a/src/main/resources/templates/thymeleaf/settings/calendar/integration.html
+++ b/src/main/resources/templates/thymeleaf/settings/calendar/integration.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <th:block th:fragment="section">
-      <div th:replace="fragments/section-heading::section-heading(~{::integrations-heading-body}, ~{})">
+      <div th:replace="~{fragments/section-heading::section-heading(~{::integrations-heading-body}, ~{})}">
         <th:block th:fragment="integrations-heading-body">
           <h2 th:text="#{settings.calendar.title}"></h2>
         </th:block>
@@ -14,7 +14,7 @@
       <div class="row">
         <aside class="col-md-4 col-md-push-8">
           <p class="help-block tw-text-sm">
-            <svg th:replace="icon/information-circle::svg(className='tw-w-4 tw-h-4')"></svg>
+            <svg th:replace="~{icon/information-circle::svg(className='tw-w-4 tw-h-4')}"></svg>
             <th:block th:text="#{settings.calendar.description}" />
           </p>
         </aside>
@@ -28,7 +28,7 @@
             </label>
             <div class="col-md-8">
               <select
-                th:replace="fragments/select::one(id='calendarSettingsProvider', name='calendarSettings.provider', options=~{::settings-calendar-providers})"
+                th:replace="~{fragments/select::one(id='calendarSettingsProvider', name='calendarSettings.provider', options=~{::settings-calendar-providers})}"
               >
                 <th:block th:fragment="settings-calendar-providers">
                   <option

--- a/src/main/resources/templates/thymeleaf/settings/public-holidays/overtime.html
+++ b/src/main/resources/templates/thymeleaf/settings/public-holidays/overtime.html
@@ -5,7 +5,9 @@
   </head>
   <body>
     <th:block th:fragment="section">
-      <div th:replace="fragments/section-heading::section-heading(~{::reminder-holiday-replacement-heading-body}, ~{})">
+      <div
+        th:replace="~{fragments/section-heading::section-heading(~{::reminder-holiday-replacement-heading-body}, ~{})}"
+      >
         <th:block th:fragment="reminder-holiday-replacement-heading-body">
           <h2 th:text="#{settings.overtime.title}"></h2>
         </th:block>
@@ -14,7 +16,7 @@
       <div class="row">
         <aside class="col-md-4 col-md-push-8">
           <p class="help-block tw-text-sm">
-            <svg th:replace="icon/information-circle::svg(className='tw-w-4 tw-h-4')"></svg>
+            <svg th:replace="~{icon/information-circle::svg(className='tw-w-4 tw-h-4')}"></svg>
             <th:block th:text="#{settings.overtime.description}" />
           </p>
         </aside>

--- a/src/main/resources/templates/thymeleaf/settings/public-holidays/public-holidays.html
+++ b/src/main/resources/templates/thymeleaf/settings/public-holidays/public-holidays.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <th:block th:fragment="section">
-      <div th:replace="fragments/section-heading::section-heading(~{::public-holidays-heading-body}, ~{})">
+      <div th:replace="~{fragments/section-heading::section-heading(~{::public-holidays-heading-body}, ~{})}">
         <th:block th:fragment="public-holidays-heading-body">
           <h2 th:text="#{settings.publicHolidays.title}"></h2>
         </th:block>
@@ -14,7 +14,7 @@
       <div class="row">
         <aside class="col-md-4 col-md-push-8">
           <p class="help-block tw-text-sm">
-            <svg th:replace="icon/information-circle::svg(className='tw-w-4 tw-h-4')"></svg>
+            <svg th:replace="~{icon/information-circle::svg(className='tw-w-4 tw-h-4')}"></svg>
             <th:block th:text="#{settings.publicHolidays.description}" />
           </p>
         </aside>
@@ -28,7 +28,7 @@
             </label>
             <div class="col-md-8">
               <select
-                th:replace="fragments/select::one(id='workingTimeSettings.workingDurationForChristmasEve', name='workingTimeSettings.workingDurationForChristmasEve', options=~{::settings-workingtimes-workingDurationForChristmasEve})"
+                th:replace="~{fragments/select::one(id='workingTimeSettings.workingDurationForChristmasEve', name='workingTimeSettings.workingDurationForChristmasEve', options=~{::settings-workingtimes-workingDurationForChristmasEve})}"
               >
                 <th:block th:fragment="settings-workingtimes-workingDurationForChristmasEve">
                   <option
@@ -50,7 +50,7 @@
             </label>
             <div class="col-md-8">
               <select
-                th:replace="fragments/select::one(id='workingTimeSettings.workingDurationForNewYearsEve', name='workingTimeSettings.workingDurationForNewYearsEve', options=~{::settings-workingtimes-workingDurationForNewYearsEve})"
+                th:replace="~{fragments/select::one(id='workingTimeSettings.workingDurationForNewYearsEve', name='workingTimeSettings.workingDurationForNewYearsEve', options=~{::settings-workingtimes-workingDurationForNewYearsEve})}"
               >
                 <th:block th:fragment="settings-workingtimes-workingDurationForNewYearsEve">
                   <option
@@ -72,7 +72,7 @@
             </label>
             <div class="col-md-8">
               <select
-                th:replace="fragments/select::one(id='federalStateType', name='workingTimeSettings.federalState', options=~{::settings-workingtimes-federalStateType})"
+                th:replace="~{fragments/select::one(id='federalStateType', name='workingTimeSettings.federalState', options=~{::settings-workingtimes-federalStateType})}"
               >
                 <th:block th:fragment="settings-workingtimes-federalStateType">
                   <optgroup th:label="#{country.general}">

--- a/src/main/resources/templates/thymeleaf/settings/public-holidays/time.html
+++ b/src/main/resources/templates/thymeleaf/settings/public-holidays/time.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <th:block th:fragment="section">
-      <div th:replace="fragments/section-heading::section-heading(~{::time-heading-body}, ~{})">
+      <div th:replace="~{fragments/section-heading::section-heading(~{::time-heading-body}, ~{})}">
         <th:block th:fragment="time-heading-body">
           <h2 th:text="#{settings.time.title}"></h2>
         </th:block>
@@ -21,7 +21,7 @@
             </label>
             <div class="col-md-8">
               <select
-                th:replace="fragments/select::one(id='timeSettings.timeZoneId', name='timeSettings.timeZoneId', options=~{::settings-time-timezoneid})"
+                th:replace="~{fragments/select::one(id='timeSettings.timeZoneId', name='timeSettings.timeZoneId', options=~{::settings-time-timezoneid})}"
                 id="yearSelect"
               >
                 <th:block th:fragment="settings-time-timezoneid">

--- a/src/main/resources/templates/thymeleaf/settings/settings_form.html
+++ b/src/main/resources/templates/thymeleaf/settings/settings_form.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en" th:lang="${language}" th:class="|tw-${theme}|" xmlns:th="http://www.thymeleaf.org">
-  <head th:replace="_layout::head(~{::title}, ~{}, ~{::scripts})">
+  <head th:replace="~{_layout::head(~{::title}, ~{}, ~{::scripts})}">
     <title th:text="#{settings.header.title}"></title>
     <th:block th:ref="scripts">
       <script defer asset:src="settings_form.js"></script>
     </th:block>
   </head>
-  <body th:replace="_layout::body(~{::content}, ~{})">
+  <body th:replace="~{_layout::body(~{::content}, ~{})}">
     <th:block th:ref="content">
       <main class="tw-max-w-6xl tw-mx-auto tw-px-4 lg:tw-px-12 xl:tw-px-0">
         <h1 th:text="#{settings.header.title}" class="tw-sr-only"></h1>

--- a/src/main/resources/templates/thymeleaf/user/user-settings.html
+++ b/src/main/resources/templates/thymeleaf/user/user-settings.html
@@ -6,7 +6,7 @@
   xmlns:th="http://www.thymeleaf.org"
   xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
 >
-  <head th:replace="_layout::head(~{::title}, ~{}, ~{::scripts})">
+  <head th:replace="~{_layout::head(~{::title}, ~{}, ~{::scripts})}">
     <title th:text="#{user-settings.header.title}"></title>
     <th:block th:fragment="scripts">
       <script
@@ -16,10 +16,10 @@
       <script defer asset:src="user_settings.js"></script>
     </th:block>
   </head>
-  <body th:replace="_layout::body(~{::main}, ~{})">
+  <body th:replace="~{_layout::body(~{::main}, ~{})}">
     <main th:fragment="main" class="tw-max-w-6xl tw-mx-auto tw-px-4 lg:tw-px-12 xl:tw-px-0">
       <div
-        th:replace="fragments/section-heading::section-heading(~{::user-applications-heading-body}, ~{::user-applications-heading-actions})"
+        th:replace="~{fragments/section-heading::section-heading(~{::user-applications-heading-body}, ~{::user-applications-heading-actions})}"
       >
         <th:block th:ref="user-applications-heading-body">
           <h1 th:text="#{user-settings.title}">Account settings</h1>
@@ -65,7 +65,7 @@
                     class="tw-flex md:tw-flex-col tw-items-center tw-gap-4 tw-m-0 tw-cursor-pointer md:tw-text-center"
                   >
                     <svg
-                      th:replace="icon/globe::svg(className='tw-w-9 tw-h-9 md:tw-w-16 md:tw-h-16 tw-stroke-1')"
+                      th:replace="~{icon/globe::svg(className='tw-w-9 tw-h-9 md:tw-w-16 md:tw-h-16 tw-stroke-1')}"
                     ></svg>
                     <span
                       th:text="#{user-settings.language.locale.system}"


### PR DESCRIPTION
https://www.thymeleaf.org/doc/tutorials/3.1/usingthymeleaf.html#parameterizable-fragment-signatures

Usage without `~{}` will trigger a hell of warnings using thymeleaf 3.1

Context: discovered during development of https://github.com/urlaubsverwaltung/urlaubsverwaltung/pull/3389
<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@urlaubsverwaltung.cloud with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
