### PR TITLE
Fix launchpad layout

### DIFF
--- a/src/main/resources/templates/launchpad/launchpad.html
+++ b/src/main/resources/templates/launchpad/launchpad.html
@@ -53,9 +53,9 @@
           <div class="nav-popup-menu-inner__content">
             <ul
               class="tw-grid tw-gap-2 tw-list-none tw-p-0 tw-m-0"
-              style="grid-template-columns: repeat(var(--cols, 1), minmax(8rem, 1fr));"
+              style="grid-template-columns: repeat(var(--cols, 1), minmax(8rem, 1fr))"
               th:with="size=${#lists.size(launchpad.apps)}"
-              th:styleappend="${size > 3 ? '--cols:3' : (size > 1 ? '--cols:2' : '--cols:1')}"
+              th:styleappend="${size > 3 ? ';--cols:3' : (size > 1 ? ';--cols:2' : ';--cols:1')}"
             >
               <li th:each="app : ${launchpad.apps}">
                 <a

--- a/src/main/resources/templates/launchpad/launchpad.html
+++ b/src/main/resources/templates/launchpad/launchpad.html
@@ -53,7 +53,7 @@
           <div class="nav-popup-menu-inner__content">
             <ul
               class="tw-grid tw-gap-2 tw-list-none tw-p-0 tw-m-0"
-              style="grid-template-columns: repeat(var(--cols, 1), minmax(8rem, 1fr))"
+              style="grid-template-columns: repeat(var(--cols, 1), minmax(8rem, 1fr));"
               th:with="size=${#lists.size(launchpad.apps)}"
               th:styleappend="${size > 3 ? '--cols:3' : (size > 1 ? '--cols:2' : '--cols:1')}"
             >


### PR DESCRIPTION
prettier removes the semicolon.
thymeleaf th:styleappend does not handle this. the string is just concatenated. therefore the style has no impact anymore :/

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to info@urlaubsverwaltung.cloud with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
