### PR TITLE
Do not retrieve authentication one error site...

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/web/FrameDataProvider.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/FrameDataProvider.java
@@ -46,6 +46,11 @@ public class FrameDataProvider implements HandlerInterceptor {
     @Override
     public void postHandle(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler, ModelAndView modelAndView) {
 
+        if (modelAndView != null && Objects.equals(modelAndView.getViewName(), "error")) {
+            modelAndView.addObject("doNotShowNavigation", true);
+            return;
+        }
+
         if (modelAndView != null && menuIsShown(modelAndView)) {
 
             final Person signedInUserInModel = (Person) modelAndView.getModelMap().get("signedInUser");

--- a/src/main/resources/templates/_layout.html
+++ b/src/main/resources/templates/_layout.html
@@ -122,7 +122,9 @@
     <th:block th:replace="${scripts}"></th:block>
   </head>
   <body th:fragment="body(content, scripts)">
-    <nav th:replace="_navigation::nav">navigation block</nav>
+    <th:block th:if="${doNotShowNavigation == null || #bools.isFalse(doNotShowNavigation)}">
+      <nav th:replace="_navigation::nav">navigation block</nav>
+    </th:block>
 
     <main th:replace="${content}">content block</main>
 


### PR DESCRIPTION
... no authentication is available and do not show menu on error for including thymeleaf pages or on thymeleaf error

Instead of en exception, because the authentication is null and a white page we now provide on template errors (200 "error" seems odd)

![grafik](https://github.com/urlaubsverwaltung/urlaubsverwaltung/assets/5683677/ce6b5f10-6971-45a6-b31a-9197ab38ebb5)

to reproduce add a typo into a variable name. 

On exceptions

![grafik](https://github.com/urlaubsverwaltung/urlaubsverwaltung/assets/5683677/38a467fa-a6dc-469c-854b-bcfde483dfd2)

to reproduce add a "throw new RuntimeException();" to a controller method and call.