### PR TITLE
Unique department names

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewController.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
 import static java.util.function.Predicate.not;
@@ -94,7 +95,7 @@ public class DepartmentViewController implements HasLaunchpad {
 
         return createNewDepartment(departmentForm, errors, model,
             () -> "department/department_form",
-            (department) -> {
+            department -> {
                 redirectAttributes.addFlashAttribute("createdDepartmentName", department.getName());
                 return "redirect:/web/department";
             });
@@ -107,7 +108,7 @@ public class DepartmentViewController implements HasLaunchpad {
 
         return createNewDepartment(departmentForm, errors, model,
             () -> new ModelAndView("department/department_form", model.asMap(), UNPROCESSABLE_ENTITY),
-            (department) -> {
+            department -> {
                 redirectAttributes.addFlashAttribute("createdDepartmentName", department.getName());
                 return new ModelAndView("redirect:/web/department");
             });
@@ -139,7 +140,7 @@ public class DepartmentViewController implements HasLaunchpad {
 
         return editDepartment(departmentForm, errors, model,
             () -> "department/department_form",
-            (department) -> {
+            department -> {
                 redirectAttributes.addFlashAttribute("updatedDepartmentName", department.getName());
                 return "redirect:/web/department";
             });
@@ -148,12 +149,12 @@ public class DepartmentViewController implements HasLaunchpad {
     @PreAuthorize(IS_OFFICE)
     @PostMapping(value = "/department/{departmentId}", produces = TURBO_STREAM_MEDIA_TYPE)
     public ModelAndView updateDepartmentAjax(@PathVariable("departmentId") Long departmentId,
-                                   @ModelAttribute("department") DepartmentForm departmentForm, Errors errors,
-                                   Model model, RedirectAttributes redirectAttributes) {
+                                             @ModelAttribute("department") DepartmentForm departmentForm, Errors errors,
+                                             Model model, RedirectAttributes redirectAttributes) {
 
         return editDepartment(departmentForm, errors, model,
             () -> new ModelAndView("department/department_form", model.asMap(), UNPROCESSABLE_ENTITY),
-            (department) -> {
+            department -> {
                 redirectAttributes.addFlashAttribute("createdDepartmentName", department.getName());
                 return new ModelAndView("redirect:/web/department");
             });
@@ -224,8 +225,8 @@ public class DepartmentViewController implements HasLaunchpad {
     }
 
     private <T> T createOrEditDepartment(DepartmentForm departmentForm, Errors errors, Model model,
-                                        Function<Department, Department> departmentFunction,
-                                        Supplier<T> errorReturn, Function<Department, T> successReturn) {
+                                         UnaryOperator<Department> departmentFunction,
+                                         Supplier<T> errorReturn, Function<Department, T> successReturn) {
 
         validator.validate(departmentForm, errors);
         if (errors.hasErrors()) {

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewController.java
@@ -147,15 +147,15 @@ public class DepartmentViewController implements HasLaunchpad {
 
     @PreAuthorize(IS_OFFICE)
     @PostMapping(value = "/department/{departmentId}", produces = TURBO_STREAM_MEDIA_TYPE)
-    public String updateDepartmentAjax(@PathVariable("departmentId") Long departmentId,
+    public ModelAndView updateDepartmentAjax(@PathVariable("departmentId") Long departmentId,
                                    @ModelAttribute("department") DepartmentForm departmentForm, Errors errors,
                                    Model model, RedirectAttributes redirectAttributes) {
 
         return editDepartment(departmentForm, errors, model,
-            () -> "department/department_form",
+            () -> new ModelAndView("department/department_form", model.asMap(), UNPROCESSABLE_ENTITY),
             (department) -> {
                 redirectAttributes.addFlashAttribute("createdDepartmentName", department.getName());
-                return "redirect:/web/department";
+                return new ModelAndView("redirect:/web/department");
             });
     }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewController.java
@@ -83,7 +83,7 @@ public class DepartmentViewController implements HasLaunchpad {
     }
 
     @PreAuthorize(IS_OFFICE)
-    @PostMapping("/department")
+    @PostMapping("/department/new")
     public String newDepartment(@ModelAttribute("department") DepartmentForm departmentForm, Errors errors,
                                 Model model, RedirectAttributes redirectAttributes) {
 
@@ -142,7 +142,7 @@ public class DepartmentViewController implements HasLaunchpad {
     }
 
     @PreAuthorize(IS_OFFICE)
-    @PostMapping(value = {"/department", "/department/{departmentId}/edit"}, params = "do-member-search")
+    @PostMapping(value = {"/department/new", "/department/{departmentId}/edit"}, params = "do-member-search")
     public String updateDepartment(@PathVariable(value = "departmentId", required = false) Long departmentId,
                                    @RequestParam("memberQuery") String memberQuery,
                                    @ModelAttribute("department") DepartmentForm departmentForm,

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewValidator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewValidator.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
+import org.synyx.urlaubsverwaltung.department.DepartmentService;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.Role;
 
@@ -28,15 +29,23 @@ public class DepartmentViewValidator implements Validator {
     private static final String ATTRIBUTE_SECOND_STAGE_AUTHORITIES = "secondStageAuthorities";
     private static final String ATTRIBUTE_TWO_STAGE_APPROVAL = "twoStageApproval";
 
-    private static final String ERROR_REASON = "error.entry.mandatory";
+    private static final String ERROR_MANDATORY = "error.entry.mandatory";
     private static final String ERROR_LENGTH = "error.entry.tooManyChars";
     private static final String ERROR_DELIMITER = "error.entry.delimiterFound";
+
+    private static final String ERROR_DUPLICATED_NAME = "department.error.name.duplicate";
     private static final String ERROR_DEPARTMENT_HEAD_NOT_ASSIGNED = "department.members.error.departmentHeadNotAssigned";
     private static final String ERROR_DEPARTMENT_HEAD_NO_ACCESS = "department.members.error.departmentHeadHasNoAccess";
 
     private static final String ERROR_SECOND_STAGE_AUTHORITY_MISSING = "department.members.error.secondStageAuthorityMissing";
     private static final String ERROR_TWO_STAGE_APPROVAL_FLAG_MISSING = "department.members.error.twoStageApprovalFlagMissing";
     private static final String ERROR_SECOND_STAGE_AUTHORITY_NO_ACCESS = "department.members.error.secondStageHasNoAccess";
+
+    private final DepartmentService departmentService;
+
+    DepartmentViewValidator(DepartmentService departmentService) {
+        this.departmentService = departmentService;
+    }
 
     @Override
     public boolean supports(@NonNull Class<?> clazz) {
@@ -58,7 +67,11 @@ public class DepartmentViewValidator implements Validator {
         final boolean hasText = StringUtils.hasText(name);
 
         if (!hasText) {
-            errors.rejectValue(ATTRIBUTE_NAME, ERROR_REASON);
+            errors.rejectValue(ATTRIBUTE_NAME, ERROR_MANDATORY);
+        }
+
+        if (hasText && departmentService.getDepartmentByName(name).isPresent()) {
+            errors.rejectValue(ATTRIBUTE_NAME, ERROR_DUPLICATED_NAME);
         }
 
         if (hasText && name.length() > MAX_CHARS_NAME) {

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/HotwiredTurboConstants.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/HotwiredTurboConstants.java
@@ -1,0 +1,10 @@
+package org.synyx.urlaubsverwaltung.web;
+
+public final class HotwiredTurboConstants {
+
+    public static final String TURBO_STREAM_MEDIA_TYPE = "text/vnd.turbo-stream.html";
+
+    private HotwiredTurboConstants() {
+        //
+    }
+}

--- a/src/main/resources/dbchangelogs/changelog-5.0.0-unique-department-names.xml
+++ b/src/main/resources/dbchangelogs/changelog-5.0.0-unique-department-names.xml
@@ -1,0 +1,40 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+  <changeSet author="schneider" id="unique-department-names">
+
+    <preConditions>
+      <tableExists tableName="department"/>
+      <columnExists tableName="department" columnName="id"/>
+      <columnExists tableName="department" columnName="name"/>
+    </preConditions>
+
+    <sql>
+      WITH DuplicateRows AS (
+        SELECT
+          id,
+          name,
+          ROW_NUMBER() OVER (PARTITION BY name ORDER BY name) AS rn,
+          COUNT(*) OVER (PARTITION BY name) AS cnt
+        FROM
+          department
+      )
+      UPDATE
+        department
+      SET
+        name = CONCAT(department.name, ' ', (DuplicateRows.cnt - DuplicateRows.rn) + 1)
+        FROM
+    DuplicateRows
+      WHERE
+        department.id = DuplicateRows.id
+        AND DuplicateRows.cnt > 1;
+    </sql>
+
+    <addUniqueConstraint columnNames="name"
+                         constraintName="unique_department_name"
+                         tableName="department"/>
+
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/dbchangelogs/changelogmaster.xml
+++ b/src/main/resources/dbchangelogs/changelogmaster.xml
@@ -5,4 +5,5 @@
 
   <include relativeToChangelogFile="true" file="changelog-5.0.0-M1-initial.xml"/>
   <include relativeToChangelogFile="true" file="changelog-5.0.0-M4-add-custom-vacation-type.xml"/>
+  <include relativeToChangelogFile="true" file="changelog-5.0.0-unique-department-names.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1187,6 +1187,9 @@ federalState.CROATIA=Kroatien
 departments.header.title=Abteilungsübersicht
 departments.title=Abteilungen
 departments.none=Es sind keine Abteilungen vorhanden.
+
+department.error.name.duplicate=Es gibt bereits eine Abteilung mit diesem Namen.
+
 # Data
 department.data.header.title.new=Neue Abteilung erstellen
 department.data.header.title.edit=Abteilung anpassen
@@ -1199,8 +1202,8 @@ department.data.twoStageApproval.activate=Zweistufigen Genehmigungsprozess aktiv
 department.data.twoStageApproval.help.members=Anträge der Mitglieder können vorläufig durch den Abteilungsleiter \
   und endgültig durch den Freigabe-Verantwortlichen genehmigt werden. Der Freigabe-Verantwortliche kann Anträge auch ohne vorläufige Genehmigung genehmigen.
 department.data.twoStageApproval.help.departmentHead=Anträge der Abteilungsleiter werden durch die Freigabe-Verantwortlichen genehmigt.
-
 department.data.lastModification=Letzte Änderung
+
 # Members
 department.members=Mitarbeiter
 department.members.active=Aktive

--- a/src/main/resources/messages_de_AT.properties
+++ b/src/main/resources/messages_de_AT.properties
@@ -836,33 +836,41 @@ person.form.workingTime.federalState.default=Systemweite Einstellung ({0})
 # Departments
 person.form.departments.title=Zugeordnete Abteilungen
 person.form.departments.none=Der Benutzer ist keiner Abteilung zugeordnet.
+
 # PERSON ACCOUNT
 person.account.header.title=Konto von {0}
+
 # base data
 person.account.basedata.title=Stammdaten
 person.account.basedata.email.notification=Keine E-Mail-Adresse hinterlegt.
 person.account.basedata.personnelNumber=Personalnummer
 person.account.basedata.personnelNumber.abbreviation=PNr.
 person.account.basedata.additionalInformation=Zusatzinformation
+
 # notifications
 person.account.notifications.nothing-active=Keine E-Mail Benachrichtigungen aktiviert.
+
 # departments
 person.account.departments.title=Abteilungen
 person.account.departments.none=Der Benutzer ist keiner Abteilung zugeordnet.
 person.account.departments.departmentHead=(Abteilungsleiter)
 person.account.departments.secondStageAuthority=(Freigabe-Verantwortlicher)
 person.account.departments.departmentHeadAndSecondStageAuthority=(Abteilungsleiter, Freigabe-Verantwortlicher)
+
 # vacation
 person.account.annualVacation.title=Urlaubsanspruch für
+
 # working time
 person.account.workingTime.title=Arbeitszeiten
 person.account.workingTime.none=Keine Angabe möglich.
 person.account.workingTime.validity=gültig ab
 person.account.workingTime.federalState=anhand von
 person.account.federalState.title=Feiertagsregelung
+
 # action
 person.account.action.create.success=Der Benutzer wurde erfolgreich erstellt.
 person.account.action.update.success=Der Benutzer wurde erfolgreich aktualisiert.
+
 # permissions
 person.account.permissions.title=Berechtigungen
 
@@ -1138,6 +1146,9 @@ federalState.CROATIA=Kroatien
 departments.header.title=Abteilungsübersicht
 departments.title=Abteilungen
 departments.none=Es sind keine Abteilungen vorhanden.
+
+department.error.name.duplicate=Es gibt bereits eine Abteilung mit diesem Namen.
+
 # Data
 department.data.header.title.new=Neue Abteilung erstellen
 department.data.header.title.edit=Abteilung anpassen
@@ -1149,8 +1160,8 @@ department.data.twoStageApproval=Zweistufiger Genehmigungsprozess
 department.data.twoStageApproval.activate=Zweistufigen Genehmigungsprozess aktivieren
 department.data.twoStageApproval.help.members=Anträge der Mitglieder können vorläufig durch den Abteilungsleiter und endgültig durch den Freigabe-Verantwortlichen genehmigt werden. Der Freigabe-Verantwortliche kann Anträge auch ohne vorläufige Genehmigung genehmigen.
 department.data.twoStageApproval.help.departmentHead=Anträge der Abteilungsleiter werden durch die Freigabe-Verantwortlichen genehmigt.
-
 department.data.lastModification=Letzte Änderung
+
 # Members
 department.members=Mitarbeiter
 department.members.active=Aktive

--- a/src/main/resources/messages_el.properties
+++ b/src/main/resources/messages_el.properties
@@ -1090,6 +1090,7 @@ federalState.CROATIA=Κροατία
 departments.header.title=Επισκόπηση τμημάτων
 departments.title=Τμήματα
 departments.none=Δεν υπάρχουν τμήματα
+
 # Data
 department.data.header.title.new=Δημιουργία νέου τμήματος
 department.data.header.title.edit=Επεξεργασία τμήματος
@@ -1101,8 +1102,10 @@ department.data.twoStageApproval=Διαδικασία έγκρισης σε δύ
 department.data.twoStageApproval.activate=Ενεργοποιήστε τη διαδικασία έγκρισης δύο σταδίων
 department.data.twoStageApproval.help.members=Οι άδειες των μελών μπορούν να εγκρίνονται προσωρινά από τον προϊστάμενο του τμήματος και τέλος εγκεκριμένο από το Δεύτερο επίπεδο εξουσιοδότησης. Το Δεύτερο επίπεδο εξουσιοδότησης μπορεί επίσης να εγκρίνει αιτήσεις χωρίς προσωρινή έγκριση.
 department.data.twoStageApproval.help.departmentHead=Οι άδειες των προϊσταμένων των τμημάτων εγκρίνονται από το Δεύτερο επίπεδο εξουσιοδότησης.
-
 department.data.lastModification=Τελευταία τροποποίηση
+
+department.error.name.duplicate=Υπάρχει ήδη ένα τμήμα με αυτό το όνομα.
+
 # Members
 department.members=Υπάλληλοι
 department.members.active=ενεργός

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -1165,6 +1165,9 @@ federalState.CROATIA=Croatia
 departments.header.title=Departments overview
 departments.title=Departments
 departments.none=There are no departments.
+
+department.error.name.duplicate=There is already a department with this name.
+
 # Data
 department.data.header.title.new=Create new department
 department.data.header.title.edit=Edit department

--- a/src/main/resources/templates/department/department_form.html
+++ b/src/main/resources/templates/department/department_form.html
@@ -22,6 +22,8 @@
           th:object="${department}"
           class="form-horizontal"
         >
+          <button type="submit" class="tw-hidden"></button>
+
           <input type="hidden" th:field="*{id}" />
 
           <div class="form-section">

--- a/src/main/resources/templates/department/department_form.html
+++ b/src/main/resources/templates/department/department_form.html
@@ -20,6 +20,7 @@
         th:action="@{__${action}__}"
         th:object="${department}"
         class="form-horizontal"
+        data-turbo="true"
       >
         <button type="submit" class="tw-hidden"></button>
 
@@ -169,6 +170,7 @@
                       th:formaction="${department.id == null ? '/web/department/new' : '/web/department/' + department.id + '/edit'}"
                       data-turbo-frame="frame-department-members"
                       data-turbo-action="replace"
+                      data-turbo="true"
                     >
                       <svg th:replace="~{icon/search::svg(className='tw-w-5 tw-h-5 tw-stroke-2')}"></svg>
                       <span class="tw-sr-only" th:text="#{action.search}">Suche</span>

--- a/src/main/resources/templates/department/department_form.html
+++ b/src/main/resources/templates/department/department_form.html
@@ -16,7 +16,7 @@
     <main th:fragment="main" class="tw-max-w-6xl tw-mx-auto tw-px-4 lg:tw-px-12 xl:tw-px-0">
       <form
         method="post"
-        th:with="action=${department.id == null ? '/web/department' : '/web/department/' + department.id}"
+        th:with="action=${department.id == null ? '/web/department/new' : '/web/department/' + department.id}"
         th:action="@{__${action}__}"
         th:object="${department}"
         class="form-horizontal"
@@ -166,7 +166,7 @@
                       id="member-search-submit"
                       class="dark:tw-bg-zinc-800 tw-px-2 tw-rounded-r-md tw-flex tw-items-center"
                       name="do-member-search"
-                      th:formaction="${department.id == null ? '/web/department' : '/web/department/' + department.id + '/edit'}"
+                      th:formaction="${department.id == null ? '/web/department/new' : '/web/department/' + department.id + '/edit'}"
                       data-turbo-frame="frame-department-members"
                       data-turbo-action="replace"
                     >

--- a/src/main/resources/templates/department/department_form.html
+++ b/src/main/resources/templates/department/department_form.html
@@ -13,286 +13,280 @@
     </th:block>
   </head>
   <body th:replace="~{_layout::body(~{::main}, ~{})}">
-    <main th:fragment="main">
-      <div class="tw-max-w-6xl tw-mx-auto tw-px-4 lg:tw-px-12 xl:tw-px-0">
-        <form
-          method="post"
-          th:with="action=${department.id == null ? '/web/department' : '/web/department/' + department.id}"
-          th:action="@{__${action}__}"
-          th:object="${department}"
-          class="form-horizontal"
-        >
-          <button type="submit" class="tw-hidden"></button>
+    <main th:fragment="main" class="tw-max-w-6xl tw-mx-auto tw-px-4 lg:tw-px-12 xl:tw-px-0">
+      <form
+        method="post"
+        th:with="action=${department.id == null ? '/web/department' : '/web/department/' + department.id}"
+        th:action="@{__${action}__}"
+        th:object="${department}"
+        class="form-horizontal"
+      >
+        <button type="submit" class="tw-hidden"></button>
 
-          <input type="hidden" th:field="*{id}" />
+        <input type="hidden" th:field="*{id}" />
 
-          <div class="form-section">
-            <div th:replace="~{fragments/section-heading::section-heading(~{::department-heading-body}, ~{})}">
-              <th:block th:ref="department-heading-body">
-                <h2 th:text="#{department.data}">Abteilungsdaten</h2>
-              </th:block>
-            </div>
-
-            <div class="row">
-              <div class="col-md-4 col-md-push-8">
-                <span class="help-block tw-text-sm">
-                  <svg th:replace="~{icon/info::svg(className='tw-w-4 tw-h-4')}"></svg>
-                  <span th:text="#{department.data.description}"></span>
-                </span>
-              </div>
-              <div class="col-md-8 col-md-pull-4">
-                <div class="form-group is-required">
-                  <label th:text="|#{department.data.name}:|" class="control-label col-md-3" for="name"></label>
-                  <div class="col-md-9">
-                    <input id="name" type="text" th:field="*{name}" class="form-control" th:errorclass="error" />
-                    <p
-                      class="tw-mt-1 tw-text-sm tw-text-red-800 dark:tw-text-red-400"
-                      th:if="${#fields.hasErrors('name')}"
-                    >
-                      <th:block th:errors="*{name}"> name Error</th:block>
-                    </p>
-                  </div>
-                </div>
-                <div class="form-group">
-                  <label th:text="|#{department.data.info}:|" class="control-label col-md-3" for="description"></label>
-                  <div class="col-md-9">
-                    <textarea
-                      id="description"
-                      rows="3"
-                      th:field="*{description}"
-                      class="form-control"
-                      th:errorclass="error"
-                      onkeyup="count(this.value, 'text-description');"
-                      onkeydown="maxChars(this,200); count(this.value, 'text-description');"
-                    ></textarea>
-                    <small>
-                      <span id="text-description"></span><th:block th:text="#{action.comment.maxChars}" />
-                    </small>
-                    <p
-                      class="tw-mt-1 tw-text-sm tw-text-red-800 dark:tw-text-red-400"
-                      th:if="${#fields.hasErrors('description')}"
-                    >
-                      <th:block th:errors="*{description}"> description Error</th:block>
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div class="row tw-mb-8">
-              <div class="col-md-4 col-md-push-8">
-                <span class="help-block tw-text-sm">
-                  <svg th:replace="~{icon/info::svg(className='tw-w-4 tw-h-4')}"></svg>
-                  <th:block th:text="#{department.data.twoStageApproval.help.members}" /><br />
-                  <svg th:replace="~{icon/info::svg(className='tw-w-4 tw-h-4')}"></svg>
-                  <th:block th:text="#{department.data.twoStageApproval.help.departmentHead}" />
-                </span>
-              </div>
-              <div class="col-md-8 col-md-pull-4">
-                <div class="form-group">
-                  <label
-                    th:text="|#{department.data.twoStageApproval}:|"
-                    class="control-label col-md-3"
-                    for="twoStageApproval"
-                  >
-                  </label>
-                  <div class="col-md-9 checkbox">
-                    <p
-                      class="tw-mt-1 tw-text-sm tw-text-red-800 dark:tw-text-red-400"
-                      th:if="${#fields.hasErrors('twoStageApproval')}"
-                    >
-                      <th:block th:errors="*{twoStageApproval}"> twoStageApproval Error</th:block>
-                    </p>
-                    <label>
-                      <input
-                        id="twoStageApproval"
-                        type="checkbox"
-                        th:field="*{twoStageApproval}"
-                        th:errorclass="error"
-                      />
-                      <span th:text="#{department.data.twoStageApproval.activate}"></span>
-                    </label>
-                  </div>
-                </div>
-              </div>
-            </div>
+        <div class="form-section">
+          <div th:replace="~{fragments/section-heading::section-heading(~{::department-heading-body}, ~{})}">
+            <th:block th:ref="department-heading-body">
+              <h2 th:text="#{department.data}">Abteilungsdaten</h2>
+            </th:block>
           </div>
 
-          <div class="form-section">
-            <div th:replace="~{fragments/section-heading::section-heading(~{::department-members-body}, ~{})}">
-              <th:block th:ref="department-members-body">
-                <h2 th:text="#{department.members}">Mitarbeiter</h2>
-              </th:block>
+          <div class="row">
+            <div class="col-md-4 col-md-push-8">
+              <span class="help-block tw-text-sm">
+                <svg th:replace="~{icon/info::svg(className='tw-w-4 tw-h-4')}"></svg>
+                <span th:text="#{department.data.description}"></span>
+              </span>
             </div>
-
-            <div class="alert alert-danger tw-mt-1 tw-text-sm" th:if="${#fields.hasErrors('departmentHeads')}">
-              <th:block th:errors="*{departmentHeads}"> departmentHeads Error</th:block>
-            </div>
-
-            <div class="alert alert-danger tw-mt-1 tw-text-sm" th:if="${#fields.hasErrors('secondStageAuthorities')}">
-              <th:block th:errors="*{secondStageAuthorities}"> secondStageAuthorities Error</th:block>
-            </div>
-
-            <div class="row">
-              <div class="col-md-4 col-md-push-8">
-                <span class="help-block tw-text-sm">
-                  <svg th:replace="~{icon/info::svg(className='tw-w-4 tw-h-4')}"></svg>
-                  <span th:text="#{department.members.description}"></span>
-                </span>
-                <span class="help-block tw-text-sm">
-                  <svg th:replace="~{icon/info::svg(className='tw-w-4 tw-h-4')}"></svg>
-                  <span th:text="#{department.members.secondStageAuthority.description}"></span>
-                </span>
-              </div>
-
-              <div class="col-md-8 col-md-pull-4">
-                <div class="form-group">
+            <div class="col-md-8 col-md-pull-4">
+              <div class="form-group is-required">
+                <label th:text="|#{department.data.name}:|" class="control-label col-md-3" for="name"></label>
+                <div class="col-md-9">
+                  <input id="name" type="text" th:field="*{name}" class="form-control" th:errorclass="error" />
                   <p
-                    th:text="|#{department.members.person}:|"
-                    class="control-label col-md-3 tw-m-0 tw-text-sm tw-font-semibold tw-leading-6"
-                  ></p>
-                  <div class="col-md-9">
-                    <div
-                      class="tw-flex tw-items-stretch tw-border tw-border-neutral-300 dark:tw-border-neutral-600 tw-rounded-md focus-within:tw-ring-2 focus-within:tw-ring-blue-300"
-                    >
-                      <label for="member-search-input" class="tw-sr-only"> Mitarbeiter Suche </label>
-                      <input
-                        id="member-search-input"
-                        type="text"
-                        class="form-control md:tw-h-full tw-border-none tw-text-ellipsis focus:tw-ring-0 tw-rounded-r-none"
-                        name="memberQuery"
-                        th:placeholder="#{action.search.placeholder.firstname-lastname}"
-                        th:value="${memberQuery}"
-                        data-auto-submit="member-search-submit"
-                        data-auto-submit-delay="100"
-                      />
-                      <button
-                        type="submit"
-                        id="member-search-submit"
-                        class="dark:tw-bg-zinc-800 tw-px-2 tw-rounded-r-md tw-flex tw-items-center"
-                        name="do-member-search"
-                        th:formaction="${department.id == null ? '/web/department' : '/web/department/' + department.id + '/edit'}"
-                        data-turbo-frame="frame-department-members"
-                        data-turbo-action="replace"
-                      >
-                        <svg th:replace="~{icon/search::svg(className='tw-w-5 tw-h-5 tw-stroke-2')}"></svg>
-                        <span class="tw-sr-only" th:text="#{action.search}">Suche</span>
-                      </button>
-                    </div>
-                    <turbo-frame id="frame-department-members">
-                      <input
-                        th:each="member : ${hiddenDepartmentMembers}"
-                        type="hidden"
-                        name="members"
-                        value="1337"
-                        th:value="${member.id}"
-                      />
-                      <input
-                        th:each="departmentHead : ${hiddenDepartmentHeads}"
-                        type="hidden"
-                        name="departmentHeads"
-                        value="1337"
-                        th:value="${departmentHead.id}"
-                      />
-                      <input
-                        th:each="secondStageAuthority : ${hiddenDepartmentSecondStageAuthorities}"
-                        type="hidden"
-                        name="secondStageAuthorities"
-                        value="1337"
-                        th:value="${secondStageAuthority.id}"
-                      />
-                      <ul class="tw-mt-4 department--members tw-p-0 tw-m-0">
-                        <li
-                          th:each="person : ${persons}"
-                          class="department--member"
-                          th:with="isInactive=${#lists.contains(person.permissions, T(org.synyx.urlaubsverwaltung.person.Role).INACTIVE)}, isMember=${#lists.contains(department.members, person)}"
-                          th:classappend="${isMember ? ( isInactive ? 'is-inactive' : 'is-assigned') : ''}"
-                        >
-                          <div class="department--member-image tw-text-blue-50 dark:tw-text-sky-800">
-                            <img
-                              th:replace="~{fragments/avatar::avatar-bordered(url=${person.gravatarURL + '?d=404&s=40'},niceName=${person.niceName},width='40px',height='40px',personId=${person.id})}"
-                              alt=""
-                            />
-                          </div>
-                          <div class="department--member-assignment">
-                            <p class="department--member-info tw-mb-2">
-                              <a
-                                th:text="${person.niceName}"
-                                th:href="@{/web/person/__${person.id}__/overview}"
-                                class="icon-link"
-                                data-turbo="false"
-                              ></a>
-                            </p>
-                            <div th:if="${isInactive}" class="tw-flex tw-items-center">
-                              <svg
-                                th:replace="~{icon/info::svg(className='tw-text-amber-300 tw-w-5 tw-h-5 tw-m-0 tw-mr-1')}"
-                              ></svg>
-                              <th:block th:text="#{department.members.assigned.inactive}"></th:block>
-                            </div>
-                            <div>
-                              <label class="tw-font-normal tw-m-0 tw-flex tw-items-center">
-                                <input
-                                  type="checkbox"
-                                  name="members"
-                                  th:id="${'members' + (personStat.index + 1)}"
-                                  th:value="${person.id}"
-                                  th:checked="${#lists.contains(department.members, person)}"
-                                  class="tw-m-0 tw-mr-2"
-                                />
-                                <input type="hidden" name="_members" value="on" />
-                                <th:block th:text="#{department.members.assigned}"></th:block>
-                              </label>
-                            </div>
-                            <div
-                              th:if="${#lists.contains(person.permissions, T(org.synyx.urlaubsverwaltung.person.Role).DEPARTMENT_HEAD)}"
-                            >
-                              <label class="tw-font-normal tw-m-0 tw-flex tw-items-center">
-                                <input
-                                  type="checkbox"
-                                  name="departmentHeads"
-                                  th:id="${'departmentHeads' + (personStat.index + 1)}"
-                                  th:value="${person.id}"
-                                  th:checked="${#lists.contains(department.departmentHeads, person)}"
-                                  class="tw-m-0 tw-mr-2"
-                                />
-                                <input type="hidden" name="_departmentHeads" value="on" />
-                                <th:block th:text="#{department.members.departmentHead}"></th:block>
-                              </label>
-                            </div>
-                            <div
-                              th:if="${#lists.contains(person.permissions, T(org.synyx.urlaubsverwaltung.person.Role).SECOND_STAGE_AUTHORITY)}"
-                            >
-                              <label class="tw-font-normal tw-m-0 tw-flex tw-items-center">
-                                <input
-                                  type="checkbox"
-                                  name="secondStageAuthorities"
-                                  th:id="${'secondStageAuthorities' + (personStat.index + 1)}"
-                                  th:value="${person.id}"
-                                  th:checked="${#lists.contains(department.secondStageAuthorities, person)}"
-                                  class="tw-m-0 tw-mr-2"
-                                />
-                                <input type="hidden" name="_secondStageAuthorities" value="on" />
-                                <th:block th:text="#{department.members.secondStageAuthority}"></th:block>
-                              </label>
-                            </div>
-                          </div>
-                        </li>
-                      </ul>
-                    </turbo-frame>
-                  </div>
+                    class="tw-mt-1 tw-text-sm tw-text-red-800 dark:tw-text-red-400"
+                    th:if="${#fields.hasErrors('name')}"
+                  >
+                    <th:block th:errors="*{name}"> name Error</th:block>
+                  </p>
+                </div>
+              </div>
+              <div class="form-group">
+                <label th:text="|#{department.data.info}:|" class="control-label col-md-3" for="description"></label>
+                <div class="col-md-9">
+                  <textarea
+                    id="description"
+                    rows="3"
+                    th:field="*{description}"
+                    class="form-control"
+                    th:errorclass="error"
+                    onkeyup="count(this.value, 'text-description');"
+                    onkeydown="maxChars(this,200); count(this.value, 'text-description');"
+                  ></textarea>
+                  <small>
+                    <span id="text-description"></span>
+                    <th:block th:text="#{action.comment.maxChars}" />
+                  </small>
+                  <p
+                    class="tw-mt-1 tw-text-sm tw-text-red-800 dark:tw-text-red-400"
+                    th:if="${#fields.hasErrors('description')}"
+                  >
+                    <th:block th:errors="*{description}"> description Error</th:block>
+                  </p>
                 </div>
               </div>
             </div>
           </div>
 
-          <hr class="tw-w-full tw-m-0 tw-mt-6" />
-
-          <div class="tw-mt-6 tw-flex tw-justify-between tw-gap-4">
-            <button type="submit" class="button-main-green tw-w-56" th:text="#{action.save}">Speichern</button>
-            <button data-back-button th:text="#{action.cancel}" type="button" class="button">Abbrechen</button>
+          <div class="row tw-mb-8">
+            <div class="col-md-4 col-md-push-8">
+              <span class="help-block tw-text-sm">
+                <svg th:replace="~{icon/info::svg(className='tw-w-4 tw-h-4')}"></svg>
+                <th:block th:text="#{department.data.twoStageApproval.help.members}" /><br />
+                <svg th:replace="~{icon/info::svg(className='tw-w-4 tw-h-4')}"></svg>
+                <th:block th:text="#{department.data.twoStageApproval.help.departmentHead}" />
+              </span>
+            </div>
+            <div class="col-md-8 col-md-pull-4">
+              <div class="form-group">
+                <label
+                  th:text="|#{department.data.twoStageApproval}:|"
+                  class="control-label col-md-3"
+                  for="twoStageApproval"
+                >
+                </label>
+                <div class="col-md-9 checkbox">
+                  <p
+                    class="tw-mt-1 tw-text-sm tw-text-red-800 dark:tw-text-red-400"
+                    th:if="${#fields.hasErrors('twoStageApproval')}"
+                  >
+                    <th:block th:errors="*{twoStageApproval}"> twoStageApproval Error</th:block>
+                  </p>
+                  <label>
+                    <input id="twoStageApproval" type="checkbox" th:field="*{twoStageApproval}" th:errorclass="error" />
+                    <span th:text="#{department.data.twoStageApproval.activate}"></span>
+                  </label>
+                </div>
+              </div>
+            </div>
           </div>
-        </form>
-      </div>
+        </div>
+
+        <div class="form-section">
+          <div th:replace="~{fragments/section-heading::section-heading(~{::department-members-body}, ~{})}">
+            <th:block th:ref="department-members-body">
+              <h2 th:text="#{department.members}">Mitarbeiter</h2>
+            </th:block>
+          </div>
+
+          <div class="alert alert-danger tw-mt-1 tw-text-sm" th:if="${#fields.hasErrors('departmentHeads')}">
+            <th:block th:errors="*{departmentHeads}"> departmentHeads Error</th:block>
+          </div>
+
+          <div class="alert alert-danger tw-mt-1 tw-text-sm" th:if="${#fields.hasErrors('secondStageAuthorities')}">
+            <th:block th:errors="*{secondStageAuthorities}"> secondStageAuthorities Error</th:block>
+          </div>
+
+          <div class="row">
+            <div class="col-md-4 col-md-push-8">
+              <span class="help-block tw-text-sm">
+                <svg th:replace="~{icon/info::svg(className='tw-w-4 tw-h-4')}"></svg>
+                <span th:text="#{department.members.description}"></span>
+              </span>
+              <span class="help-block tw-text-sm">
+                <svg th:replace="~{icon/info::svg(className='tw-w-4 tw-h-4')}"></svg>
+                <span th:text="#{department.members.secondStageAuthority.description}"></span>
+              </span>
+            </div>
+
+            <div class="col-md-8 col-md-pull-4">
+              <div class="form-group">
+                <p
+                  th:text="|#{department.members.person}:|"
+                  class="control-label col-md-3 tw-m-0 tw-text-sm tw-font-semibold tw-leading-6"
+                ></p>
+                <div class="col-md-9">
+                  <div
+                    class="tw-flex tw-items-stretch tw-border tw-border-neutral-300 dark:tw-border-neutral-600 tw-rounded-md focus-within:tw-ring-2 focus-within:tw-ring-blue-300"
+                  >
+                    <label for="member-search-input" class="tw-sr-only"> Mitarbeiter Suche </label>
+                    <input
+                      id="member-search-input"
+                      type="text"
+                      class="form-control md:tw-h-full tw-border-none tw-text-ellipsis focus:tw-ring-0 tw-rounded-r-none"
+                      name="memberQuery"
+                      th:placeholder="#{action.search.placeholder.firstname-lastname}"
+                      th:value="${memberQuery}"
+                      data-auto-submit="member-search-submit"
+                      data-auto-submit-delay="100"
+                    />
+                    <button
+                      type="submit"
+                      id="member-search-submit"
+                      class="dark:tw-bg-zinc-800 tw-px-2 tw-rounded-r-md tw-flex tw-items-center"
+                      name="do-member-search"
+                      th:formaction="${department.id == null ? '/web/department' : '/web/department/' + department.id + '/edit'}"
+                      data-turbo-frame="frame-department-members"
+                      data-turbo-action="replace"
+                    >
+                      <svg th:replace="~{icon/search::svg(className='tw-w-5 tw-h-5 tw-stroke-2')}"></svg>
+                      <span class="tw-sr-only" th:text="#{action.search}">Suche</span>
+                    </button>
+                  </div>
+                  <turbo-frame id="frame-department-members">
+                    <input
+                      th:each="member : ${hiddenDepartmentMembers}"
+                      type="hidden"
+                      name="members"
+                      value="1337"
+                      th:value="${member.id}"
+                    />
+                    <input
+                      th:each="departmentHead : ${hiddenDepartmentHeads}"
+                      type="hidden"
+                      name="departmentHeads"
+                      value="1337"
+                      th:value="${departmentHead.id}"
+                    />
+                    <input
+                      th:each="secondStageAuthority : ${hiddenDepartmentSecondStageAuthorities}"
+                      type="hidden"
+                      name="secondStageAuthorities"
+                      value="1337"
+                      th:value="${secondStageAuthority.id}"
+                    />
+                    <ul class="tw-mt-4 department--members tw-p-0 tw-m-0">
+                      <li
+                        th:each="person : ${persons}"
+                        class="department--member"
+                        th:with="isInactive=${#lists.contains(person.permissions, T(org.synyx.urlaubsverwaltung.person.Role).INACTIVE)}, isMember=${#lists.contains(department.members, person)}"
+                        th:classappend="${isMember ? ( isInactive ? 'is-inactive' : 'is-assigned') : ''}"
+                      >
+                        <div class="department--member-image tw-text-blue-50 dark:tw-text-sky-800">
+                          <img
+                            th:replace="~{fragments/avatar::avatar-bordered(url=${person.gravatarURL + '?d=404&s=40'},niceName=${person.niceName},width='40px',height='40px',personId=${person.id})}"
+                            alt=""
+                          />
+                        </div>
+                        <div class="department--member-assignment">
+                          <p class="department--member-info tw-mb-2">
+                            <a
+                              th:text="${person.niceName}"
+                              th:href="@{/web/person/__${person.id}__/overview}"
+                              class="icon-link"
+                              data-turbo="false"
+                            ></a>
+                          </p>
+                          <div th:if="${isInactive}" class="tw-flex tw-items-center">
+                            <svg
+                              th:replace="~{icon/info::svg(className='tw-text-amber-300 tw-w-5 tw-h-5 tw-m-0 tw-mr-1')}"
+                            ></svg>
+                            <th:block th:text="#{department.members.assigned.inactive}"></th:block>
+                          </div>
+                          <div>
+                            <label class="tw-font-normal tw-m-0 tw-flex tw-items-center">
+                              <input
+                                type="checkbox"
+                                name="members"
+                                th:id="${'members' + (personStat.index + 1)}"
+                                th:value="${person.id}"
+                                th:checked="${#lists.contains(department.members, person)}"
+                                class="tw-m-0 tw-mr-2"
+                              />
+                              <input type="hidden" name="_members" value="on" />
+                              <th:block th:text="#{department.members.assigned}"></th:block>
+                            </label>
+                          </div>
+                          <div
+                            th:if="${#lists.contains(person.permissions, T(org.synyx.urlaubsverwaltung.person.Role).DEPARTMENT_HEAD)}"
+                          >
+                            <label class="tw-font-normal tw-m-0 tw-flex tw-items-center">
+                              <input
+                                type="checkbox"
+                                name="departmentHeads"
+                                th:id="${'departmentHeads' + (personStat.index + 1)}"
+                                th:value="${person.id}"
+                                th:checked="${#lists.contains(department.departmentHeads, person)}"
+                                class="tw-m-0 tw-mr-2"
+                              />
+                              <input type="hidden" name="_departmentHeads" value="on" />
+                              <th:block th:text="#{department.members.departmentHead}"></th:block>
+                            </label>
+                          </div>
+                          <div
+                            th:if="${#lists.contains(person.permissions, T(org.synyx.urlaubsverwaltung.person.Role).SECOND_STAGE_AUTHORITY)}"
+                          >
+                            <label class="tw-font-normal tw-m-0 tw-flex tw-items-center">
+                              <input
+                                type="checkbox"
+                                name="secondStageAuthorities"
+                                th:id="${'secondStageAuthorities' + (personStat.index + 1)}"
+                                th:value="${person.id}"
+                                th:checked="${#lists.contains(department.secondStageAuthorities, person)}"
+                                class="tw-m-0 tw-mr-2"
+                              />
+                              <input type="hidden" name="_secondStageAuthorities" value="on" />
+                              <th:block th:text="#{department.members.secondStageAuthority}"></th:block>
+                            </label>
+                          </div>
+                        </div>
+                      </li>
+                    </ul>
+                  </turbo-frame>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <hr class="tw-w-full tw-m-0 tw-mt-6" />
+
+        <div class="tw-mt-6 tw-flex tw-justify-between tw-gap-4">
+          <button type="submit" class="button-main-green tw-w-56" th:text="#{action.save}">Speichern</button>
+          <button data-back-button th:text="#{action.cancel}" type="button" class="button">Abbrechen</button>
+        </div>
+      </form>
     </main>
   </body>
 </html>

--- a/src/main/resources/templates/department/department_form.html
+++ b/src/main/resources/templates/department/department_form.html
@@ -21,7 +21,6 @@
           th:action="@{__${action}__}"
           th:object="${department}"
           class="form-horizontal"
-          data-turbo="true"
         >
           <input type="hidden" th:field="*{id}" />
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewControllerTest.java
@@ -138,7 +138,7 @@ class DepartmentViewControllerTest {
         final DepartmentForm expectedDepartmentForm = new DepartmentForm();
         expectedDepartmentForm.setName("fight club");
 
-        perform(post("/web/department")
+        perform(post("/web/department/new")
             .param("do-member-search", "")
             .param("memberQuery", givenQuery)
             .param("name", "fight club")
@@ -171,7 +171,7 @@ class DepartmentViewControllerTest {
         final DepartmentForm expectedDepartmentForm = new DepartmentForm();
         expectedDepartmentForm.setName("fight club");
 
-        perform(post("/web/department")
+        perform(post("/web/department/new")
             .header("Turbo-Frame", "awesome-turbo-frame")
             .param("do-member-search", "")
             .param("memberQuery", givenQuery)
@@ -219,7 +219,7 @@ class DepartmentViewControllerTest {
         expectedDepartmentForm.setDepartmentHeads(List.of(departmentHead));
         expectedDepartmentForm.setSecondStageAuthorities(List.of(secondStageAuthority));
 
-        perform(post("/web/department")
+        perform(post("/web/department/new")
             .param("do-member-search", "")
             .param("memberQuery", "bruce")
             .param("name", "fight club")
@@ -275,7 +275,7 @@ class DepartmentViewControllerTest {
         expectedDepartmentForm.setDepartmentHeads(List.of(departmentHead));
         expectedDepartmentForm.setSecondStageAuthorities(List.of(secondStageAuthority));
 
-        perform(post("/web/department")
+        perform(post("/web/department/new")
             .header("Turbo-Frame", "awesome-turbo-frame")
             .param("do-member-search", "")
             .param("memberQuery", "bruce")
@@ -565,7 +565,7 @@ class DepartmentViewControllerTest {
 
         }).when(validator).validate(any(), any());
 
-        perform(post("/web/department"))
+        perform(post("/web/department/new"))
             .andExpect(view().name("department/department_form"));
 
         verify(departmentService, never()).create(any());
@@ -576,7 +576,7 @@ class DepartmentViewControllerTest {
 
         when(departmentService.create(any())).thenReturn(new Department());
 
-        perform(post("/web/department"));
+        perform(post("/web/department/new"));
 
         verify(departmentService).create(any(Department.class));
     }
@@ -588,7 +588,7 @@ class DepartmentViewControllerTest {
         department.setName("department");
         when(departmentService.create(any())).thenReturn(department);
 
-        perform(post("/web/department"))
+        perform(post("/web/department/new"))
             .andExpect(status().isFound())
             .andExpect(flash().attribute("createdDepartmentName", "department"))
             .andExpect(redirectedUrl("/web/department"));

--- a/src/test/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewValidatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/department/web/DepartmentViewValidatorTest.java
@@ -6,14 +6,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.validation.Errors;
+import org.synyx.urlaubsverwaltung.department.Department;
+import org.synyx.urlaubsverwaltung.department.DepartmentService;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.Role;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 import static org.synyx.urlaubsverwaltung.person.Role.DEPARTMENT_HEAD;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,9 +28,12 @@ class DepartmentViewValidatorTest {
     @Mock
     private Errors errors;
 
+    @Mock
+    private DepartmentService departmentService;
+
     @BeforeEach
     void setUp() {
-        sut = new DepartmentViewValidator();
+        sut = new DepartmentViewValidator(departmentService);
     }
 
     @Test
@@ -40,6 +47,17 @@ class DepartmentViewValidatorTest {
         final DepartmentForm departmentForm = new DepartmentForm();
         sut.validate(departmentForm, errors);
         verify(errors).rejectValue("name", "error.entry.mandatory");
+    }
+
+    @Test
+    void ensureNameIsNotADuplicate() {
+        final DepartmentForm departmentForm = new DepartmentForm();
+        departmentForm.setName("duplicateName");
+
+        when(departmentService.getDepartmentByName("duplicateName")).thenReturn(Optional.of(new Department()));
+
+        sut.validate(departmentForm, errors);
+        verify(errors).rejectValue("name", "department.error.name.duplicate");
     }
 
     @Test


### PR DESCRIPTION
closes #4009 

@bseber derzeit werden keine Fehlernachrichten auf der Abteilungsseite ausgegeben. Wenn ich in der `department_form.html` in der Zeile 24 `data-turbo="true"` entferne geht es. Was übersehe ich gerade?

=> Er geht in `updateDepartment`, das ist eher nicht korrekt und dort fehlt auch die Validierung? Warum geht er denn in update beim Anlegen?