### PR TITLE
Revert "optional 'personId' parameter for avatar"

### DIFF
--- a/src/main/resources/templates/_navigation.html
+++ b/src/main/resources/templates/_navigation.html
@@ -149,7 +149,7 @@
                   >
                     <span class="tw-inline-flex tw-text-blue-200 dark:tw-text-sky-800">
                       <img
-                        th:replace="~{fragments/avatar::avatar(className='tw-w-8 tw-h-8 lg:tw-w-9 lg:tw-h-9',url=${menuGravatarUrl + '?d=404'},niceName=${userFirstName + ' ' + userLastName},width='40px',height='40px')}"
+                        th:replace="~{fragments/avatar::avatar(className='tw-w-8 tw-h-8 lg:tw-w-9 lg:tw-h-9',url=${menuGravatarUrl + '?d=404'},niceName=${userFirstName + ' ' + userLastName},width='40px',height='40px',personId=null)}"
                         alt=""
                       />
                     </span>
@@ -166,7 +166,7 @@
                           >
                             <span class="tw-text-blue-200 dark:tw-text-sky-800">
                               <img
-                                th:replace="~{fragments/avatar::avatar(url=${menuGravatarUrl + '?d=404&s=128'},niceName=${userFirstName + ' ' + userLastName},width='64px',height='64px')}"
+                                th:replace="~{fragments/avatar::avatar(url=${menuGravatarUrl + '?d=404&s=128'},niceName=${userFirstName + ' ' + userLastName},width='64px',height='64px',personId=null)}"
                                 alt=""
                               />
                             </span>

--- a/src/main/resources/templates/fragments/avatar.html
+++ b/src/main/resources/templates/fragments/avatar.html
@@ -5,7 +5,7 @@
     <title>avatar</title>
   </head>
   <body>
-    <th:block th:fragment="avatar(url,niceName,width,height)">
+    <th:block th:fragment="avatar(url,niceName,width,height,personId)">
       <a
         th:if="${personId != null}"
         th:href="@{/web/person/__${personId}__/overview}"
@@ -44,10 +44,10 @@
     </th:block>
 
     <span
-      th:fragment="avatar-bordered(url,niceName,width,height)"
+      th:fragment="avatar-bordered(url,niceName,width,height,personId)"
       class="tw-bg-gradient-to-br tw-from-blue-50 tw-to-blue-200 dark:tw-from-sky-800 dark:tw-to-zinc-800 tw-rounded-full tw-p-1 tw-inline-flex"
     >
-      <img src="#" alt="" th:replace="~{::avatar(${url},${niceName},${width},${height})}" />
+      <img src="#" alt="" th:replace="~{::avatar(${url},${niceName},${width},${height},${personId})}" />
     </span>
   </body>
 </html>

--- a/src/main/resources/templates/thymeleaf/application/application-form.html
+++ b/src/main/resources/templates/thymeleaf/application/application-form.html
@@ -26,7 +26,7 @@
           <div class="tw-flex">
             <div class="tw-mr-4 tw-mt-1 tw-text-blue-50 dark:tw-text-sky-800">
               <img
-                th:replace="~{fragments/avatar::avatar(url=${holidayReplacement.person.gravatarURL + '?d=404&s=40'},niceName=${holidayReplacement.person.niceName},width='40px',height='40px')}"
+                th:replace="~{fragments/avatar::avatar(url=${holidayReplacement.person.gravatarURL + '?d=404&s=40'},niceName=${holidayReplacement.person.niceName},width='40px',height='40px',personId=null)}"
                 alt=""
               />
             </div>

--- a/src/main/resources/templates/thymeleaf/person/person-overview-reduced.html
+++ b/src/main/resources/templates/thymeleaf/person/person-overview-reduced.html
@@ -27,7 +27,7 @@
           th:replace="thymeleaf/person/box::person-box-with-departments(person=${person}, departments=${departmentsOfPerson})"
         ></div>
       </div>
-      <p class="tw-text-sm" th:text="#{overview.reduced.info(${person.niceName})}"/>
+      <p class="tw-text-sm" th:text="#{overview.reduced.info(${person.niceName})}" />
     </main>
   </body>
 </html>


### PR DESCRIPTION
refs #2036

Fix: Der Avatar ist aus dem Navigationsbereich oben verschoben.

Es wurde ein Link innerhalb eine Links gerendert, was vom Browser korrigiert wird -> inner Link wird Nebendran gesetzt als Element.

<img width="1303" alt="bug-avatar-navi" src="https://user-images.githubusercontent.com/1732200/208317874-d7c11ebc-722e-4396-963a-0705b02952f8.png">

<img width="575" alt="bug-avatar-html" src="https://user-images.githubusercontent.com/1732200/208317872-0fb7c34c-a5d0-4129-b394-323d9085fb20.png">
