### PR TITLE
fix avatar fallback image

### DIFF
--- a/src/main/resources/templates/fragments/avatar.html
+++ b/src/main/resources/templates/fragments/avatar.html
@@ -16,7 +16,7 @@
           src="#"
           th:src="${url}"
           alt=""
-          class="gravatar gravatar--medium tw-rounded-full"
+          class="gravatar gravatar--medium tw-rounded-full tw-block"
           th:classappend="${className}"
           th:width="${width == null ? '32px' : width}"
           th:height="${height == null ? '32px' : height}"

--- a/src/main/resources/templates/fragments/avatar.html
+++ b/src/main/resources/templates/fragments/avatar.html
@@ -10,6 +10,7 @@
         th:if="${personId != null}"
         th:href="@{/web/person/__${personId}__/overview}"
         th:aria-label="#{nav.avatar-menu.overview.link(${niceName})}"
+        class="tw-text-inherit"
       >
         <img
           th:if="${url != null}"


### PR DESCRIPTION
avatar with initials is now a circle again.
without this patch it is oval, with a padding on the bottom.

refs #2036 

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@urlaubsverwaltung.cloud with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
