### PR TITLE
Remove not needed security beans

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/OidcSecurityConfiguration.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/OidcSecurityConfiguration.java
@@ -3,15 +3,11 @@ package org.synyx.urlaubsverwaltung.security.oidc;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
 import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
-import org.springframework.security.oauth2.client.web.AuthenticatedPrincipalOAuth2AuthorizedClientRepository;
-import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.synyx.urlaubsverwaltung.person.PersonService;
 
@@ -25,16 +21,6 @@ class OidcSecurityConfiguration {
 
     OidcSecurityConfiguration(OidcSecurityProperties properties) {
         this.properties = properties;
-    }
-
-    @Bean
-    OAuth2AuthorizedClientService authorizedClientService(ClientRegistrationRepository clientRegistrationRepository) {
-        return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
-    }
-
-    @Bean
-    OAuth2AuthorizedClientRepository authorizedClientRepository(OAuth2AuthorizedClientService authorizedClientService) {
-        return new AuthenticatedPrincipalOAuth2AuthorizedClientRepository(authorizedClientService);
     }
 
     @Bean


### PR DESCRIPTION
will be done via `OAuth2WebSecurityConfiguration` and triggered by the `OAuth2ClientAutoConfiguration`