### PR TITLE
fix person name link navigation

### DIFF
--- a/src/main/resources/templates/fragments/avatar.html
+++ b/src/main/resources/templates/fragments/avatar.html
@@ -11,6 +11,7 @@
         th:href="@{/web/person/__${personId}__/overview}"
         th:aria-label="#{nav.avatar-menu.overview.link(${niceName})}"
         class="tw-text-inherit"
+        data-turbo-frame="_top"
       >
         <img
           th:if="${url != null}"

--- a/src/main/resources/templates/thymeleaf/absences/absences-overview.html
+++ b/src/main/resources/templates/thymeleaf/absences/absences-overview.html
@@ -202,7 +202,7 @@
                   </div>
                 </th>
                 <th scope="row" class="tw-py-0.5 tw-pl-2 tw-pr-4 print:tw-py-1.5">
-                  <a th:href="@{/web/person/__${person.id}__/overview}" class="icon-link">
+                  <a th:href="@{/web/person/__${person.id}__/overview}" class="icon-link" data-turbo-frame="_top">
                     <div class="tw-flex tw-flex-col tw-justify-center tw-leading-tight">
                       <th:block th:text="${person.firstName}" />&nbsp;
                       <span th:text="${person.lastName}"></span>

--- a/src/main/resources/templates/thymeleaf/application/app-sections/section-progress.html
+++ b/src/main/resources/templates/thymeleaf/application/app-sections/section-progress.html
@@ -29,6 +29,7 @@
                   th:text="${comment.person.niceName}"
                   th:href="@{/web/person/__${comment.person.id}__/overview}"
                   class="icon-link"
+                  data-turbo-frame="_top"
                 ></a>
               </td>
               <td th:if="${comment.person == null}" th:text="#{application.progress.deleted-author}"></td>

--- a/src/main/resources/templates/thymeleaf/application/application-detail.html
+++ b/src/main/resources/templates/thymeleaf/application/application-detail.html
@@ -270,6 +270,7 @@
                   th:text="${departmentApplication.person.niceName}"
                   th:href="@{/web/person/__${departmentApplication.person.id}__/overview}"
                   class="icon-link"
+                  data-turbo-frame="_top"
                 ></a>
               </td>
               <td>

--- a/src/main/resources/templates/thymeleaf/application/application-overview.html
+++ b/src/main/resources/templates/thymeleaf/application/application-overview.html
@@ -125,6 +125,7 @@
                     th:text="${signedInUser.niceName}"
                     th:href="@{/web/person/__${signedInUser.id}__/overview}"
                     class="icon-link"
+                    data-turbo-frame="_top"
                   ></a>
                 </span>
                 <span class="tw-text-lg lg:tw-text-sm" th:text="#{application.applier.applied}"></span>
@@ -237,6 +238,7 @@
                     th:text="${signedInUser.niceName}"
                     th:href="@{/web/person/__${signedInUser.id}__/overview}"
                     class="icon-link"
+                    data-turbo-frame="_top"
                   />
                 </span>
                 <span class="tw-text-lg lg:tw-text-sm" th:text="#{application.applier.represents}"></span>
@@ -264,6 +266,7 @@
                         th:text="${replacementInfo.person.name}"
                         th:href="@{/web/person/__${replacementInfo.person.id}__/overview}"
                         class="icon-link"
+                        data-turbo-frame="_top"
                       />
                     </span>
                   </div>
@@ -329,6 +332,7 @@
                   th:text="${otherRequestForLeave.person.name}"
                   th:href="@{/web/person/__${otherRequestForLeave.person.id}__/overview}"
                   class="icon-link"
+                  data-turbo-frame="_top"
                 ></a>
                 <span class="md:tw-text-sm" th:text="#{application.applier.applied}"></span>
               </span>
@@ -454,6 +458,7 @@
                     th:text="${cancellationRequest.person.name}"
                     th:href="@{/web/person/__${cancellationRequest.person.id}__/overview}"
                     class="icon-link"
+                    data-turbo-frame="_top"
                   ></a>
                   <span class="md:tw-text-sm" th:text="#{application.applier.applied}"></span>
                 </span>

--- a/src/main/resources/templates/thymeleaf/application/application-statistics.html
+++ b/src/main/resources/templates/thymeleaf/application/application-statistics.html
@@ -316,6 +316,7 @@
                     th:text="${statistic.firstName}"
                     th:href="@{/web/person/__${statistic.id}__/overview}"
                     class="icon-link"
+                    data-turbo-frame="_top"
                   ></a>
                 </td>
                 <td class="tw-hidden lg:tw-table-cell print:tw-table-cell">
@@ -323,6 +324,7 @@
                     th:text="${statistic.lastName}"
                     th:href="@{/web/person/__${statistic.id}__/overview}"
                     class="icon-link"
+                    data-turbo-frame="_top"
                   ></a>
                 </td>
                 <td class="lg:tw-hidden print:tw-hidden">
@@ -330,6 +332,7 @@
                     th:text="${statistic.niceName}"
                     th:href="@{/web/person/__${statistic.id}__/overview}"
                     class="icon-link"
+                    data-turbo-frame="_top"
                   ></a>
                 </td>
                 <td class="md:tw-hidden print:tw-hidden">

--- a/src/main/resources/templates/thymeleaf/application/application_form.html
+++ b/src/main/resources/templates/thymeleaf/application/application_form.html
@@ -457,6 +457,7 @@
                                   th:text="${holidayReplacement.person.niceName}"
                                   th:href="@{/web/person/__${holidayReplacement.person.id}__/overview}"
                                   class="icon-link"
+                                  data-turbo-frame="_top"
                                 ></a>
                                 <ul
                                   th:if="${not #lists.isEmpty(holidayReplacement.departments)}"

--- a/src/main/resources/templates/thymeleaf/department/department_form.html
+++ b/src/main/resources/templates/thymeleaf/department/department_form.html
@@ -220,6 +220,7 @@
                                 th:text="${person.niceName}"
                                 th:href="@{/web/person/__${person.id}__/overview}"
                                 class="icon-link"
+                                data-turbo-frame="_top"
                               ></a>
                             </p>
                             <div th:if="${isInactive}" class="tw-flex tw-items-center">

--- a/src/main/resources/templates/thymeleaf/overtime/overtime_details.html
+++ b/src/main/resources/templates/thymeleaf/overtime/overtime_details.html
@@ -103,6 +103,7 @@
                     th:text="${comment.person.niceName}"
                     th:href="@{/web/person/__${comment.person.id}__/overview}"
                     class="icon-link"
+                    data-turbo-frame="_top"
                   ></a>
                 </td>
                 <td th:if="${comment.person == null}" th:text="#{overtime.progress.deleted-author}"></td>

--- a/src/main/resources/templates/thymeleaf/person/persons.html
+++ b/src/main/resources/templates/thymeleaf/person/persons.html
@@ -247,6 +247,7 @@
                       th:text="${person.firstName}"
                       th:href="@{/web/person/__${person.id}__/overview}"
                       class="icon-link"
+                      data-turbo-frame="_top"
                     ></a>
                   </td>
                   <td class="lastname">
@@ -254,6 +255,7 @@
                       th:text="${person.lastName}"
                       th:href="@{/web/person/__${person.id}__/overview}"
                       class="icon-link"
+                      data-turbo-frame="_top"
                     ></a>
                   </td>
                   <td class="is-centered hidden-xs hidden-sm print:tw-table-cell">

--- a/src/main/resources/templates/thymeleaf/sicknote/sick_days.html
+++ b/src/main/resources/templates/thymeleaf/sicknote/sick_days.html
@@ -315,6 +315,7 @@
                   th:text="${sickDaysStatistic.personFirstName}"
                   th:href="@{/web/person/__${sickDaysStatistic.personId}__/overview}"
                   class="icon-link"
+                  data-turbo-frame="_top"
                 ></a>
               </td>
               <td class="hidden-xs">
@@ -322,6 +323,7 @@
                   th:text="${sickDaysStatistic.personLastName}"
                   th:href="@{/web/person/__${sickDaysStatistic.personId}__/overview}"
                   class="icon-link"
+                  data-turbo-frame="_top"
                 ></a>
               </td>
               <td class="visible-xs">
@@ -329,12 +331,14 @@
                   th:text="${sickDaysStatistic.personNiceName}"
                   th:href="@{/web/person/__${sickDaysStatistic.personId}__/overview}"
                   class="icon-link"
+                  data-turbo-frame="_top"
                 ></a>
               </td>
               <td class="hidden-xs">
                 <a
                   th:href="@{/web/person/__${sickDaysStatistic.personId}__/overview#anchorSickNotes}"
                   class="icon-link"
+                  data-turbo-frame="_top"
                 >
                   <div class="tw-flex tw-items-center">
                     <svg th:replace="icon/medkit::svg(className='tw-w-4 tw-h-4')"></svg>
@@ -360,6 +364,7 @@
                 <a
                   th:href="@{/web/person/__${sickDaysStatistic.personId}__/overview#anchorSickNotes}"
                   class="icon-link"
+                  data-turbo-frame="_top"
                 >
                   <div class="tw-flex tw-items-center">
                     <svg th:replace="icon/child::svg(className='tw-w-3 tw-h-3')"></svg>

--- a/src/main/resources/templates/thymeleaf/sicknote/sick_note.html
+++ b/src/main/resources/templates/thymeleaf/sicknote/sick_note.html
@@ -222,6 +222,7 @@
                     th:text="${comment.person.niceName}"
                     th:href="@{/web/person/__${comment.person.id}__/overview}"
                     class="icon-link"
+                    data-turbo-frame="_top"
                   ></a>
                 </td>
                 <td th:if="${comment.person == null}" th:text="#{sicknote.progress.deleted-author}"></td>


### PR DESCRIPTION
turbo intercepts the links on some pages (e.g. wrapped by `tubo-frame`) which could result in race conditions replacing a frame, body, whole page or full page reload. I have not analysed it deeper...

There are two options to solve this:
1. disable turbo with `data-turbo=false` attribute
2. instruct turbo to handle the page root with `data-target=_top`

The second options seems to be the best since
- this attribute does not take effect when turbo is disabled
- we still take advantage of a maybe more performant client side navigation (when turbo is enabled on the page that uses a person link)

closes #3560 