### PR TITLE
Fix immutable Set in public holiday

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysServiceImpl.java
@@ -13,6 +13,7 @@ import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeSettings;
 
 import java.time.LocalDate;
 import java.time.Month;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -90,7 +91,7 @@ public class PublicHolidaysServiceImpl implements PublicHolidaysService {
 
         final Set<Holiday> holidays = getHolidayManager(federalState)
             .map(holidayManager -> holidayManager.getHolidays(from, to, PUBLIC_HOLIDAY, federalState.getCodes()))
-            .orElseGet(Set::of);
+            .orElseGet(HashSet::new);
 
         final DateRange requestRange = new DateRange(from, to);
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysServiceImplTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.when;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.GERMANY_BADEN_WUERTTEMBERG;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.GERMANY_BAYERN_MUENCHEN;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.GERMANY_BERLIN;
+import static org.synyx.urlaubsverwaltung.workingtime.FederalState.NONE;
 
 @ExtendWith(MockitoExtension.class)
 class PublicHolidaysServiceImplTest {
@@ -202,6 +203,19 @@ class PublicHolidaysServiceImplTest {
         when(settingsService.getSettings()).thenReturn(new Settings());
 
         final List<PublicHoliday> publicHolidays = sut.getPublicHolidays(of(2020, JANUARY, 1), of(2023, DECEMBER, 31), GERMANY_BADEN_WUERTTEMBERG);
+
+        assertThat(publicHolidays).contains(
+            new PublicHoliday(LocalDate.of(2020, DECEMBER, 31), null, null),
+            new PublicHoliday(LocalDate.of(2021, DECEMBER, 31), null, null),
+            new PublicHoliday(LocalDate.of(2023, DECEMBER, 31), null, null));
+    }
+
+    @Test
+    void ensureGetPublicHolidaysReturnsWhenPersonHasNoPublicHolidaysDefined() {
+
+        when(settingsService.getSettings()).thenReturn(new Settings());
+
+        final List<PublicHoliday> publicHolidays = sut.getPublicHolidays(of(2020, JANUARY, 1), of(2023, DECEMBER, 31), NONE);
 
         assertThat(publicHolidays).contains(
             new PublicHoliday(LocalDate.of(2020, DECEMBER, 31), null, null),


### PR DESCRIPTION
If no public holidays are in use, and they get called, the code cannot add further public holiday because the set is immutable.

closes #4999 

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
