### PR TITLE
make repubish events reusable

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/extension/application/ApplicationEventRepublisher.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/extension/application/ApplicationEventRepublisher.java
@@ -3,59 +3,40 @@ package org.synyx.urlaubsverwaltung.extension.application;
 import org.slf4j.Logger;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.event.ApplicationStartedEvent;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.synyx.urlaubsverwaltung.application.application.ApplicationAllowedEvent;
 import org.synyx.urlaubsverwaltung.application.application.ApplicationService;
-import org.synyx.urlaubsverwaltung.tenancy.configuration.single.ConditionalOnSingleTenantMode;
 
-import java.time.Clock;
 import java.time.LocalDate;
 
 import static java.lang.invoke.MethodHandles.lookup;
-import static java.time.temporal.TemporalAdjusters.lastDayOfYear;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.synyx.urlaubsverwaltung.application.application.ApplicationStatus.ALLOWED;
 
 @Component
 @ConditionalOnProperty(value = "uv.extensions.application.republish.enabled", havingValue = "true")
 @ConditionalOnBean(ApplicationEventHandlerExtension.class)
-@ConditionalOnSingleTenantMode
 public class ApplicationEventRepublisher {
 
     private static final Logger LOG = getLogger(lookup().lookupClass());
 
     private final ApplicationService applicationService;
     private final ApplicationEventHandlerExtension applicationEventHandlerExtension;
-    private final Clock clock;
 
-    ApplicationEventRepublisher(ApplicationService applicationService, ApplicationEventHandlerExtension applicationEventHandlerExtension, Clock clock) {
+    ApplicationEventRepublisher(ApplicationService applicationService, ApplicationEventHandlerExtension applicationEventHandlerExtension) {
         this.applicationService = applicationService;
         this.applicationEventHandlerExtension = applicationEventHandlerExtension;
-        this.clock = clock;
     }
 
-    @Async
-    @EventListener(ApplicationStartedEvent.class)
-    void republishEvents() {
-
+    public void republishEvents(LocalDate start, LocalDate end) {
         LOG.info("Republishing all events with type=ApplicationAllowedEvent");
-
-        final LocalDate now = LocalDate.now(clock);
-
-        final LocalDate startOfYear = now.withDayOfYear(1);
-        final LocalDate endOfYear = startOfYear.with(lastDayOfYear());
-
-        applicationService.getApplicationsForACertainPeriodAndState(startOfYear, endOfYear, ALLOWED)
+        applicationService.getApplicationsForACertainPeriodAndState(start, end, ALLOWED)
             .stream()
             .map(ApplicationAllowedEvent::of)
             .forEach(event -> {
                 LOG.info("Publishing ApplicationAllowedEvent with id={} for personId={} with startDate={} and endDate={}", event.application().getId(), event.application().getPerson().getId(), event.application().getStartDate(), event.application().getEndDate());
                 applicationEventHandlerExtension.on(event);
             });
-
         LOG.info("Republished all events with type=ApplicationAllowedEvent");
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/extension/application/ApplicationEventRepublisherSingleTenant.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/extension/application/ApplicationEventRepublisherSingleTenant.java
@@ -1,0 +1,39 @@
+package org.synyx.urlaubsverwaltung.extension.application;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.synyx.urlaubsverwaltung.tenancy.configuration.single.ConditionalOnSingleTenantMode;
+
+import java.time.Clock;
+import java.time.LocalDate;
+
+import static java.time.temporal.TemporalAdjusters.lastDayOfYear;
+
+@Component
+@ConditionalOnProperty(value = "uv.extensions.application.republish.enabled", havingValue = "true")
+@ConditionalOnBean(ApplicationEventHandlerExtension.class)
+@ConditionalOnSingleTenantMode
+class ApplicationEventRepublisherSingleTenant {
+
+    private final ApplicationEventRepublisher applicationEventRepublisher;
+    private final Clock clock;
+
+    ApplicationEventRepublisherSingleTenant(ApplicationEventRepublisher applicationEventRepublisher, Clock clock) {
+        this.applicationEventRepublisher = applicationEventRepublisher;
+        this.clock = clock;
+    }
+
+    @Async
+    @EventListener(ApplicationStartedEvent.class)
+    public void republishEvents() {
+        final LocalDate now = LocalDate.now(clock);
+        final LocalDate startOfYear = now.withDayOfYear(1);
+        final LocalDate endOfYear = startOfYear.with(lastDayOfYear());
+
+        applicationEventRepublisher.republishEvents(startOfYear, endOfYear);
+    }
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/extension/sicknote/SickNoteEventRepublisher.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/extension/sicknote/SickNoteEventRepublisher.java
@@ -3,58 +3,39 @@ package org.synyx.urlaubsverwaltung.extension.sicknote;
 import org.slf4j.Logger;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.event.ApplicationStartedEvent;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteCreatedEvent;
 import org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteService;
-import org.synyx.urlaubsverwaltung.tenancy.configuration.single.ConditionalOnSingleTenantMode;
 
-import java.time.Clock;
 import java.time.LocalDate;
 
 import static java.lang.invoke.MethodHandles.lookup;
-import static java.time.temporal.TemporalAdjusters.lastDayOfYear;
 import static org.slf4j.LoggerFactory.getLogger;
 
 @Component
 @ConditionalOnProperty(value = "uv.extensions.sicknote.republish.enabled", havingValue = "true")
 @ConditionalOnBean(SickNoteEventHandlerExtension.class)
-@ConditionalOnSingleTenantMode
 public class SickNoteEventRepublisher {
 
     private static final Logger LOG = getLogger(lookup().lookupClass());
 
     private final SickNoteService sickNoteService;
     private final SickNoteEventHandlerExtension sickNoteEventHandlerExtension;
-    private final Clock clock;
 
-    SickNoteEventRepublisher(SickNoteService sickNoteService, SickNoteEventHandlerExtension sickNoteEventHandlerExtension, Clock clock) {
+    SickNoteEventRepublisher(SickNoteService sickNoteService, SickNoteEventHandlerExtension sickNoteEventHandlerExtension) {
         this.sickNoteService = sickNoteService;
         this.sickNoteEventHandlerExtension = sickNoteEventHandlerExtension;
-        this.clock = clock;
     }
 
-    @Async
-    @EventListener(ApplicationStartedEvent.class)
-    void republishEvents() {
-
+    public void republishEvents(LocalDate start, LocalDate end) {
         LOG.info("Republishing all events with type sickNoteCreatedEvent");
-
-        final LocalDate now = LocalDate.now(clock);
-
-        final LocalDate startOfYear = now.withDayOfYear(1);
-        final LocalDate endOfYear = startOfYear.with(lastDayOfYear());
-
-        sickNoteService.getAllActiveByPeriod(startOfYear, endOfYear)
+        sickNoteService.getAllActiveByPeriod(start, end)
             .stream()
             .map(SickNoteCreatedEvent::of)
             .forEach(event -> {
                 LOG.info("Publishing sickNoteCreatedEvent with id={} for personId={} with startDate={} and endDate={}", event.sickNote().getId(), event.sickNote().getPerson().getId(), event.sickNote().getStartDate(), event.sickNote().getEndDate());
                 sickNoteEventHandlerExtension.on(event);
             });
-
         LOG.info("Republished all events with type=SickNoteCreatedEvent");
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/extension/sicknote/SickNoteEventRepublisherSingleTenant.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/extension/sicknote/SickNoteEventRepublisherSingleTenant.java
@@ -1,0 +1,39 @@
+package org.synyx.urlaubsverwaltung.extension.sicknote;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.synyx.urlaubsverwaltung.tenancy.configuration.single.ConditionalOnSingleTenantMode;
+
+import java.time.Clock;
+import java.time.LocalDate;
+
+import static java.time.temporal.TemporalAdjusters.lastDayOfYear;
+
+@Component
+@ConditionalOnProperty(value = "uv.extensions.sicknote.republish.enabled", havingValue = "true")
+@ConditionalOnBean(SickNoteEventHandlerExtension.class)
+@ConditionalOnSingleTenantMode
+class SickNoteEventRepublisherSingleTenant {
+
+    private final SickNoteEventRepublisher sickNoteEventRepublisher;
+    private final Clock clock;
+
+    SickNoteEventRepublisherSingleTenant(SickNoteEventRepublisher sickNoteEventRepublisher, Clock clock) {
+        this.sickNoteEventRepublisher = sickNoteEventRepublisher;
+        this.clock = clock;
+    }
+
+    @Async
+    @EventListener(ApplicationStartedEvent.class)
+    public void republishEvents() {
+        final LocalDate now = LocalDate.now(clock);
+        final LocalDate startOfYear = now.withDayOfYear(1);
+        final LocalDate endOfYear = startOfYear.with(lastDayOfYear());
+
+        sickNoteEventRepublisher.republishEvents(startOfYear, endOfYear);
+    }
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/extension/vacationtype/VacationTypeEventRepublisher.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/extension/vacationtype/VacationTypeEventRepublisher.java
@@ -3,14 +3,10 @@ package org.synyx.urlaubsverwaltung.extension.vacationtype;
 import org.slf4j.Logger;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.event.ApplicationStartedEvent;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.synyx.urlaubsverwaltung.application.vacationtype.VacationType;
 import org.synyx.urlaubsverwaltung.application.vacationtype.VacationTypeService;
 import org.synyx.urlaubsverwaltung.application.vacationtype.VacationTypeUpdatedEvent;
-import org.synyx.urlaubsverwaltung.tenancy.configuration.single.ConditionalOnSingleTenantMode;
 
 import static java.lang.invoke.MethodHandles.lookup;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -18,8 +14,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 @Component
 @ConditionalOnProperty(value = "uv.extensions.vacationtype.republish.enabled", havingValue = "true")
 @ConditionalOnBean(VacationTypeEventHandlerExtension.class)
-@ConditionalOnSingleTenantMode
-class VacationTypeEventRepublisher {
+public class VacationTypeEventRepublisher {
 
     private static final Logger LOG = getLogger(lookup().lookupClass());
 
@@ -32,12 +27,8 @@ class VacationTypeEventRepublisher {
         this.vacationTypeEventHandlerExtension = vacationTypeEventHandlerExtension;
     }
 
-    @Async
-    @EventListener(ApplicationStartedEvent.class)
-    void republishEvents() {
-
+    public void republishEvents() {
         LOG.info("Republishing all events with type=VacationTypeUpdatedEvent");
-
         vacationTypeService.getAllVacationTypes()
             .stream()
             .map(VacationTypeUpdatedEvent::of)
@@ -47,7 +38,6 @@ class VacationTypeEventRepublisher {
                     event.id(), updatedVacationType.getId(), updatedVacationType.getCategory(), updatedVacationType.isActive(), updatedVacationType.isRequiresApprovalToApply());
                 vacationTypeEventHandlerExtension.onVacationTypeUpdated(event);
             });
-
         LOG.info("Republished all events with type=VacationTypeUpdatedEvent");
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/extension/vacationtype/VacationTypeEventRepublisherSingleTenant.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/extension/vacationtype/VacationTypeEventRepublisherSingleTenant.java
@@ -1,0 +1,28 @@
+package org.synyx.urlaubsverwaltung.extension.vacationtype;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.synyx.urlaubsverwaltung.tenancy.configuration.single.ConditionalOnSingleTenantMode;
+
+@Component
+@ConditionalOnProperty(value = "uv.extensions.vacationtype.republish.enabled", havingValue = "true")
+@ConditionalOnBean(VacationTypeEventHandlerExtension.class)
+@ConditionalOnSingleTenantMode
+class VacationTypeEventRepublisherSingleTenant {
+
+    private final VacationTypeEventRepublisher vacationTypeEventRepublisher;
+
+    VacationTypeEventRepublisherSingleTenant(VacationTypeEventRepublisher vacationTypeEventRepublisher) {
+        this.vacationTypeEventRepublisher = vacationTypeEventRepublisher;
+    }
+
+    @Async
+    @EventListener(ApplicationStartedEvent.class)
+    public void republishEvents() {
+        vacationTypeEventRepublisher.republishEvents();
+    }
+}


### PR DESCRIPTION
split the triggering of republish events from the actual republish

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
