### PR TITLE
Add public holidays for croatia

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/AbsenceApiController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/AbsenceApiController.java
@@ -159,7 +159,7 @@ public class AbsenceApiController {
         return workingTimeService.getFederalStatesByPersonAndDateRange(person, new DateRange(start, end)).entrySet().stream()
             .map(entry -> publicHolidaysService.getPublicHolidays(entry.getKey().getStartDate(), entry.getKey().getEndDate(), entry.getValue()))
             .flatMap(List::stream)
-            .collect(toMap(PublicHoliday::getDate, Function.identity()));
+            .collect(toMap(PublicHoliday::getDate, Function.identity(), (publicHoliday, publicHoliday2) -> new PublicHoliday(publicHoliday.getDate(), publicHoliday.getDayLength(), publicHoliday.getDescription().concat("/").concat(publicHoliday2.getDescription()))));
     }
 
     private Stream<DayAbsenceDto> toDayAbsenceDto(AbsencePeriod absence, Map<LocalDate, PublicHoliday> holidaysByDate) {

--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewController.java
@@ -272,7 +272,8 @@ public class AbsenceOverviewViewController implements HasLaunchpad {
             .entrySet().stream()
             .map(entry -> publicHolidaysService.getPublicHolidays(entry.getKey().getStartDate(), entry.getKey().getEndDate(), entry.getValue()))
             .flatMap(List::stream)
-            .collect(toMap(PublicHoliday::getDate, Function.identity()));
+            .collect(toMap(PublicHoliday::getDate, Function.identity(), (publicHoliday, publicHoliday2) -> new PublicHoliday(publicHoliday.getDate(),publicHoliday.getDayLength(), publicHoliday.getDescription().concat("/").concat(publicHoliday2.getDescription()))));
+
     }
 
     private AbsenceOverviewMonthDto initializeAbsenceOverviewMonthDto(LocalDate date, List<Person> personList, Locale locale) {

--- a/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayConfiguration.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayConfiguration.java
@@ -13,7 +13,7 @@ import java.util.Map;
 @Configuration
 class PublicHolidayConfiguration {
 
-    private static final List<String> COUNTRIES = List.of("de", "at", "ch", "gb", "gr", "mt", "it");
+    private static final List<String> COUNTRIES = List.of("de", "at", "ch", "gb", "gr", "mt", "it", "hr");
 
     @Bean
     Map<String, HolidayManager> holidayManagerMap() {

--- a/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysService.java
@@ -32,6 +32,9 @@ public interface PublicHolidaysService {
      * Returns a list of public holiday information for the given date range (inclusive from and to) and the federal state.
      * If there is no public holiday at the given date range the return value is an empty list, otherwise
      * the public holidays will be returned.
+     * <p>
+     * Hint: it is possible that there are two public holidays at the same day e.g. if there is a fixed public holiday
+     * and a movable that will be at the same day in a special year.
      *
      * @param from         to get public holiday from
      * @param to           to get public holiday to
@@ -63,6 +66,9 @@ public interface PublicHolidaysService {
      * <p>
      * Hint: we added this method so that the working time settings will not be requested from the database for each call of a day e.g.
      * We will remove this method when the "betriebsferien" will be ready so that we do not need to call for Christmas and new years eve.
+     * <p>
+     * Hint: it is possible that there are two public holidays at the same day e.g. if there is a fixed public holiday
+     * and a movable that will be at the same day in a special year.
      *
      * @param from                to get public holiday from
      * @param to                  to get public holiday to

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/FederalState.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/FederalState.java
@@ -87,7 +87,9 @@ public enum FederalState {
 
     MALTA("mt", "mt"),
 
-    ITALY("it","it");
+    ITALY("it","it"),
+
+    CROATIA("hr","hr");
 
     private final String[] codes;
 

--- a/src/main/resources/Holidays_hr.xml
+++ b/src/main/resources/Holidays_hr.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration hierarchy="hr" description="Croatia"
+               xmlns="https://focus_shift.de/jollyday/schema/holiday"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="https://focus_shift.de/jollyday/schema/holiday https://focus_shift.de/jollyday/schema/holiday/holiday.xsd">
+  <Holidays>
+    <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
+    <Fixed month="JANUARY" day="6" descriptionPropertiesKey="EPIPHANY"/>
+    <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
+    <Fixed month="MAY" day="30" descriptionPropertiesKey="NATIONAL_DAY" validFrom="2020"/>
+    <Fixed month="JUNE" day="22" descriptionPropertiesKey="ANTI_FASCIST"/>
+    <Fixed month="JUNE" day="25" descriptionPropertiesKey="STATEHOOD" validFrom="2002" validTo="2019"/>
+    <Fixed month="AUGUST" day="5" descriptionPropertiesKey="VICTORY"/>
+    <Fixed month="AUGUST" day="15" descriptionPropertiesKey="ASSUMPTION_MARY"/>
+    <Fixed month="OCTOBER" day="8" descriptionPropertiesKey="INDEPENDENCE_DAY" validFrom="2002" validTo="2019"/>
+    <Fixed month="NOVEMBER" day="1" descriptionPropertiesKey="ALL_SAINTS"/>
+    <Fixed month="NOVEMBER" day="18" descriptionPropertiesKey="REMEMBRANCE" validFrom="2020"/>
+    <Fixed month="DECEMBER" day="24" descriptionPropertiesKey="CHRISTMAS_EVE" localizedType="UNOFFICIAL_HOLIDAY"/>
+    <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS"/>
+    <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="STEPHENS"/>
+    <Fixed month="DECEMBER" day="31" descriptionPropertiesKey="NEW_YEARS_EVE" localizedType="UNOFFICIAL_HOLIDAY"/>
+    <ChristianHoliday type="EASTER" descriptionPropertiesKey="christian.EASTER"/>
+    <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY"/>
+    <ChristianHoliday type="CORPUS_CHRISTI" descriptionPropertiesKey="christian.CORPUS_CHRISTI"/>
+  </Holidays>
+</Configuration>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1083,6 +1083,7 @@ country.gb=Vereinigtes Königreich
 country.gr=Griechenland
 country.mt=Malta
 country.it=Italien
+country.hr=Kroatien
 
 # No Federal States
 federalState.NONE=Keine Feiertagesregelung
@@ -1167,6 +1168,9 @@ federalState.MALTA=Malta
 
 # Federal States Italy
 federalState.ITALY=Italien
+
+# Federal States Croatia
+federalState.CROATIA=Kroatien
 
 # DEPARTMENTS
 departments.header.title=Abteilungsübersicht

--- a/src/main/resources/messages_de_AT.properties
+++ b/src/main/resources/messages_de_AT.properties
@@ -1033,6 +1033,7 @@ country.gb=Vereinigtes Königreich
 country.gr=Griechenland
 country.mt=Malta
 country.it=Italien
+country.hr=Kroatien
 
 # No Federal States
 federalState.NONE=Keine Feiertagesregelung
@@ -1117,6 +1118,9 @@ federalState.MALTA=Malta
 
 # Federal States Italy
 federalState.ITALY=Italien
+
+# Federal States Croatia
+federalState.CROATIA=Kroatien
 
 # DEPARTMENTS
 departments.header.title=Abteilungsübersicht

--- a/src/main/resources/messages_el.properties
+++ b/src/main/resources/messages_el.properties
@@ -986,6 +986,7 @@ country.gb=Ηνωμένο Βασίλειο
 country.gr=Ελλάδα
 country.mt=Μάλτα
 country.it=Ιταλία
+country.hr=Κροατία
 
 # No Federal States
 federalState.NONE=Κανένας κανονισμός επίσημων αργιών
@@ -1070,6 +1071,9 @@ federalState.MALTA=Μάλτα
 
 # Federal States Italy
 federalState.ITALY=Ιταλία
+
+# Federal States Croatia
+federalState.CROATIA=Κροατία
 
 # DEPARTMENTS
 departments.header.title=Επισκόπηση τμημάτων

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -1061,6 +1061,7 @@ country.gb=United Kingdom
 country.gr=Greece
 country.mt=Malta
 country.it=Italy
+country.hr=Croatia
 
 # No Federal States
 federalState.NONE=No public holiday regulation
@@ -1145,6 +1146,9 @@ federalState.MALTA=Malta
 
 # Federal States Italy
 federalState.ITALY=Italy
+
+# Federal States Croatia
+federalState.CROATIA=Croatia
 
 # DEPARTMENTS
 departments.header.title=Departments overview

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/FederalStateTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/FederalStateTest.java
@@ -275,14 +275,16 @@ class FederalStateTest {
         final List<FederalState> grFederalStates = Arrays.stream(FederalState.values()).filter(federalState -> "gr".equals(federalState.getCountry())).collect(toList());
         final List<FederalState> mtFederalStates = Arrays.stream(FederalState.values()).filter(federalState -> "mt".equals(federalState.getCountry())).collect(toList());
         final List<FederalState> itFederalStates = Arrays.stream(FederalState.values()).filter(federalState -> "it".equals(federalState.getCountry())).collect(toList());
+        final List<FederalState> hrFederalStates = Arrays.stream(FederalState.values()).filter(federalState -> "hr".equals(federalState.getCountry())).collect(toList());
 
-        assertThat(federalStatesTypesByCountry).hasSize(7)
+        assertThat(federalStatesTypesByCountry).hasSize(8)
             .contains(entry("de", germanyFederalStates))
             .contains(entry("at", austriaFederalStates))
             .contains(entry("ch", switzerlandFederalStates))
             .contains(entry("gb", ukFederalStates))
             .contains(entry("gr", grFederalStates))
             .contains(entry("mt", mtFederalStates))
-            .contains(entry("it", itFederalStates));
+            .contains(entry("it", itFederalStates))
+            .contains(entry("hr", hrFederalStates));
     }
 }


### PR DESCRIPTION
ToDo:
* in 2024 two public holidays are on the same day see https://publicholidays.com.hr/2024-dates/ 30.5.2024 so we need a better solution for https://github.com/urlaubsverwaltung/urlaubsverwaltung/blob/fd1f6e6c597edb7645179cac86dcf1f41e6b7e63/src/main/java/org/synyx/urlaubsverwaltung/absence/AbsenceApiController.java#L158
because this returns a map.

Quick fix: only return the first public holiday in a merging function, maybe with both descriptions?