### PR TITLE
Enable partial output while procession in thymeleaf...

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -36,9 +36,6 @@ spring:
     fallback-to-system-locale: false
   liquibase:
     change-log: classpath:/dbchangelogs/changelogmaster.xml
-  thymeleaf:
-    servlet:
-      produce-partial-output-while-processing: false
   threads:
     virtual:
       enabled: true


### PR DESCRIPTION
... if there is a site with forms and therefore a session is needed it is not possible to enable partial procession if session is not always true.
But now we do not have any "free" site with a form. We had one with the login page via the default login, but that one is gone and therefore we can use partial output. If there would be any other page with a form or something else, we would need to enable sessions 'always' for the given site.

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
