### PR TITLE
ApplicationEventHandlerExtension: Fill translationKey for ProvidedVacationType

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/extension/application/ApplicationEventHandlerExtension.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/extension/application/ApplicationEventHandlerExtension.java
@@ -19,6 +19,7 @@ import org.synyx.urlaubsverwaltung.application.application.Application;
 import org.synyx.urlaubsverwaltung.application.application.ApplicationAllowedEvent;
 import org.synyx.urlaubsverwaltung.application.application.ApplicationCancelledEvent;
 import org.synyx.urlaubsverwaltung.application.application.ApplicationCreatedFromSickNoteEvent;
+import org.synyx.urlaubsverwaltung.application.vacationtype.ProvidedVacationType;
 import org.synyx.urlaubsverwaltung.application.vacationtype.VacationType;
 import org.synyx.urlaubsverwaltung.person.Person;
 
@@ -171,6 +172,7 @@ public class ApplicationEventHandlerExtension {
             .requiresApprovalToCancel(vacationType.isRequiresApprovalToCancel())
             .color(vacationType.getColor().name())
             .visibleToEveryone(vacationType.isVisibleToEveryone())
+            .translationKey(getTranslationKey(vacationType))
             .build();
     }
 
@@ -230,5 +232,12 @@ public class ApplicationEventHandlerExtension {
 
     private static Predicate<AbsencePeriod> isNoon(org.synyx.urlaubsverwaltung.period.DayLength dayLength) {
         return absencePeriod -> dayLength.isNoon() && absencePeriod.getAbsenceRecords().stream().allMatch(absenceRecord -> absenceRecord.getNoon().isPresent());
+    }
+
+    private static String getTranslationKey(VacationType<?> vacationType) {
+        if (vacationType instanceof ProvidedVacationType providedVacationType) {
+            return providedVacationType.getMessageKey();
+        }
+        return null;
     }
 }


### PR DESCRIPTION
use-case: filtering messages based on this translationKey ... having this value with null, doesn't allow that use-case.

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
