### PR TITLE
Change build image to builder-jammy-base to restore build mechanism a…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,6 +319,7 @@
             <env>
               <BPE_DEFAULT_BPL_JVM_CLASS_ADJUSTMENT>120%</BPE_DEFAULT_BPL_JVM_CLASS_ADJUSTMENT>
             </env>
+            <builder>paketobuildpacks/builder-jammy-base</builder>
           </image>
           <docker>
             <publishRegistry>


### PR DESCRIPTION
…s before spring boot 3.4

shell in run image is needed, the run image specified in Builder metadata should be used: builder-jammy-base-> run-jammy-base

see:
* https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.4-Release-Notes#paketo-tiny-builder-for-building-oci-images
* https://docs.spring.io/spring-boot/maven-plugin/build-image.html#build-image.build-image-goal.parameter-details.image

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
