### PR TITLE
Fix double calculated overtime hours on application for leave edit

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimeService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimeService.java
@@ -81,6 +81,15 @@ public interface OvertimeService {
     Duration getLeftOvertimeForPerson(Person person);
 
     /**
+     * Get the left overtime hours of the given person: the difference between the total overtime and the overtime
+     * reduction excluding the given applications
+     *
+     * @param person to get the left overtime for
+     * @return the left overtime, never {@code null}
+     */
+    Duration getLeftOvertimeForPerson(Person person, List<Long> excludingApplicationIDs);
+
+    /**
      * Get the left overtime hours of the given persons: the difference between the total overtime and the overtime
      * reduction.
      *

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimeServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimeServiceImpl.java
@@ -136,6 +136,18 @@ class OvertimeServiceImpl implements OvertimeService {
     }
 
     @Override
+    public Duration getLeftOvertimeForPerson(Person person, List<Long> excludingApplicationIDs) {
+
+        final List<Application> applications = applicationService.findApplicationsByIds(excludingApplicationIDs);
+        final Duration leftOvertimeForPerson = getLeftOvertimeForPerson(person);
+
+        return applications.stream()
+            .filter(application -> application.getVacationType().isOfCategory(OVERTIME))
+            .map(Application::getHours)
+            .reduce(leftOvertimeForPerson, Duration::plus);
+    }
+
+    @Override
     public Map<Person, LeftOvertime> getLeftOvertimeTotalAndDateRangeForPersons(List<Person> persons, List<Application> applications, LocalDate start, LocalDate end) {
 
         final Map<Person, List<Application>> overtimeApplicationsByPerson = applications.stream()


### PR DESCRIPTION
closes #4451

ToDo:
- [x] test
- [x] better create an overtime service method with an exclude of application by ids ?