### PR TITLE
render navigation popups one layer above navigation buttons

### DIFF
--- a/src/main/css/components/navigation.css
+++ b/src/main/css/components/navigation.css
@@ -163,6 +163,7 @@
 
   .nav-popup-menu {
     position: fixed;
+    z-index: 1;
     top: 100%;
     bottom: 0;
     left: 0;


### PR DESCRIPTION
closes #4431

Unschön ist auch die offene Hauptnavigation. Habe ich allerdings nicht auf die Schnelle verbessern können. Schauen wir uns an, wenn wir die Navigation umbauen.

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
