### PR TITLE
replace timepicker dependency with custom code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "rollup": "4.43.0",
         "rollup-plugin-esbuild": "6.2.1",
         "rollup-plugin-postcss": "4.0.2",
-        "timepicker": "1.14.1",
         "underscore": "1.13.7"
       },
       "devDependencies": {
@@ -15626,13 +15625,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/timepicker": {
-      "version": "1.14.1",
-      "license": "MIT",
-      "dependencies": {
-        "jquery": "^3.5.1"
-      }
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
@@ -26143,12 +26135,6 @@
       "dev": true,
       "requires": {
         "thenify": ">= 3.1.0 < 4"
-      }
-    },
-    "timepicker": {
-      "version": "1.14.1",
-      "requires": {
-        "jquery": "^3.5.1"
       }
     },
     "tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "rollup": "4.43.0",
     "rollup-plugin-esbuild": "6.2.1",
     "rollup-plugin-postcss": "4.0.2",
-    "timepicker": "1.14.1",
     "underscore": "1.13.7"
   },
   "devDependencies": {

--- a/src/main/css/bundles/style.css
+++ b/src/main/css/bundles/style.css
@@ -31,6 +31,7 @@
 @import "../components/print.css";
 @import "../components/section-heading.css";
 @import "../components/text-bubble.css";
+@import "../components/timepicker.css";
 @import "../components/tooltip.css";
 @import "../components/ui.timepicker.css";
 

--- a/src/main/css/components/timepicker.css
+++ b/src/main/css/components/timepicker.css
@@ -1,0 +1,17 @@
+.timepicker-list-box .list-box-option {
+  padding: 0.125rem 1rem;
+}
+
+.timepicker-list-box .list-box-option:hover,
+.timepicker-list-box .list-box-option[data-focused] {
+  @apply dark:tw-bg-zinc-700;
+}
+
+.timepicker-list-box .list-box-option[aria-selected="true"] {
+  @apply dark:tw-bg-blue-700;
+}
+
+.timepicker-list-box .list-box-option[aria-selected="true"]:hover,
+.timepicker-list-box .list-box-option[aria-selected="true"][data-focused] {
+  @apply dark:tw-bg-blue-800;
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveFormViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveFormViewController.java
@@ -41,8 +41,11 @@ import java.math.BigDecimal;
 import java.sql.Time;
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.Year;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -459,6 +462,19 @@ class ApplicationForLeaveFormViewController implements HasLaunchpad {
 
         final List<VacationTypeDto> vacationTypeColors = vacationTypeViewModelService.getVacationTypeColors();
         model.addAttribute("vacationTypeColors", vacationTypeColors);
+        model.addAttribute("timeValues", timeValues());
+    }
+
+    private List<String> timeValues() {
+        LocalDateTime time = LocalDateTime.now().withHour(0).withMinute(0);
+        final int dayOfYear = time.getDayOfYear();
+        final List<String> values = new ArrayList<>();
+        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+        while (dayOfYear == time.getDayOfYear()) {
+            values.add(formatter.format(time));
+            time = time.plusMinutes(15);
+        }
+        return values;
     }
 
     private VacationType<?> findVacationType(Collection<VacationType<?>> vacationTypes, Long id) {

--- a/src/main/javascript/components/timepicker/index.js
+++ b/src/main/javascript/components/timepicker/index.js
@@ -1,2 +1,1 @@
-import "timepicker";
-import "timepicker/jquery.timepicker.css";
+export * from "./timepicker";

--- a/src/main/javascript/components/timepicker/list-box-option.js
+++ b/src/main/javascript/components/timepicker/list-box-option.js
@@ -1,0 +1,50 @@
+export class ListBoxOption extends HTMLLIElement {
+  constructor() {
+    super();
+    this.setAttribute("id", `list-box-option-${randomKey()}`);
+    this.setAttribute("role", "option");
+    this.classList.add("list-box-option");
+    this.style.cursor = "pointer";
+  }
+  set selected(selected) {
+    this.setAttribute("aria-selected", selected ? "true" : "false");
+  }
+
+  get selected() {
+    return this.dataset.selected === "true";
+  }
+
+  set focused(focused) {
+    if (focused) {
+      this.dataset.focused = "true";
+    } else {
+      this.classList.remove("active");
+      delete this.dataset.focused;
+    }
+  }
+
+  set label(label) {
+    this.setAttribute("aria-label", label);
+  }
+
+  get label() {
+    return this.getAttribute("aria-label");
+  }
+
+  set value(value) {
+    this.dataset.value = value;
+  }
+
+  get value() {
+    return this.dataset.value;
+  }
+}
+
+function randomKey() {
+  return Math.random()
+    .toString(36)
+    .replaceAll(/[^a-z]+/g, "")
+    .slice(0, 12);
+}
+
+customElements.define("uv-list-box-option", ListBoxOption, { extends: "li" });

--- a/src/main/javascript/components/timepicker/list-box.js
+++ b/src/main/javascript/components/timepicker/list-box.js
@@ -1,0 +1,236 @@
+export class ListBox extends HTMLDivElement {
+  #cleanup = () => {};
+
+  #open = false;
+  #focusedOptionIndex = -1;
+  #value;
+  #ul;
+
+  constructor(options) {
+    super();
+
+    this.classList.add(
+      "list-box",
+      "dark:tw-border",
+      "dark:tw-border-zinc-700",
+      "dark:tw-bg-zinc-900",
+      "dark:tw-rounded",
+      "dark:tw-mt-2",
+      "dark:tw-backdrop-filter",
+      "dark:tw-backdrop-blur-xl",
+      "supports-backdrop-blur:dark:tw-bg-zinc-900/70",
+    );
+    this.style.overflow = "auto";
+    this.style.height = "10rem";
+
+    const ul = (this.#ul = document.createElement("ul"));
+    ul.style.listStyleType = "none";
+    ul.style.margin = "0";
+    ul.style.padding = "0";
+    ul.style.fontVariantNumeric = "tabular-nums";
+    ul.setAttribute("role", "listbox");
+    ul.append(...options);
+    this.append(ul);
+  }
+
+  get selectedOptionId() {
+    return this.#ul.getAttribute("aria-activedescendant");
+  }
+
+  set selectedOptionId(selectedId) {
+    if (selectedId) {
+      this.#ul.setAttribute("aria-activedescendant", selectedId);
+    } else {
+      this.#ul.removeAttribute("aria-activedescendant");
+    }
+  }
+
+  get value() {
+    return this.#value;
+  }
+
+  set opened(open) {
+    if (this.#open !== open) {
+      this.#open = open;
+      if (open) {
+        this.#renderFocusedElement(this.#ul.querySelectorAll("li"));
+        document.body.append(this);
+      } else {
+        this.remove();
+      }
+    }
+  }
+
+  get opened() {
+    return this.#open;
+  }
+
+  open({ relativeTo }) {
+    if (relativeTo) {
+      const { left, top, height } = relativeTo.getBoundingClientRect();
+      this.style.position = "absolute";
+      this.style.left = `${left}px`;
+      this.style.top = `calc(${top + height}px + .125rem)`;
+    }
+    this.opened = true;
+  }
+
+  close() {
+    this.opened = false;
+  }
+
+  focusValue(value) {
+    const options = this.#ul.querySelectorAll("li");
+    for (let [index, option] of options.entries()) {
+      if (option.value.startsWith(value)) {
+        this.#focusedOptionIndex = index;
+        this.#renderFocusedElement(options);
+        break;
+      }
+    }
+  }
+
+  focusNextOption() {
+    const options = this.#ul.querySelectorAll("li");
+    if (this.#focusedOptionIndex < options.length - 1) {
+      this.#focusedOptionIndex++;
+      this.#renderFocusedElement(options);
+    }
+  }
+
+  focusPreviousOption() {
+    if (this.#focusedOptionIndex > 0) {
+      const options = this.#ul.querySelectorAll("li");
+      this.#focusedOptionIndex--;
+      this.#renderFocusedElement(options);
+    }
+  }
+
+  connectedCallback() {
+    if (this.#focusedOptionIndex > -1) {
+      this.selectedOptionId = this.#ul.querySelector(`li:nth-child(${this.#focusedOptionIndex})`)?.getAttribute("id");
+    }
+
+    const handleGlobalKeyDown = (event) => {
+      if (!this.opened) {
+        return;
+      }
+
+      const options = this.#ul.querySelectorAll("li");
+
+      if (event.key === "Enter") {
+        event.preventDefault(); // prevent form submit
+
+        let selectedOption;
+
+        for (const [index, option] of options.entries()) {
+          const selected = index === this.#focusedOptionIndex;
+          if (selected) {
+            option.selected = true;
+            this.#value = option.value;
+            selectedOption = option;
+          } else {
+            option.selected = false;
+          }
+        }
+
+        this.dispatchEvent(
+          new CustomEvent("list-box:value-changed", {
+            detail: {
+              value: this.#value,
+              option: selectedOption,
+            },
+            bubbles: true,
+          }),
+        );
+
+        this.close();
+      }
+
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault(); // prevent scrolling TODO required?
+        if (event.key === "ArrowDown") {
+          this.focusNextOption();
+        } else if (event.key === "ArrowUp") {
+          this.focusPreviousOption();
+        }
+      }
+    };
+
+    const handleClick = (event) => {
+      const target = event.target;
+      const clickedOption = target.tag === "LI" ? target : target.closest("li");
+
+      if (clickedOption) {
+        // TODO is this event.preventDefault a special case for color-picker?
+        // prevent scrolling up to the absolute positioned checkbox.
+        event.preventDefault();
+
+        const options = this.#ul.querySelectorAll("li");
+        for (const [index, option] of options.entries()) {
+          if (option === clickedOption) {
+            option.selected = true;
+            this.#value = option.value;
+            this.#focusedOptionIndex = index;
+          } else {
+            option.selected = false;
+          }
+        }
+
+        this.dispatchEvent(
+          new CustomEvent("list-box:value-changed", {
+            detail: {
+              value: clickedOption.value,
+              option: clickedOption,
+            },
+            bubbles: true,
+          }),
+        );
+      }
+    };
+
+    // defer event registration to avoid events that could have opened this list-box recently
+    // (e.g. a text input with ArrowDown/ArrowUp, see timepicker)
+    setTimeout(() => {
+      document.addEventListener("keydown", handleGlobalKeyDown);
+      this.addEventListener("click", handleClick);
+    });
+
+    this.#cleanup = () => {
+      document.removeEventListener("keydown", handleGlobalKeyDown);
+      this.removeEventListener("click", handleClick);
+    };
+  }
+
+  #renderFocusedElement(options) {
+    let focusedOption;
+
+    for (const [index, option] of options.entries()) {
+      if (index === this.#focusedOptionIndex) {
+        option.focused = true;
+        this.selectedOptionId = option.getAttribute("id");
+        focusedOption = option;
+      } else {
+        option.focused = false;
+      }
+    }
+
+    if (focusedOption) {
+      const { height: optionHeight, top: optionTop } = focusedOption.getBoundingClientRect();
+      const { height: containerHeight } = this.getBoundingClientRect();
+      if (optionTop > containerHeight) {
+        this.scrollTop = focusedOption.offsetTop - optionHeight;
+      }
+    }
+  }
+
+  disconnectedCallback() {
+    this.#cleanup();
+    // reset index to focus selected option or nothing when list-box is opened again
+    this.#focusedOptionIndex = [...this.#ul.querySelectorAll("li")].indexOf(
+      this.#ul.querySelector("li[aria-selected='true']"),
+    );
+  }
+}
+
+customElements.define("uv-list-box", ListBox, { extends: "div" });

--- a/src/main/javascript/components/timepicker/timepicker.js
+++ b/src/main/javascript/components/timepicker/timepicker.js
@@ -1,0 +1,148 @@
+import { ListBox } from "./list-box";
+import { ListBoxOption } from "./list-box-option";
+
+// to format a Date to "HH:mm"
+// AM/PM is not supported currently
+const dtf = new Intl.DateTimeFormat("de-DE", { hour: "numeric", minute: "numeric" });
+
+export class Timepicker extends HTMLInputElement {
+  #cleanup = () => {};
+
+  #listBox;
+
+  constructor() {
+    super();
+    this.classList.add("timepicker");
+    this.#listBox = this.#createListBox();
+    this.#listBox.classList.add("timepicker-list-box");
+  }
+
+  connectedCallback() {
+    const handleGlobalFocusIn = (event) => {
+      if (event.target === this) {
+        this.#listBox.open({ relativeTo: this });
+      } else {
+        this.#listBox.close();
+      }
+    };
+
+    // TODO move into list-box?
+    const handleGlobalClick = (event) => {
+      if (event.target === this) {
+        // could be opened by "focus" already
+        // however, we support clicking the focused input element to open the list-box
+        if (!this.#listBox.opened) {
+          this.#listBox.open({ relativeTo: this });
+          event.stopImmediatePropagation(); // click listener called twice otherwise
+        }
+      } else if (!this.#listBox.contains(event.target) && this.#listBox.opened) {
+        this.#listBox.close();
+      }
+    };
+
+    const handleInputKeyDown = (event) => {
+      if (this.#listBox.opened) {
+        switch (event.key) {
+          case "Enter": {
+            event.preventDefault();
+            break;
+          }
+          case "Escape": {
+            this.#listBox.close();
+            break;
+          }
+          // No default
+        }
+      } else {
+        switch (event.key) {
+          case "ArrowUp":
+          case "ArrowDown": {
+            event.preventDefault();
+            this.#listBox.open({ relativeTo: this });
+            break;
+          }
+          // No default
+        }
+      }
+    };
+
+    const focusPrediction = debounce(() => {
+      if (this.value.length === 1 && this.value !== "0") {
+        this.#listBox.focusValue("0" + this.value);
+      } else if (this.value.length === 4) {
+        this.#listBox.focusValue(`${this.value.slice(0, 2)}:${this.value.slice(2, 4)}`);
+      } else {
+        this.#listBox.focusValue(this.value);
+      }
+    }, 100);
+
+    const handleInput = () => {
+      focusPrediction();
+    };
+
+    const handleListBoxValueChanged = (event) => {
+      this.value = event.detail.value;
+
+      this.focus();
+      this.setSelectionRange(this.value.length, this.value.length);
+
+      // hide after focus. since input:focus actually shows the list-box
+      this.#listBox.close();
+    };
+
+    document.body.addEventListener("focusin", handleGlobalFocusIn);
+    document.body.addEventListener("click", handleGlobalClick);
+    this.addEventListener("keydown", handleInputKeyDown);
+    this.addEventListener("input", handleInput);
+    this.#listBox.addEventListener("list-box:value-changed", handleListBoxValueChanged);
+
+    this.#cleanup = () => {
+      document.body.removeEventListener("focusin", handleGlobalFocusIn);
+      document.body.removeEventListener("click", handleGlobalClick);
+      this.removeEventListener("keydown", handleInputKeyDown);
+      this.removeEventListener("input", handleInput);
+      this.#listBox.removeEventListener("list-box:value-changed", handleListBoxValueChanged);
+    };
+  }
+
+  disconnectedCallback() {
+    this.#cleanup();
+  }
+  #createListBox() {
+    const d = new Date();
+    d.setHours(0);
+    d.setMinutes(0);
+    d.setSeconds(0);
+    d.setMilliseconds(0);
+
+    const options = [];
+    const origin = d.getTime();
+    let n = origin;
+
+    while (n < origin + 8.64e7) {
+      const option = new ListBoxOption();
+      option.style.padding = "";
+      option.textContent = dtf.format(d);
+      option.value = dtf.format(d);
+
+      options.push(option);
+
+      n += 900_000;
+      d.setTime(n);
+    }
+
+    return new ListBox(options);
+  }
+}
+
+function debounce(function_, delay = 0) {
+  let h;
+  return (...arguments_) => {
+    clearTimeout(h);
+    h = setTimeout(() => {
+      function_.apply(undefined, arguments_);
+    }, delay);
+  };
+}
+
+customElements.define("uv-timepicker", Timepicker, { extends: "input" });

--- a/src/main/javascript/js/application/app-form.js
+++ b/src/main/javascript/js/application/app-form.js
@@ -1,7 +1,6 @@
 import $ from "jquery";
 import { parseISO } from "date-fns";
 import { createDatepicker } from "../../components/datepicker";
-import "../../components/timepicker";
 import sendGetDaysRequest from "../send-get-days-request";
 import sendGetDepartmentVacationsRequest from "../send-get-department-vacations-request";
 
@@ -64,20 +63,6 @@ document.addEventListener("DOMContentLoaded", async function () {
     sendGetDaysRequest(apiPrefix, startDate, endDate, dayLength, personId, ".days");
     sendGetDepartmentVacationsRequest(apiPrefix, startDate, endDate, personId, "#departmentVacations");
   }
-
-  // Timepicker for optional startTime and endTime
-  $("#startTime").timepicker({
-    step: 15,
-    timeFormat: "H:i",
-    forceRoundTime: true,
-    scrollDefault: "now",
-  });
-  $("#endTime").timepicker({
-    step: 15,
-    timeFormat: "H:i",
-    forceRoundTime: true,
-    scrollDefault: "now",
-  });
 
   let applicationSubmitPressed = false;
   document.querySelector("#apply-application").addEventListener("click", (event) => {

--- a/src/main/resources/templates/application/application_form.html
+++ b/src/main/resources/templates/application/application_form.html
@@ -158,6 +158,8 @@
                   </div>
                   <div class="col-xs-4 col-md-4">
                     <input
+                      is="uv-timepicker"
+                      type="text"
                       id="startTime"
                       name="startTime"
                       class="form-control"
@@ -198,6 +200,8 @@
                   </div>
                   <div class="col-xs-4 col-md-4">
                     <input
+                      is="uv-timepicker"
+                      type="text"
                       id="endTime"
                       name="endTime"
                       class="form-control"


### PR DESCRIPTION
known issues / TODOs: (given we want to keep this behaviour)

* [ ] open timepicker with current time when no value has been entered yet
* [ ] position timepicker on top of input when it would overflow screen
* [ ] position timepicker after window resize, or hide it
* [ ] fix timepicker positioning after scrolling down
* [ ] fix safari
* [ ] check mobile
  * [ ] iOS
  * [ ] Android

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
