### PR TITLE
Unnecessary parentheses

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/AbsencePeriod.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/AbsencePeriod.java
@@ -109,7 +109,7 @@ public class AbsencePeriod {
         }
 
         public boolean isHalfDayAbsence() {
-            return (this.morning == null && this.noon != null) || (this.morning != null && this.noon == null);
+            return this.morning == null && this.noon != null || this.morning != null && this.noon == null;
         }
 
         /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/account/AccountInteractionServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/account/AccountInteractionServiceImpl.java
@@ -199,7 +199,7 @@ class AccountInteractionServiceImpl implements AccountInteractionService {
      * calculate remaining vacation days starting from today's month, round to ceiling
      */
     private BigDecimal getRemainingVacationDaysForThisYear(LocalDate today, Integer defaultVacationDays) {
-        final double vacationDaysPerMonth = ((double) defaultVacationDays) / 12;
+        final double vacationDaysPerMonth = (double) defaultVacationDays / 12;
         final int remainingMonthForThisYear = 12 - (today.getMonthValue() - 1);
         return new BigDecimal((int) Math.ceil(vacationDaysPerMonth * remainingMonthForThisYear));
     }

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewController.java
@@ -481,7 +481,7 @@ class ApplicationForLeaveDetailsViewController implements HasLaunchpad {
         return responsiblePersonService.getResponsibleManagersOf(personOfInterest)
             .stream()
             .filter(not(isEqual(signedInUser)))
-            .filter(person -> person.hasRole(BOSS) || person.hasRole(SECOND_STAGE_AUTHORITY) || (person.hasRole(DEPARTMENT_HEAD) && application.hasStatus(WAITING)))
+            .filter(person -> person.hasRole(BOSS) || person.hasRole(SECOND_STAGE_AUTHORITY) || person.hasRole(DEPARTMENT_HEAD) && application.hasStatus(WAITING))
             .collect(toList());
     }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveFormValidator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveFormValidator.java
@@ -295,7 +295,7 @@ class ApplicationForLeaveFormValidator implements Validator {
             errors.reject(ERROR_PERIOD);
         }
 
-        if ((startTimeIsProvided && endTimeIsProvided) &&
+        if (startTimeIsProvided && endTimeIsProvided &&
             (endTime.isBefore(startTime) || endTime.equals(startTime))) {
             errors.reject(ERROR_PERIOD);
         }
@@ -311,7 +311,7 @@ class ApplicationForLeaveFormValidator implements Validator {
         final BigDecimal hours = applicationForLeave.getHours();
         final Integer minutes = applicationForLeave.getMinutes();
         final boolean overtimeFunctionIsActive = settings.getOvertimeSettings().isOvertimeActive();
-        final boolean overtimeReductionInputRequiredButNotProvided = overtimeFunctionIsActive && (hours == null && minutes == null);
+        final boolean overtimeReductionInputRequiredButNotProvided = overtimeFunctionIsActive && hours == null && minutes == null;
 
         if (overtimeReductionInputRequiredButNotProvided && !errors.hasFieldErrors(ATTRIBUTE_HOURS)) {
             errors.rejectValue(ATTRIBUTE_HOURS, ERROR_MISSING_HOURS);
@@ -324,7 +324,7 @@ class ApplicationForLeaveFormValidator implements Validator {
             errors.rejectValue(ATTRIBUTE_HOURS, ERROR_INVALID_HOURS);
         }
 
-        if (minutes != null && (minutes < 0 || (minutes == 0 && hoursNullOrZero))) {
+        if (minutes != null && (minutes < 0 || minutes == 0 && hoursNullOrZero)) {
             errors.rejectValue(ATTRIBUTE_MINUTES, ERROR_INVALID_HOURS);
         }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveFormViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveFormViewController.java
@@ -566,7 +566,7 @@ class ApplicationForLeaveFormViewController implements HasLaunchpad {
 
     private List<Person> getManagedPersons(Person signedInUser) {
 
-        if (signedInUser.hasRole(OFFICE) || (signedInUser.hasRole(BOSS) && signedInUser.hasRole(APPLICATION_ADD))) {
+        if (signedInUser.hasRole(OFFICE) || signedInUser.hasRole(BOSS) && signedInUser.hasRole(APPLICATION_ADD)) {
             return personService.getActivePersons();
         }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissionEvaluator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissionEvaluator.java
@@ -19,12 +19,12 @@ class ApplicationForLeavePermissionEvaluator {
 
     static boolean isAllowedToAllowWaitingApplication(Application application, Person signedInUser, boolean isDepartmentHeadOfPerson, boolean isSecondStageAuthorityOfPerson) {
         return application.hasStatus(WAITING)
-            && (signedInUser.hasRole(BOSS) || ((isDepartmentHeadOfPerson || isSecondStageAuthorityOfPerson) && !application.getPerson().equals(signedInUser)));
+            && (signedInUser.hasRole(BOSS) || (isDepartmentHeadOfPerson || isSecondStageAuthorityOfPerson) && !application.getPerson().equals(signedInUser));
     }
 
     static boolean isAllowedToAllowTemporaryAllowedApplication(Application application, Person signedInUser, boolean isSecondStageAuthorityOfPerson) {
         return application.hasStatus(TEMPORARY_ALLOWED)
-            && (signedInUser.hasRole(BOSS) || (isSecondStageAuthorityOfPerson && !application.getPerson().equals(signedInUser)));
+            && (signedInUser.hasRole(BOSS) || isSecondStageAuthorityOfPerson && !application.getPerson().equals(signedInUser));
     }
 
     static boolean isAllowedToRejectApplication(Application application, Person signedInUser, boolean isDepartmentHeadOfPerson, boolean isSecondStageAuthorityOfPerson) {
@@ -41,37 +41,37 @@ class ApplicationForLeavePermissionEvaluator {
 
     static boolean isAllowedToCancelApplication(Application application, Person signedInUser, boolean isDepartmentHeadOfPerson, boolean isSecondStageAuthorityOfPerson) {
         return (application.hasStatus(ALLOWED) || application.hasStatus(TEMPORARY_ALLOWED) || application.hasStatus(ALLOWED_CANCELLATION_REQUESTED))
-            && (signedInUser.hasRole(OFFICE) || ((signedInUser.hasRole(BOSS) || isDepartmentHeadOfPerson || isSecondStageAuthorityOfPerson) && signedInUser.hasRole(APPLICATION_CANCEL)));
+            && (signedInUser.hasRole(OFFICE) || (signedInUser.hasRole(BOSS) || isDepartmentHeadOfPerson || isSecondStageAuthorityOfPerson) && signedInUser.hasRole(APPLICATION_CANCEL));
     }
 
     static boolean isAllowedToCancelDirectlyApplication(Application application, Person signedInUser, boolean isDepartmentHeadOfPerson, boolean isSecondStageAuthorityOfPerson, boolean requiresApprovalToCancel) {
         return (application.hasStatus(WAITING) || application.hasStatus(ALLOWED) || application.hasStatus(TEMPORARY_ALLOWED) || application.hasStatus(ALLOWED_CANCELLATION_REQUESTED))
             && !requiresApprovalToCancel
-            && (application.getPerson().equals(signedInUser) || signedInUser.hasRole(OFFICE) || ((signedInUser.hasRole(BOSS) || isDepartmentHeadOfPerson || isSecondStageAuthorityOfPerson) && signedInUser.hasRole(APPLICATION_CANCEL)));
+            && (application.getPerson().equals(signedInUser) || signedInUser.hasRole(OFFICE) || (signedInUser.hasRole(BOSS) || isDepartmentHeadOfPerson || isSecondStageAuthorityOfPerson) && signedInUser.hasRole(APPLICATION_CANCEL));
     }
 
     static boolean isAllowedToStartCancellationRequest(Application application, Person signedInUser, boolean isDepartmentHeadOfPerson, boolean isSecondStageAuthorityOfPerson, boolean requiresApprovalToCancel) {
         return (application.hasStatus(ALLOWED) || application.hasStatus(TEMPORARY_ALLOWED) || application.hasStatus(ALLOWED_CANCELLATION_REQUESTED))
             && requiresApprovalToCancel
-            && !(signedInUser.hasRole(OFFICE) || ((signedInUser.hasRole(BOSS) || isDepartmentHeadOfPerson || isSecondStageAuthorityOfPerson) && signedInUser.hasRole(APPLICATION_CANCEL)));
+            && !(signedInUser.hasRole(OFFICE) || (signedInUser.hasRole(BOSS) || isDepartmentHeadOfPerson || isSecondStageAuthorityOfPerson) && signedInUser.hasRole(APPLICATION_CANCEL));
     }
 
     static boolean isAllowedToDeclineCancellationRequest(Application application, Person signedInUser, boolean isDepartmentHeadOfPerson, boolean isSecondStageAuthorityOfPerson) {
         return application.hasStatus(ALLOWED_CANCELLATION_REQUESTED)
-            && (signedInUser.hasRole(OFFICE) || ((signedInUser.hasRole(BOSS) || isDepartmentHeadOfPerson || isSecondStageAuthorityOfPerson) && signedInUser.hasRole(APPLICATION_CANCELLATION_REQUESTED)));
+            && (signedInUser.hasRole(OFFICE) || (signedInUser.hasRole(BOSS) || isDepartmentHeadOfPerson || isSecondStageAuthorityOfPerson) && signedInUser.hasRole(APPLICATION_CANCELLATION_REQUESTED));
     }
 
     static boolean isAllowedToEditApplication(Application application, Person signedInUser) {
-        return (application.hasStatus(WAITING) && application.getPerson().equals(signedInUser)) || signedInUser.hasRole(OFFICE);
+        return application.hasStatus(WAITING) && application.getPerson().equals(signedInUser) || signedInUser.hasRole(OFFICE);
     }
 
     static boolean isAllowedToRemindApplication(Application application, Person signedInUser, boolean isDepartmentHeadOfPerson, boolean isSecondStageAuthorityOfPerson) {
         return (application.hasStatus(WAITING) || application.hasStatus(TEMPORARY_ALLOWED))
-            && (application.getPerson().equals(signedInUser) && !(signedInUser.hasRole(BOSS) || isDepartmentHeadOfPerson || isSecondStageAuthorityOfPerson));
+            && application.getPerson().equals(signedInUser) && !(signedInUser.hasRole(BOSS) || isDepartmentHeadOfPerson || isSecondStageAuthorityOfPerson);
     }
 
     static boolean isAllowedToReferApplication(Application application, Person signedInUser, boolean isDepartmentHeadOfPerson, boolean isSecondStageAuthorityOfPerson) {
         return (application.hasStatus(WAITING) || application.hasStatus(TEMPORARY_ALLOWED))
-            && (signedInUser.hasRole(BOSS) || signedInUser.hasRole(OFFICE) || ((isDepartmentHeadOfPerson || isSecondStageAuthorityOfPerson) && !application.getPerson().equals(signedInUser)));
+            && (signedInUser.hasRole(BOSS) || signedInUser.hasRole(OFFICE) || (isDepartmentHeadOfPerson || isSecondStageAuthorityOfPerson) && !application.getPerson().equals(signedInUser));
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveViewController.java
@@ -158,7 +158,7 @@ class ApplicationForLeaveViewController implements HasLaunchpad {
 
     private static boolean isAllowedToAccessCancellationRequest(Person signedInUser) {
         return signedInUser.hasRole(OFFICE)
-            || (signedInUser.hasRole(APPLICATION_CANCELLATION_REQUESTED) && (signedInUser.hasAnyRole(BOSS, DEPARTMENT_HEAD, SECOND_STAGE_AUTHORITY)));
+            || signedInUser.hasRole(APPLICATION_CANCELLATION_REQUESTED) && signedInUser.hasAnyRole(BOSS, DEPARTMENT_HEAD, SECOND_STAGE_AUTHORITY);
     }
 
     private static boolean isAllowedToAccessOtherApplications(Person signedInUser) {
@@ -167,7 +167,7 @@ class ApplicationForLeaveViewController implements HasLaunchpad {
 
     private static boolean isAllowedToAccessSickNoteSubmissions(Person signedInUser) {
         return signedInUser.hasRole(OFFICE)
-            || (signedInUser.hasRole(SICK_NOTE_EDIT) && (signedInUser.hasAnyRole(BOSS, DEPARTMENT_HEAD, SECOND_STAGE_AUTHORITY)));
+            || signedInUser.hasRole(SICK_NOTE_EDIT) && signedInUser.hasAnyRole(BOSS, DEPARTMENT_HEAD, SECOND_STAGE_AUTHORITY);
     }
 
     private List<SubmittedSickNoteDto> mapToSickNoteDtoList(List<SubmittedSickNote> sickNotes, Locale locale) {
@@ -218,9 +218,9 @@ class ApplicationForLeaveViewController implements HasLaunchpad {
         final boolean isOwn = person.equals(signedInUser);
 
         final boolean isAllowedToEdit = isWaiting && isOwn;
-        final boolean isAllowedToTemporaryApprove = twoStageApproval && isWaiting && (isDepartmentHeadOfPerson && !isOwn) && !isBoss && !isSecondStageAuthorityOfPerson;
-        final boolean isAllowedToApprove = (isWaiting && (isBoss || ((isDepartmentHeadOfPerson || isSecondStageAuthorityOfPerson) && !isOwn))) || (isTemporaryAllowed && (isBoss || (isSecondStageAuthorityOfPerson && !isOwn)));
-        final boolean isAllowedToCancel = ((isWaiting || isTemporaryAllowed || isAllowed) && isOwn) || ((isWaiting || isTemporaryAllowed || isAllowed || isCancellationRequested) && isOffice);
+        final boolean isAllowedToTemporaryApprove = twoStageApproval && isWaiting && isDepartmentHeadOfPerson && !isOwn && !isBoss && !isSecondStageAuthorityOfPerson;
+        final boolean isAllowedToApprove = isWaiting && (isBoss || (isDepartmentHeadOfPerson || isSecondStageAuthorityOfPerson) && !isOwn) || isTemporaryAllowed && (isBoss || isSecondStageAuthorityOfPerson && !isOwn);
+        final boolean isAllowedToCancel = (isWaiting || isTemporaryAllowed || isAllowed) && isOwn || (isWaiting || isTemporaryAllowed || isAllowed || isCancellationRequested) && isOffice;
         final boolean isAllowedToReject = (isWaiting || isTemporaryAllowed) && !isOwn && (isBoss || isDepartmentHeadOfPerson || isSecondStageAuthorityOfPerson);
 
         return ApplicationForLeaveDto.builder()
@@ -316,7 +316,7 @@ class ApplicationForLeaveViewController implements HasLaunchpad {
         }
 
         final List<Application> cancellationRequests = new ArrayList<>();
-        if (signedInUser.hasRole(OFFICE) || (signedInUser.hasRole(BOSS) && signedInUser.hasRole(APPLICATION_CANCELLATION_REQUESTED))) {
+        if (signedInUser.hasRole(OFFICE) || signedInUser.hasRole(BOSS) && signedInUser.hasRole(APPLICATION_CANCELLATION_REQUESTED)) {
             cancellationRequests.addAll(applicationService.getForStates(List.of(ALLOWED_CANCELLATION_REQUESTED)));
         } else {
             if (signedInUser.hasRole(SECOND_STAGE_AUTHORITY) && signedInUser.hasRole(APPLICATION_CANCELLATION_REQUESTED)) {
@@ -436,7 +436,7 @@ class ApplicationForLeaveViewController implements HasLaunchpad {
 
     private List<Person> getPersonsForRelevantSubmittedSickNotes(Person signedInUser) {
 
-        if (signedInUser.hasRole(OFFICE) || (signedInUser.hasRole(BOSS) && signedInUser.hasRole(SICK_NOTE_EDIT))) {
+        if (signedInUser.hasRole(OFFICE) || signedInUser.hasRole(BOSS) && signedInUser.hasRole(SICK_NOTE_EDIT)) {
             return personService.getActivePersons().stream().filter(person -> !person.equals(signedInUser)).toList();
         }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImpl.java
@@ -412,8 +412,8 @@ class DepartmentServiceImpl implements DepartmentService {
     public boolean isPersonAllowedToManageDepartment(Person person, Department department) {
 
         return person.hasRole(OFFICE) || person.hasRole(BOSS) ||
-            (department.getDepartmentHeads().contains(person) && person.hasRole(DEPARTMENT_HEAD)) ||
-            (department.getSecondStageAuthorities().contains(person) && person.hasRole(SECOND_STAGE_AUTHORITY));
+            department.getDepartmentHeads().contains(person) && person.hasRole(DEPARTMENT_HEAD) ||
+            department.getSecondStageAuthorities().contains(person) && person.hasRole(SECOND_STAGE_AUTHORITY);
     }
 
     @Override

--- a/src/main/java/org/synyx/urlaubsverwaltung/overlap/OverlapService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overlap/OverlapService.java
@@ -230,7 +230,7 @@ public class OverlapService {
         }
 
         // check if intervals abut or gap
-        for (int i = 0; (i + 1) < listOfOverlaps.size(); i++) {
+        for (int i = 0; i + 1 < listOfOverlaps.size(); i++) {
             // if they don't abut, you can calculate the gap
             // test if end of interval is equals resp. one day plus of start of other interval
             // e.g. if period 1: 16.-18. and period 2: 19.-20 --> they abut

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimeServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimeServiceImpl.java
@@ -262,8 +262,8 @@ class OvertimeServiceImpl implements OvertimeService {
     public boolean isUserIsAllowedToWriteOvertime(Person signedInUser, Person personOfOvertime) {
         final OvertimeSettings overtimeSettings = settingsService.getSettings().getOvertimeSettings();
         return signedInUser.hasRole(OFFICE)
-            || (signedInUser.equals(personOfOvertime) && !overtimeSettings.isOvertimeWritePrivilegedOnly())
-            || (signedInUser.isPrivileged() && overtimeSettings.isOvertimeWritePrivilegedOnly());
+            || signedInUser.equals(personOfOvertime) && !overtimeSettings.isOvertimeWritePrivilegedOnly()
+            || signedInUser.isPrivileged() && overtimeSettings.isOvertimeWritePrivilegedOnly();
     }
 
     /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/web/OvertimeViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/web/OvertimeViewController.java
@@ -289,7 +289,7 @@ public class OvertimeViewController implements HasLaunchpad {
 
         final OvertimeSettings overtimeSettings = settingsService.getSettings().getOvertimeSettings();
 
-        boolean canAddOvertimeForAnotherUser = signedInUser.hasRole(OFFICE) || (signedInUser.isPrivileged() && overtimeSettings.isOvertimeWritePrivilegedOnly());
+        boolean canAddOvertimeForAnotherUser = signedInUser.hasRole(OFFICE) || signedInUser.isPrivileged() && overtimeSettings.isOvertimeWritePrivilegedOnly();
         model.addAttribute("canAddOvertimeForAnotherUser", canAddOvertimeForAnotherUser);
 
         model.addAttribute("overtimeReductionPossible", overtimeSettings.isOvertimeReductionWithoutApplicationActive());

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/UserApiMethodSecurity.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/UserApiMethodSecurity.java
@@ -57,6 +57,6 @@ public class UserApiMethodSecurity {
         }
 
         final String usernameToCheck = person.get().getUsername();
-        return (usernameToCheck != null) && usernameToCheck.equals(authentication.getName());
+        return usernameToCheck != null && usernameToCheck.equals(authentication.getName());
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewController.java
@@ -167,7 +167,7 @@ class SickNoteViewController implements HasLaunchpad {
             model.addAttribute("comments", comments);
 
             model.addAttribute("canAcceptSickNote", isOffice || isAllowedToEditSickNote);
-            model.addAttribute("canEditSickNote", isOffice || isAllowedToEditSickNote || (isSamePerson && sickNote.isSubmitted()));
+            model.addAttribute("canEditSickNote", isOffice || isAllowedToEditSickNote || isSamePerson && sickNote.isSubmitted());
             model.addAttribute("canConvertSickNote", isOffice);
             model.addAttribute("canDeleteSickNote", isOffice || isPersonAllowedToExecuteRoleOn(signedInUser, SICK_NOTE_CANCEL, sickNotePerson));
             model.addAttribute("canCommentSickNote", isOffice || isPersonAllowedToExecuteRoleOn(signedInUser, SICK_NOTE_COMMENT, sickNotePerson));
@@ -219,7 +219,7 @@ class SickNoteViewController implements HasLaunchpad {
         if (userIsAllowedToSubmitSickNotes) {
             final boolean noRedirect = noExtensionRedirect != null && (noExtensionRedirect.isEmpty() || "true".equalsIgnoreCase(noExtensionRedirect));
             final Optional<SickNote> sickNoteOfYesterdayOrLastWorkDay = sickNoteService.getSickNoteOfYesterdayOrLastWorkDay(sickNotePerson);
-            if (!noRedirect && (sickNoteOfYesterdayOrLastWorkDay.isPresent() && sickNoteOfYesterdayOrLastWorkDay.get().getDayLength().isFull())) {
+            if (!noRedirect && sickNoteOfYesterdayOrLastWorkDay.isPresent() && sickNoteOfYesterdayOrLastWorkDay.get().getDayLength().isFull()) {
                 LOG.info("sick note of last work day found");
                 return "redirect:/web/sicknote/extend";
             } else {
@@ -285,7 +285,7 @@ class SickNoteViewController implements HasLaunchpad {
         final boolean allowedToSubmitSickNotes = settingsService.getSettings().getSickNoteSettings().getUserIsAllowedToSubmitSickNotes();
 
         final SickNote updatedSickNote;
-        if (signedInUser.hasAnyRole(OFFICE, SICK_NOTE_ADD) || (personIsApplier && !allowedToSubmitSickNotes)) {
+        if (signedInUser.hasAnyRole(OFFICE, SICK_NOTE_ADD) || personIsApplier && !allowedToSubmitSickNotes) {
             updatedSickNote = sickNoteInteractionService.create(sickNote, signedInUser, sickNoteFormDto.getComment());
         } else {
             updatedSickNote = sickNoteInteractionService.submit(sickNote, signedInUser, sickNoteFormDto.getComment());

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/statistics/SickNoteStatisticsService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/statistics/SickNoteStatisticsService.java
@@ -52,7 +52,7 @@ public class SickNoteStatisticsService {
 
     private List<SickNote> getSickNotes(Person person, LocalDate from, LocalDate to) {
 
-        if (person.hasRole(OFFICE) || (person.hasRole(BOSS) && person.hasRole(SICK_NOTE_VIEW))) {
+        if (person.hasRole(OFFICE) || person.hasRole(BOSS) && person.hasRole(SICK_NOTE_VIEW)) {
             return sickNoteService.getAllActiveByPeriod(from, to);
         }
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveFormValidatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveFormValidatorTest.java
@@ -727,7 +727,7 @@ class ApplicationForLeaveFormValidatorTest {
         when(vacationTypeService.getById(3L))
             .thenReturn(Optional.of(ProvidedVacationType.builder(new StaticMessageSource()).id(3L).messageKey("message_key_3").category(UNPAIDLEAVE).build()));
 
-        Consumer<ApplicationForLeaveFormVacationTypeDto> assertHoursNotMandatory = (vacationTypeDto) -> {
+        Consumer<ApplicationForLeaveFormVacationTypeDto> assertHoursNotMandatory = vacationTypeDto -> {
             appForm.setVacationType(vacationTypeDto);
             appForm.setHours(null);
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/comment/ApplicationCommentEntityTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/comment/ApplicationCommentEntityTest.java
@@ -18,7 +18,7 @@ class ApplicationCommentEntityTest {
     @Test
     void ensureDateIsSetOnInitialization() {
 
-        Consumer<ApplicationCommentEntity> assertDateIsSetToToday = (comment) -> {
+        Consumer<ApplicationCommentEntity> assertDateIsSetToToday = comment -> {
             assertThat(comment.getDate()).isEqualTo(Instant.now(Clock.systemUTC()).truncatedTo(DAYS));
         };
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/web/OvertimeFormValidatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/web/OvertimeFormValidatorTest.java
@@ -493,7 +493,7 @@ class OvertimeFormValidatorTest {
         when(overtimeService.getLeftOvertimeForPerson(any(Person.class))).thenReturn(Duration.ZERO);
 
         final OvertimeForm overtimeForm = new OvertimeForm(createOvertimeRecord());
-        Consumer<String> assertMayBeEmpty = (comment) -> {
+        Consumer<String> assertMayBeEmpty = comment -> {
             overtimeForm.setComment(comment);
 
             sut.validate(overtimeForm, errors);

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sickdays/SickDaysDetailedStatisticsTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sickdays/SickDaysDetailedStatisticsTest.java
@@ -40,7 +40,7 @@ class SickDaysDetailedStatisticsTest {
         final Map<LocalDate, WorkingDayInformation> workingTimes = buildWorkingTimeByDate(
             LocalDate.of(2022, 1, 1),
             LocalDate.of(2022, 12, 31),
-            (date) -> new WorkingDayInformation(FULL, WORKDAY, WORKDAY)
+            date -> new WorkingDayInformation(FULL, WORKDAY, WORKDAY)
         );
         final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(workingTimes);
 
@@ -142,7 +142,7 @@ class SickDaysDetailedStatisticsTest {
         final Map<LocalDate, WorkingDayInformation> workingTimes = buildWorkingTimeByDate(
             LocalDate.of(2022, 1, 1),
             LocalDate.of(2022, 12, 31),
-            (date) -> new WorkingDayInformation(FULL, WORKDAY, WORKDAY)
+            date -> new WorkingDayInformation(FULL, WORKDAY, WORKDAY)
         );
         final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(workingTimes);
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sickdays/SickDaysOverviewViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sickdays/SickDaysOverviewViewControllerTest.java
@@ -185,7 +185,7 @@ class SickDaysOverviewViewControllerTest {
         final Map<LocalDate, WorkingDayInformation> workingTimes = buildWorkingTimeByDate(
             LocalDate.of(2019, 1, 1),
             LocalDate.of(2019, 12, 31),
-            (date) -> new WorkingDayInformation(FULL, WORKDAY, WORKDAY)
+            date -> new WorkingDayInformation(FULL, WORKDAY, WORKDAY)
         );
         final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(workingTimes);
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteTest.java
@@ -33,7 +33,7 @@ class SickNoteTest {
         final Map<LocalDate, WorkingDayInformation> workingTimes = buildWorkingTimeByDate(
             LocalDate.of(2022, JUNE, 1),
             LocalDate.of(2022, JUNE, 30),
-            (date) -> new WorkingDayInformation(FULL, WORKDAY, WORKDAY)
+            date -> new WorkingDayInformation(FULL, WORKDAY, WORKDAY)
         );
         final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(workingTimes);
 
@@ -56,7 +56,7 @@ class SickNoteTest {
         final Map<LocalDate, WorkingDayInformation> workingTimes = buildWorkingTimeByDate(
             LocalDate.of(2022, JUNE, 1),
             LocalDate.of(2022, JUNE, 30),
-            (date) -> new WorkingDayInformation(FULL, WORKDAY, WORKDAY)
+            date -> new WorkingDayInformation(FULL, WORKDAY, WORKDAY)
         );
         final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(workingTimes);
 
@@ -104,7 +104,7 @@ class SickNoteTest {
         final Map<LocalDate, WorkingDayInformation> workingTimes = buildWorkingTimeByDate(
             LocalDate.of(2022, JUNE, 1),
             LocalDate.of(2022, JUNE, 30),
-            (date) -> new WorkingDayInformation(FULL, WORKDAY, WORKDAY)
+            date -> new WorkingDayInformation(FULL, WORKDAY, WORKDAY)
         );
         final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(workingTimes);
 
@@ -129,7 +129,7 @@ class SickNoteTest {
         final Map<LocalDate, WorkingDayInformation> workingTimes = buildWorkingTimeByDate(
             LocalDate.of(2022, JUNE, 1),
             LocalDate.of(2022, JUNE, 30),
-            (date) -> new WorkingDayInformation(FULL, WORKDAY, WORKDAY)
+            date -> new WorkingDayInformation(FULL, WORKDAY, WORKDAY)
         );
         final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(workingTimes);
 
@@ -279,7 +279,7 @@ class SickNoteTest {
         final Map<LocalDate, WorkingDayInformation> workingTimes = buildWorkingTimeByDate(
             LocalDate.of(2022, JANUARY, 1),
             LocalDate.of(2022, DECEMBER, 31),
-            (date) -> new WorkingDayInformation(FULL, WORKDAY, WORKDAY)
+            date -> new WorkingDayInformation(FULL, WORKDAY, WORKDAY)
         );
         final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(workingTimes);
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/ApplicationForLeaveUIIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/ApplicationForLeaveUIIT.java
@@ -154,7 +154,7 @@ class ApplicationForLeaveUIIT {
         navigationPage.logout();
 
         page.navigate("http://localhost:" + port + "/oauth2/authorization/keycloak");
-        loginPage.login(new LoginPage.Credentials(userPerson.getEmail(), (userPerson.getEmail())));
+        loginPage.login(new LoginPage.Credentials(userPerson.getEmail(), userPerson.getEmail()));
 
         assertThat(overviewPage.isVisibleForPerson(userPerson.getNiceName(), LocalDate.now().getYear())).isTrue();
 


### PR DESCRIPTION
Parentheses are considered unnecessary if the evaluation order of an expression remains unchanged after you remove the parentheses.

run: https://www.jetbrains.com/help/inspectopedia/UnnecessaryParentheses.html