### PR TITLE
Added lithuanian public holidays

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayConfiguration.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayConfiguration.java
@@ -13,7 +13,7 @@ import java.util.Map;
 @Configuration
 class PublicHolidayConfiguration {
 
-    private static final List<String> COUNTRIES = List.of("de", "at", "ch", "gb", "gr", "mt", "it", "hr", "es", "nl");
+    private static final List<String> COUNTRIES = List.of("de", "at", "ch", "gb", "gr", "mt", "it", "hr", "es", "nl", "lt");
 
     @Bean
     Map<String, HolidayManager> holidayManagerMap() {

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/FederalState.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/FederalState.java
@@ -112,7 +112,9 @@ public enum FederalState {
     SPAIN_CANTABRIA("es", "cb"),
     SPAIN_VALENCIA("es", "vc"),
 
-    NETHERLANDS("nl", "nl");
+    NETHERLANDS("nl", "nl"),
+
+    LITHUANIA("lt", "lt");
 
     private final String[] codes;
 

--- a/src/main/resources/Holidays_lt.xml
+++ b/src/main/resources/Holidays_lt.xml
@@ -14,8 +14,10 @@
     <Fixed month="AUGUST" day="15" descriptionPropertiesKey="ASSUMPTION_DAY"/>
     <Fixed month="NOVEMBER" day="1" descriptionPropertiesKey="ALL_SAINTS"/>
     <Fixed month="NOVEMBER" day="2" descriptionPropertiesKey="ALL_SOULS" validFrom="2020"/>
+    <Fixed month="DECEMBER" day="24" descriptionPropertiesKey="CHRISTMAS_EVE" localizedType="UNOFFICIAL_HOLIDAY"/>
     <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS_EVE"/>
     <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="CHRISTMAS"/>
+    <Fixed month="DECEMBER" day="31" descriptionPropertiesKey="NEW_YEARS_EVE" localizedType="UNOFFICIAL_HOLIDAY"/>
     <ChristianHoliday type="EASTER" descriptionPropertiesKey="christian.EASTER"/>
     <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY"/>
   </Holidays>

--- a/src/main/resources/Holidays_lt.xml
+++ b/src/main/resources/Holidays_lt.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Configuration hierarchy="lt" description="Lithuania"
+               xmlns="https://focus_shift.de/jollyday/schema/holiday"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="https://focus_shift.de/jollyday/schema/holiday https://focus_shift.de/jollyday/schema/holiday/holiday.xsd">
+  <Holidays>
+    <Fixed month="JANUARY" day="1" descriptionPropertiesKey="NEW_YEAR"/>
+    <Fixed month="FEBRUARY" day="16" descriptionPropertiesKey="UNIFICATION"/>
+    <Fixed month="MARCH" day="11" descriptionPropertiesKey="INDEPENDENCE_DAY"/>
+    <Fixed month="MAY" day="1" descriptionPropertiesKey="LABOUR_DAY"/>
+    <Fixed month="JUNE" day="24" descriptionPropertiesKey="JOHANNIS_DAY"/>
+    <Fixed month="JULY" day="6" descriptionPropertiesKey="STATEHOOD"/>
+    <Fixed month="AUGUST" day="15" descriptionPropertiesKey="ASSUMPTION_DAY"/>
+    <Fixed month="NOVEMBER" day="1" descriptionPropertiesKey="ALL_SAINTS"/>
+    <Fixed month="NOVEMBER" day="2" descriptionPropertiesKey="ALL_SOULS" validFrom="2020"/>
+    <Fixed month="DECEMBER" day="25" descriptionPropertiesKey="CHRISTMAS_EVE"/>
+    <Fixed month="DECEMBER" day="26" descriptionPropertiesKey="CHRISTMAS"/>
+    <ChristianHoliday type="EASTER" descriptionPropertiesKey="christian.EASTER"/>
+    <ChristianHoliday type="EASTER_MONDAY" descriptionPropertiesKey="christian.EASTER_MONDAY"/>
+  </Holidays>
+</Configuration>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1108,6 +1108,7 @@ country.it=Italien
 country.hr=Kroatien
 country.es=Spanien
 country.nl=Niederlande
+country.lt=Litauen
 
 # No Federal States
 federalState.NONE=Keine Feiertagesregelung
@@ -1220,6 +1221,9 @@ federalState.SPAIN_VALENCIA=Valencia
 
 # Federal States Netherlands
 federalState.NETHERLANDS=Niederlande
+
+# Federal States Lithuania
+federalState.LITHUANIA=Litauen
 
 # DEPARTMENTS
 departments.header.title=Abteilungsübersicht

--- a/src/main/resources/messages_de_AT.properties
+++ b/src/main/resources/messages_de_AT.properties
@@ -1060,6 +1060,7 @@ country.it=Italien
 country.hr=Kroatien
 country.es=Spanien
 country.nl=Niederlande
+country.lt=Litauen
 
 # No Federal States
 federalState.NONE=Keine Feiertagesregelung
@@ -1172,6 +1173,9 @@ federalState.SPAIN_VALENCIA=Valencia
 
 # Federal States Netherlands
 federalState.NETHERLANDS=Niederlande
+
+# Federal States Lithuania
+federalState.LITHUANIA=Litauen
 
 # DEPARTMENTS
 departments.header.title=Abteilungsübersicht

--- a/src/main/resources/messages_el.properties
+++ b/src/main/resources/messages_el.properties
@@ -1005,6 +1005,7 @@ country.it=Ιταλία
 country.hr=Κροατία
 country.es=Ισπανία
 country.nl=Ολλανδία
+country.lt=Λιθουανία
 
 # No Federal States
 federalState.NONE=Κανένας κανονισμός επίσημων αργιών
@@ -1117,6 +1118,9 @@ federalState.SPAIN_VALENCIA=Valencia
 
 # Federal States Netherlands
 federalState.NETHERLANDS=Ολλανδία
+
+# Federal States Lithuania
+federalState.LITHUANIA=Λιθουανία
 
 # DEPARTMENTS
 departments.header.title=Επισκόπηση τμημάτων

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -1079,6 +1079,8 @@ country.it=Italy
 country.hr=Croatia
 country.es=Spain
 country.nl=The Netherlands
+country.lt=Lithuania
+
 
 # No Federal States
 federalState.NONE=No public holiday regulation
@@ -1191,6 +1193,9 @@ federalState.SPAIN_VALENCIA=Valencia
 
 # Federal States Netherlands
 federalState.NETHERLANDS=The Netherlands
+
+# Federal States Lithuania
+federalState.LITHUANIA=Lithuania
 
 # DEPARTMENTS
 departments.header.title=Departments overview

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/FederalStateTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/FederalStateTest.java
@@ -46,6 +46,7 @@ import static org.synyx.urlaubsverwaltung.workingtime.FederalState.GERMANY_SCHLE
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.GERMANY_THUERINGEN;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.GREECE_GREECE;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.ITALY;
+import static org.synyx.urlaubsverwaltung.workingtime.FederalState.LITHUANIA;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.MALTA;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.NETHERLANDS;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.NONE;
@@ -210,6 +211,8 @@ class FederalStateTest {
             Arguments.of(SPAIN_VALENCIA, "vc", null),
 
             Arguments.of(NETHERLANDS, "nl", null)
+
+            Arguments.of(LITHUANIA, "lt", null)
         );
     }
 
@@ -347,8 +350,9 @@ class FederalStateTest {
         final List<FederalState> hrFederalStates = Arrays.stream(FederalState.values()).filter(federalState -> "hr".equals(federalState.getCountry())).collect(toList());
         final List<FederalState> esFederalStates = Arrays.stream(FederalState.values()).filter(federalState -> "es".equals(federalState.getCountry())).collect(toList());
         final List<FederalState> nlFederalStates = Arrays.stream(FederalState.values()).filter(federalState -> "nl".equals(federalState.getCountry())).collect(toList());
+        final List<FederalState> ltFederalStates = Arrays.stream(FederalState.values()).filter(federalState -> "lt".equals(federalState.getCountry())).collect(toList());
 
-        assertThat(federalStatesTypesByCountry).hasSize(10)
+        assertThat(federalStatesTypesByCountry).hasSize(11)
             .contains(entry("de", germanyFederalStates))
             .contains(entry("at", austriaFederalStates))
             .contains(entry("ch", switzerlandFederalStates))
@@ -358,7 +362,7 @@ class FederalStateTest {
             .contains(entry("it", itFederalStates))
             .contains(entry("hr", hrFederalStates))
             .contains(entry("es", esFederalStates))
-            .contains(entry("hr", hrFederalStates))
-            .contains(entry("nl", nlFederalStates));
+            .contains(entry("nl", nlFederalStates))
+            .contains(entry("lt", ltFederalStates));
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/FederalStateTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/FederalStateTest.java
@@ -210,7 +210,7 @@ class FederalStateTest {
             Arguments.of(SPAIN_CANTABRIA, "cb", null),
             Arguments.of(SPAIN_VALENCIA, "vc", null),
 
-            Arguments.of(NETHERLANDS, "nl", null)
+            Arguments.of(NETHERLANDS, "nl", null),
 
             Arguments.of(LITHUANIA, "lt", null)
         );


### PR DESCRIPTION
Just added lithuanian public holidays to the tool (source: https://github.com/focus-shift/jollyday/blob/main/jollyday-core/src/main/resources/holidays/Holidays_lt.xml).

In FederalStateTest removed duplicated line
`.contains(entry("hr", hrFederalStates))`

Thank you for the active development on the tool.

closes #4837 