### PR TITLE
Fix rendering issue of account_cron_updated_accounts_turn_of_the_year.txt template

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/account/TurnOfTheYearAccountUpdaterService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/account/TurnOfTheYearAccountUpdaterService.java
@@ -13,7 +13,6 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.Year;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -39,9 +38,8 @@ public class TurnOfTheYearAccountUpdaterService {
     private final Clock clock;
 
     @Autowired
-    public TurnOfTheYearAccountUpdaterService(PersonService personService, AccountService accountService,
+    TurnOfTheYearAccountUpdaterService(PersonService personService, AccountService accountService,
                                               AccountInteractionService accountInteractionService, VacationDaysReminderService vacationDaysReminderService, MailService mailService, Clock clock) {
-
         this.personService = personService;
         this.accountService = accountService;
         this.accountInteractionService = accountInteractionService;
@@ -85,11 +83,11 @@ public class TurnOfTheYearAccountUpdaterService {
      */
     private void sendSuccessfullyUpdatedAccountsNotification(List<Account> updatedAccounts) {
 
-        Map<String, Object> model = new HashMap<>();
-        model.put("accounts", updatedAccounts);
-        model.put("totalRemainingVacationDays", updatedAccounts.stream().map(Account::getRemainingVacationDays).reduce(BigDecimal::add).orElse(BigDecimal.ZERO));
-        model.put("today", LocalDate.now(clock));
-
+        final Map<String, Object> model = Map.of(
+            "accounts", updatedAccounts,
+            "totalRemainingVacationDays", updatedAccounts.stream().map(Account::getRemainingVacationDays).reduce(BigDecimal::add).orElse(BigDecimal.ZERO),
+            "today", LocalDate.now(clock)
+        );
         final String subjectMessageKey = "subject.account.updatedRemainingDays";
         final String templateName = "account_cron_updated_accounts_turn_of_the_year";
 

--- a/src/main/resources/MailMessages_de.properties
+++ b/src/main/resources/MailMessages_de.properties
@@ -29,7 +29,7 @@ application.data.sicknotetype.sicknotechild=Kind-Krankmeldung
 
 # account
 account.vacation_entitlement.information=Mehr Informationen zu deinem Urlaubsanspruch findest du hier:
-account.remaining_vacation_days=Stand Resturlaubstage zum 1. Januar {0} (mitgenommene Resturlaubstage aus dem Vorjahr)
+account.remaining_vacation_days=Resturlaubstage zum {0} (mitgenommene Resturlaubstage aus dem Vorjahr)
 account.remaining_vacation_days.last_year=Gesamtzahl an Resturlaubstagen aus dem Vorjahr:
 account.remaining_vacation_days.last_year.use_until=Du hast noch {0, choice, 0#{0} Tage|1#1 Tag|1.5#{0} Tage} Resturlaub aus dem Vorjahr, bitte denke daran den Urlaub bis zum {1} zu nehmen.
 account.remaining_vacation_days.expired=leider ist dein Resturlaub zum {0} in Höhe von {1, choice, 0#{1} Tage|1#1 Tag|1.5#{1} Tagen} verfallen.

--- a/src/main/resources/MailMessages_de_AT.properties
+++ b/src/main/resources/MailMessages_de_AT.properties
@@ -29,7 +29,7 @@ application.data.sicknotetype.sicknotechild=Kind-Krankmeldung
 
 # account
 account.vacation_entitlement.information=Mehr Informationen zu deinem Urlaubsanspruch findest du hier:
-account.remaining_vacation_days=Stand Resturlaubstage zum 1. Januar {0} (mitgenommene Resturlaubstage aus dem Vorjahr)
+account.remaining_vacation_days=Resturlaubstage zum {0} (mitgenommene Resturlaubstage aus dem Vorjahr)
 account.remaining_vacation_days.last_year=Gesamtzahl an Resturlaubstagen aus dem Vorjahr:
 account.remaining_vacation_days.last_year.use_until=Du hast noch {0, choice, 0#{0} Tage|1#1 Tag|1.5#{0} Tage} Resturlaub aus dem Vorjahr, bitte denke daran den Urlaub bis zum {1} zu nehmen.
 account.remaining_vacation_days.expired=leider ist dein Resturlaub zum {0} in Höhe von {1, choice, 0#{1} Tage|1#1 Tag|1.5#{1} Tagen} verfallen.

--- a/src/main/resources/MailMessages_el.properties
+++ b/src/main/resources/MailMessages_el.properties
@@ -29,7 +29,7 @@ application.data.sicknotetype.sicknotechild=Χαρτί άρρωστου παιδ
 
 # account
 account.vacation_entitlement.information=Μπορείτε να βρείτε περισσότερες πληροφορίες σχετικά με το δικαίωμα διακοπών σας εδώ:
-account.remaining_vacation_days=Σταθερό υπόλοιπο ημερών διακοπών την 1η Ιανουαρίου {0} (υπόλοιπες ημέρες διακοπών που λαμβάνονται από το προηγούμενο έτος)
+account.remaining_vacation_days=Υπολειπόμενες ημέρες άδειας την {0} (υπολειπόμενες ημέρες άδειας που λήφθηκαν από το προηγούμενο έτος)
 account.remaining_vacation_days.last_year=Συνολικός αριθμός ημερών άδειας που απομένουν από το προηγούμενο έτος:
 account.remaining_vacation_days.last_year.use_until=Έχετε {0, choice, 0#{0} ημέρες|1#1 ημέρα|1.5#{0} ημέρες} υπόλοιπο άδειας από το προηγούμενο έτος, θυμηθείτε να πάρετε την άδεια μέχρι την {1}.
 account.remaining_vacation_days.expired=Δυστυχώς, η υπόλοιπη άδεια σας από {0} έχει λήξει στο ποσό των {1, choice, 0#{1} ημέρες|1#1 ημέρα|1.5#{1} ημέρες}.

--- a/src/main/resources/MailMessages_en.properties
+++ b/src/main/resources/MailMessages_en.properties
@@ -29,7 +29,7 @@ application.data.sicknotetype.sicknotechild=Child sick note
 
 # account
 account.vacation_entitlement.information=You can find more information about your holiday entitlement here:
-account.remaining_vacation_days=Stand of remaining holiday days as of 1 January {0} (remaining holiday days taken from the previous year)
+account.remaining_vacation_days=Remaining leave days as of {0} (remaining leave days taken from the previous year)
 account.remaining_vacation_days.last_year=Total number of remaining leave days from the previous year:
 account.remaining_vacation_days.last_year.use_until=You have {0, choice, 0#{0} days|1#1 day|1.5#{0} days} remaining leave from the previous year, please remember to take the leave by {1}.
 account.remaining_vacation_days.expired=Unfortunately, your remaining leave as of {0} has expired in the amount of {1, choice, 0#{1} days|1#1 day|1.5#{1} days}.

--- a/src/main/resources/mail/account_cron_updated_accounts_turn_of_the_year.txt
+++ b/src/main/resources/mail/account_cron_updated_accounts_turn_of_the_year.txt
@@ -1,9 +1,7 @@
 [(#{greeting(${recipient.niceName})})],
 
-[(#{account.remaining_vacation_days(${today.format("yyyy")})}]
-
+[(#{account.remaining_vacation_days(${#temporals.format(today, "dd.MM.yyyy")})})]
 [# th:each="account : ${accounts}"]
 [(${account.person.niceName})]: [(${account.remainingVacationDays})]
 [/]
-
 [(#{account.remaining_vacation_days.last_year})] [(${totalRemainingVacationDays})]

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/TurnOfTheYearAccountUpdaterServiceIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/TurnOfTheYearAccountUpdaterServiceIT.java
@@ -1,0 +1,107 @@
+package org.synyx.urlaubsverwaltung.account;
+
+import com.icegreen.greenmail.junit5.GreenMailExtension;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.transaction.annotation.Transactional;
+import org.synyx.urlaubsverwaltung.TestContainersBase;
+import org.synyx.urlaubsverwaltung.person.Person;
+import org.synyx.urlaubsverwaltung.person.PersonService;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+import static java.math.BigDecimal.TEN;
+import static java.math.BigDecimal.TWO;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+import static org.synyx.urlaubsverwaltung.TestDataCreator.createHolidaysAccount;
+import static org.synyx.urlaubsverwaltung.person.Role.OFFICE;
+
+@SpringBootTest(properties = {"spring.mail.port=3025", "spring.mail.host=localhost", "spring.main.allow-bean-definition-overriding=true"})
+@Transactional
+class TurnOfTheYearAccountUpdaterServiceIT extends TestContainersBase {
+
+    @RegisterExtension
+    static final GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP_IMAP);
+
+    @Autowired
+    private TurnOfTheYearAccountUpdaterService sut;
+
+    @MockBean
+    private PersonService personService;
+    @MockBean
+    private AccountService accountService;
+    @MockBean
+    private AccountInteractionService accountInteractionService;
+
+    @TestConfiguration
+    public static class ClockConfig {
+        @Bean
+        public Clock clock() {
+            return Clock.fixed(Instant.parse("2022-01-01T00:00:00.00Z"), ZoneId.of("UTC"));
+        }
+    }
+
+    @Test
+    void ensureToSendSuccessfullyUpdatedAccountsNotification() throws MessagingException, IOException {
+
+        final Person person = new Person("franka", "Potente", "Franka", "franka.potente@example.org");
+        final Person person2 = new Person("michel", "Schneider", "Michel", "michel.schneider@example.org");
+        when(personService.getActivePersons()).thenReturn(List.of(person, person2));
+
+        final Account account1 = createHolidaysAccount(person, 2021);
+        when(accountService.getHolidaysAccount(2021, person)).thenReturn(Optional.of(account1));
+
+        final Account account2 = createHolidaysAccount(person2, 2021);
+        when(accountService.getHolidaysAccount(2021, person2)).thenReturn(Optional.of(account2));
+
+        final Account newAccount1 = createHolidaysAccount(person, 2022);
+        newAccount1.setRemainingVacationDays(TEN);
+        when(accountInteractionService.autoCreateOrUpdateNextYearsHolidaysAccount(account1)).thenReturn(newAccount1);
+
+        final Account newAccount2 = createHolidaysAccount(person2, 2022);
+        newAccount2.setRemainingVacationDays(TWO);
+        when(accountInteractionService.autoCreateOrUpdateNextYearsHolidaysAccount(account2)).thenReturn(newAccount2);
+
+        final Person office = new Person("office", "Office", "Senorita", "office@example.org");
+        when(personService.getActivePersonsByRole(OFFICE)).thenReturn(List.of(office));
+
+        sut.updateAccountsForNextPeriod();
+
+        final MimeMessage[] inbox = greenMail.getReceivedMessagesForDomain(office.getEmail());
+        assertThat(inbox.length).isOne();
+
+        final Message msg = inbox[0];
+        assertThat(msg.getSubject()).contains("Auswertung Resturlaubstage");
+        assertThat(new InternetAddress(office.getEmail())).isEqualTo(msg.getAllRecipients()[0]);
+
+        assertThat(readPlainContent(msg)).isEqualTo("""
+            Hallo Senorita Office,
+
+            Resturlaubstage zum 01.01.2022 (mitgenommene Resturlaubstage aus dem Vorjahr)
+
+            Franka Potente: 10
+            Michel Schneider: 2
+
+            Gesamtzahl an Resturlaubstagen aus dem Vorjahr: 12""");
+    }
+
+    private String readPlainContent(Message message) throws MessagingException, IOException {
+        return message.getContent().toString().replaceAll("\\r", "");
+    }
+}


### PR DESCRIPTION
Fix rendering issue of account_cron_updated_accounts_turn_of_the_year.txt template


was:
```
Hallo Aaron Rosenbauer,

[(#{account.remaining_vacation_days(${today.format("yyyy")})}]


Aaron Rosenbauer: 2.00
Abby Balkow: 2.00
Abby Göckeritz: 2.00
Abby Gunkel: 2.00
Abigail Deckert: 2.00
...

```