### PR TITLE
Fix: Absence endpoint HATEOAS links

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/AbsenceDto.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/AbsenceDto.java
@@ -1,11 +1,18 @@
 package org.synyx.urlaubsverwaltung.absence;
 
 import org.springframework.hateoas.RepresentationModel;
+import org.synyx.urlaubsverwaltung.application.vacationtype.VacationCategory;
 import org.synyx.urlaubsverwaltung.period.DayLength;
 
 import java.time.LocalDate;
 
 import static java.time.format.DateTimeFormatter.ofPattern;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+import static org.synyx.urlaubsverwaltung.absence.AbsenceDto.AbsenceType.NO_WORKDAY;
+import static org.synyx.urlaubsverwaltung.absence.AbsenceDto.AbsenceType.PUBLIC_HOLIDAY;
+import static org.synyx.urlaubsverwaltung.absence.AbsenceDto.AbsenceType.SICK_NOTE;
+import static org.synyx.urlaubsverwaltung.absence.AbsenceDto.AbsenceType.VACATION;
 import static org.synyx.urlaubsverwaltung.api.RestApiDateFormat.DATE_PATTERN;
 
 /**
@@ -29,15 +36,28 @@ public class AbsenceDto extends RepresentationModel<AbsenceDto> {
     private final String category;
     private final Long typeId;
 
-    AbsenceDto(LocalDate date, AbsenceType absenceType, Long id, String status, DayLength dayLength, String category, Long typeId) {
+    AbsenceDto(LocalDate date, DayLength dayLength, AbsencePeriod.RecordInfo recordInfo) {
         this.date = date.format(ofPattern(DATE_PATTERN));
-        this.absenceType = absenceType;
-        this.id = id;
-        this.status = status;
+        this.absenceType = toAbsenceTypes(recordInfo.getAbsenceType());
+        this.id = recordInfo.getId().orElse(null);
+        this.status = recordInfo.getStatus().name();
         this.absent = dayLength.name();
         this.absentNumeric = dayLength.getDuration().doubleValue();
-        this.category = category;
-        this.typeId = typeId;
+        this.category = recordInfo.getCategory().orElse(null);
+        this.typeId = recordInfo.getTypeId().orElse(null);
+
+        if (VacationCategory.OVERTIME.name().equals(category) && id != null) {
+            this.add(linkTo(methodOn(OvertimeAbsenceApiController.class).overtimeAbsence(recordInfo.getPerson().getId(), id)).withRel("overtime"));
+        }
+    }
+
+    private AbsenceDto.AbsenceType toAbsenceTypes(AbsencePeriod.AbsenceType genericAbsenceType) {
+        return switch (genericAbsenceType) {
+            case VACATION -> VACATION;
+            case SICK -> SICK_NOTE;
+            case NO_WORKDAY -> NO_WORKDAY;
+            case PUBLIC_HOLIDAY -> PUBLIC_HOLIDAY;
+        };
     }
 
     public String getDate() {

--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/AbsencesDto.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/AbsencesDto.java
@@ -1,8 +1,10 @@
 package org.synyx.urlaubsverwaltung.absence;
 
+import org.springframework.hateoas.RepresentationModel;
+
 import java.util.List;
 
-public class AbsencesDto {
+public class AbsencesDto extends RepresentationModel<AbsencesDto> {
 
     private final List<AbsenceDto> absences;
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/absence/AbsenceApiControllerIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/absence/AbsenceApiControllerIT.java
@@ -107,8 +107,7 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "absenceType": "VACATION",
                           "category": "HOLIDAY",
                           "typeId": 1,
-                          "status": "WAITING",
-                          "links": []
+                          "status": "WAITING"
                         }
                     ]
                 }
@@ -149,8 +148,7 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "absenceType": "VACATION",
                           "category": "HOLIDAY",
                           "typeId": 1,
-                          "status": "WAITING",
-                          "links": []
+                          "status": "WAITING"
                         }
                     ]
                 }
@@ -191,8 +189,7 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "absenceType": "VACATION",
                           "category": "HOLIDAY",
                           "typeId": 1,
-                          "status": "WAITING",
-                          "links": []
+                          "status": "WAITING"
                         }
                     ]
                 }
@@ -235,12 +232,11 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "category": "OVERTIME",
                           "typeId": 1,
                           "status": "WAITING",
-                          "links": [
-                              {
-                                "rel": "overtime",
+                          "_links": {
+                             "overtime": {
                                 "href": "http://localhost/api/persons/23/absences/42/overtime"
                               }
-                          ]
+                          }
                         }
                     ]
                 }
@@ -283,8 +279,7 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "absenceType": "SICK_NOTE",
                           "category": "SICK_NOTE",
                           "typeId": 1,
-                          "status": "ACTIVE",
-                          "links": []
+                          "status": "ACTIVE"
                         }
                     ]
                 }
@@ -325,8 +320,7 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "absenceType": "SICK_NOTE",
                           "category": "SICK_NOTE",
                           "typeId": 1,
-                          "status": "ACTIVE",
-                          "links": []
+                          "status": "ACTIVE"
                         }
                     ]
                 }
@@ -367,8 +361,7 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "absenceType": "SICK_NOTE",
                           "category": "SICK_NOTE",
                           "typeId": 1,
-                          "status": "ACTIVE",
-                          "links": []
+                          "status": "ACTIVE"
                         }
                     ]
                 }
@@ -411,8 +404,7 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "absenceType": "VACATION",
                           "category": "HOLIDAY",
                           "typeId": 1,
-                          "status": "WAITING",
-                          "links": []
+                          "status": "WAITING"
                         },
                         {
                           "date": "2016-01-02",
@@ -422,8 +414,7 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "absenceType": "SICK_NOTE",
                           "category": "SICK_NOTE",
                           "typeId": 1,
-                          "status": "ACTIVE",
-                          "links": []
+                          "status": "ACTIVE"
                         }
                     ]
                 }
@@ -465,8 +456,7 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "absenceType": "SICK_NOTE",
                           "category": "SICK_NOTE",
                           "typeId": 1,
-                          "status": "ACTIVE",
-                          "links": []
+                          "status": "ACTIVE"
                         },
                         {
                           "date": "2016-01-02",
@@ -476,8 +466,7 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "absenceType": "VACATION",
                           "category": "HOLIDAY",
                           "typeId": 1,
-                          "status": "WAITING",
-                          "links": []
+                          "status": "WAITING"
                         }
                     ]
                 }
@@ -520,8 +509,7 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "absenceType": "VACATION",
                           "category": "HOLIDAY",
                           "typeId": 1,
-                          "status": "WAITING",
-                          "links": []
+                          "status": "WAITING"
                         },
                         {
                           "date": "2016-12-24",
@@ -531,8 +519,7 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "absenceType": "PUBLIC_HOLIDAY",
                           "category": null,
                           "typeId": null,
-                          "status": "ACTIVE",
-                          "links": []
+                          "status": "ACTIVE"
                         }
                     ]
                 }
@@ -576,8 +563,7 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "absenceType": "VACATION",
                           "category": "HOLIDAY",
                           "typeId": 1,
-                          "status": "WAITING",
-                          "links": []
+                          "status": "WAITING"
                         }
                     ]
                 }
@@ -619,8 +605,7 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "absenceType": "SICK_NOTE",
                           "category": "SICK_NOTE",
                           "typeId": 1,
-                          "status": "ACTIVE",
-                          "links": []
+                          "status": "ACTIVE"
                         }
                     ]
                 }
@@ -671,8 +656,7 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "absenceType": "PUBLIC_HOLIDAY",
                           "category": null,
                           "typeId": null,
-                          "status": "ACTIVE",
-                          "links": []
+                          "status": "ACTIVE"
                         },
                         {
                           "date": "2016-01-07",
@@ -682,8 +666,7 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "absenceType": "NO_WORKDAY",
                           "category": null,
                           "typeId": null,
-                          "status": "ACTIVE",
-                          "links": []
+                          "status": "ACTIVE"
                         }
                     ]
                 }
@@ -724,8 +707,7 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "absenceType": "VACATION",
                           "category": "HOLIDAY",
                           "typeId": 1,
-                          "status": "WAITING",
-                          "links": []
+                          "status": "WAITING"
                         },
                         {
                           "date": "2016-02-12",
@@ -735,8 +717,7 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "absenceType": "SICK_NOTE",
                           "category": "SICK_NOTE",
                           "typeId": 1,
-                          "status": "ACTIVE",
-                          "links": []
+                          "status": "ACTIVE"
                         }
                     ]
                 }
@@ -778,8 +759,7 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "absenceType": "VACATION",
                           "category": "HOLIDAY",
                           "typeId": 1,
-                          "status": "WAITING",
-                          "links": []
+                          "status": "WAITING"
                         },
                         {
                           "date": "2016-01-01",
@@ -789,8 +769,7 @@ class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
                           "absenceType": "VACATION",
                           "status": "WAITING",
                           "category": "HOLIDAY",
-                          "typeId": 1,
-                          "links": []
+                          "typeId": 1
                         }
                     ]
                 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/absence/AbsenceApiControllerIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/absence/AbsenceApiControllerIT.java
@@ -1,14 +1,17 @@
 package org.synyx.urlaubsverwaltung.absence;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.synyx.urlaubsverwaltung.api.RestControllerAdviceExceptionHandler;
+import org.springframework.web.context.WebApplicationContext;
+import org.synyx.urlaubsverwaltung.SingleTenantTestContainersBase;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
 
@@ -21,6 +24,8 @@ import static java.time.Month.FEBRUARY;
 import static java.time.Month.JANUARY;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.json.JsonCompareMode.STRICT;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -29,19 +34,16 @@ import static org.synyx.urlaubsverwaltung.absence.AbsencePeriod.AbsenceStatus.AC
 import static org.synyx.urlaubsverwaltung.absence.AbsencePeriod.AbsenceStatus.WAITING;
 
 @ExtendWith(MockitoExtension.class)
-class AbsenceApiControllerTest {
+@SpringBootTest
+class AbsenceApiControllerIT extends SingleTenantTestContainersBase {
 
-    private AbsenceApiController sut;
+    @Autowired
+    private WebApplicationContext context;
 
-    @Mock
+    @MockitoBean
     private PersonService personService;
-    @Mock
+    @MockitoBean
     private AbsenceService absenceService;
-
-    @BeforeEach
-    void setUp() {
-        sut = new AbsenceApiController(personService, absenceService);
-    }
 
     @Test
     void ensureEmptyAbsences() throws Exception {
@@ -56,16 +58,17 @@ class AbsenceApiControllerTest {
 
         perform(
             get("/api/persons/23/absences")
+                .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
                 .param("from", "2016-01-01")
                 .param("to", "2016-01-07")
         )
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(content().json("""
-            {
-              "absences": []
-            }
-            """, STRICT));
+                {
+                  "absences": []
+                }
+                """, STRICT));
     }
 
     // VACATION --------------------------------------------------------------------------------------------------------
@@ -87,28 +90,29 @@ class AbsenceApiControllerTest {
 
         perform(
             get("/api/persons/23/absences")
+                .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
                 .param("from", "2016-01-01")
                 .param("to", "2016-12-31")
         )
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(content().json("""
-            {
-                "absences": [
-                    {
-                      "date": "2016-01-02",
-                      "id": 42,
-                      "absent": "FULL",
-                      "absentNumeric": 1,
-                      "absenceType": "VACATION",
-                      "category": "HOLIDAY",
-                      "typeId": 1,
-                      "status": "WAITING",
-                      "links": []
-                    }
-                ]
-            }
-            """, STRICT));
+                {
+                    "absences": [
+                        {
+                          "date": "2016-01-02",
+                          "id": 42,
+                          "absent": "FULL",
+                          "absentNumeric": 1,
+                          "absenceType": "VACATION",
+                          "category": "HOLIDAY",
+                          "typeId": 1,
+                          "status": "WAITING",
+                          "links": []
+                        }
+                    ]
+                }
+                """, STRICT));
     }
 
     @Test
@@ -128,28 +132,29 @@ class AbsenceApiControllerTest {
 
         perform(
             get("/api/persons/23/absences")
+                .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
                 .param("from", "2016-01-01")
                 .param("to", "2016-12-31")
         )
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(content().json("""
-            {
-                "absences": [
-                    {
-                      "date": "2016-01-02",
-                      "id": 42,
-                      "absent": "MORNING",
-                      "absentNumeric": 0.5,
-                      "absenceType": "VACATION",
-                      "category": "HOLIDAY",
-                      "typeId": 1,
-                      "status": "WAITING",
-                      "links": []
-                    }
-                ]
-            }
-            """, STRICT));
+                {
+                    "absences": [
+                        {
+                          "date": "2016-01-02",
+                          "id": 42,
+                          "absent": "MORNING",
+                          "absentNumeric": 0.5,
+                          "absenceType": "VACATION",
+                          "category": "HOLIDAY",
+                          "typeId": 1,
+                          "status": "WAITING",
+                          "links": []
+                        }
+                    ]
+                }
+                """, STRICT));
     }
 
     @Test
@@ -169,28 +174,29 @@ class AbsenceApiControllerTest {
 
         perform(
             get("/api/persons/23/absences")
+                .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
                 .param("from", "2016-01-01")
                 .param("to", "2016-12-31")
         )
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(content().json("""
-            {
-                "absences": [
-                    {
-                      "date": "2016-01-02",
-                      "id": 42,
-                      "absent": "NOON",
-                      "absentNumeric": 0.5,
-                      "absenceType": "VACATION",
-                      "category": "HOLIDAY",
-                      "typeId": 1,
-                      "status": "WAITING",
-                      "links": []
-                    }
-                ]
-            }
-            """, STRICT));
+                {
+                    "absences": [
+                        {
+                          "date": "2016-01-02",
+                          "id": 42,
+                          "absent": "NOON",
+                          "absentNumeric": 0.5,
+                          "absenceType": "VACATION",
+                          "category": "HOLIDAY",
+                          "typeId": 1,
+                          "status": "WAITING",
+                          "links": []
+                        }
+                    ]
+                }
+                """, STRICT));
     }
 
     @Test
@@ -211,33 +217,34 @@ class AbsenceApiControllerTest {
 
         perform(
             get("/api/persons/23/absences")
+                .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
                 .param("from", "2016-01-01")
                 .param("to", "2016-12-31")
         )
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(content().json("""
-            {
-                "absences": [
-                    {
-                      "date": "2016-01-02",
-                      "id": 42,
-                      "absent": "NOON",
-                      "absentNumeric": 0.5,
-                      "absenceType": "VACATION",
-                      "category": "OVERTIME",
-                      "typeId": 1,
-                      "status": "WAITING",
-                      "links": [
-                          {
-                            "rel": "overtime",
-                            "href": "http://localhost/api/persons/23/absences/42/overtime"
-                          }
-                      ]
-                    }
-                ]
-            }
-            """, STRICT));
+                {
+                    "absences": [
+                        {
+                          "date": "2016-01-02",
+                          "id": 42,
+                          "absent": "NOON",
+                          "absentNumeric": 0.5,
+                          "absenceType": "VACATION",
+                          "category": "OVERTIME",
+                          "typeId": 1,
+                          "status": "WAITING",
+                          "links": [
+                              {
+                                "rel": "overtime",
+                                "href": "http://localhost/api/persons/23/absences/42/overtime"
+                              }
+                          ]
+                        }
+                    ]
+                }
+                """, STRICT));
     }
 
     // SICK ------------------------------------------------------------------------------------------------------------
@@ -259,28 +266,29 @@ class AbsenceApiControllerTest {
 
         perform(
             get("/api/persons/23/absences")
+                .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
                 .param("from", "2016-01-01")
                 .param("to", "2016-12-31")
         )
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(content().json("""
-            {
-                "absences": [
-                    {
-                      "date": "2016-01-02",
-                      "id": 42,
-                      "absent": "FULL",
-                      "absentNumeric": 1,
-                      "absenceType": "SICK_NOTE",
-                      "category": "SICK_NOTE",
-                      "typeId": 1,
-                      "status": "ACTIVE",
-                      "links": []
-                    }
-                ]
-            }
-            """, STRICT));
+                {
+                    "absences": [
+                        {
+                          "date": "2016-01-02",
+                          "id": 42,
+                          "absent": "FULL",
+                          "absentNumeric": 1,
+                          "absenceType": "SICK_NOTE",
+                          "category": "SICK_NOTE",
+                          "typeId": 1,
+                          "status": "ACTIVE",
+                          "links": []
+                        }
+                    ]
+                }
+                """, STRICT));
     }
 
     @Test
@@ -300,28 +308,29 @@ class AbsenceApiControllerTest {
 
         perform(
             get("/api/persons/23/absences")
+                .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
                 .param("from", "2016-01-01")
                 .param("to", "2016-12-31")
         )
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(content().json("""
-            {
-                "absences": [
-                    {
-                      "date": "2016-01-02",
-                      "id": 42,
-                      "absent": "MORNING",
-                      "absentNumeric": 0.5,
-                      "absenceType": "SICK_NOTE",
-                      "category": "SICK_NOTE",
-                      "typeId": 1,
-                      "status": "ACTIVE",
-                      "links": []
-                    }
-                ]
-            }
-            """, STRICT));
+                {
+                    "absences": [
+                        {
+                          "date": "2016-01-02",
+                          "id": 42,
+                          "absent": "MORNING",
+                          "absentNumeric": 0.5,
+                          "absenceType": "SICK_NOTE",
+                          "category": "SICK_NOTE",
+                          "typeId": 1,
+                          "status": "ACTIVE",
+                          "links": []
+                        }
+                    ]
+                }
+                """, STRICT));
     }
 
     @Test
@@ -341,28 +350,29 @@ class AbsenceApiControllerTest {
 
         perform(
             get("/api/persons/23/absences")
+                .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
                 .param("from", "2016-01-01")
                 .param("to", "2016-12-31")
         )
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(content().json("""
-            {
-                "absences": [
-                    {
-                      "date": "2016-01-02",
-                      "id": 42,
-                      "absent": "NOON",
-                      "absentNumeric": 0.5,
-                      "absenceType": "SICK_NOTE",
-                      "category": "SICK_NOTE",
-                      "typeId": 1,
-                      "status": "ACTIVE",
-                      "links": []
-                    }
-                ]
-            }
-            """, STRICT));
+                {
+                    "absences": [
+                        {
+                          "date": "2016-01-02",
+                          "id": 42,
+                          "absent": "NOON",
+                          "absentNumeric": 0.5,
+                          "absenceType": "SICK_NOTE",
+                          "category": "SICK_NOTE",
+                          "typeId": 1,
+                          "status": "ACTIVE",
+                          "links": []
+                        }
+                    ]
+                }
+                """, STRICT));
     }
 
     // VACATION / SICK - COMBINATION -----------------------------------------------------------------------------------
@@ -384,39 +394,40 @@ class AbsenceApiControllerTest {
 
         perform(
             get("/api/persons/23/absences")
+                .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
                 .param("from", "2016-01-01")
                 .param("to", "2016-12-31")
         )
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(content().json("""
-            {
-                "absences": [
-                    {
-                      "date": "2016-01-02",
-                      "id": 1337,
-                      "absent": "MORNING",
-                      "absentNumeric": 0.5,
-                      "absenceType": "VACATION",
-                      "category": "HOLIDAY",
-                      "typeId": 1,
-                      "status": "WAITING",
-                      "links": []
-                    },
-                    {
-                      "date": "2016-01-02",
-                      "id": 42,
-                      "absent": "NOON",
-                      "absentNumeric": 0.5,
-                      "absenceType": "SICK_NOTE",
-                      "category": "SICK_NOTE",
-                      "typeId": 1,
-                      "status": "ACTIVE",
-                      "links": []
-                    }
-                ]
-            }
-            """, STRICT));
+                {
+                    "absences": [
+                        {
+                          "date": "2016-01-02",
+                          "id": 1337,
+                          "absent": "MORNING",
+                          "absentNumeric": 0.5,
+                          "absenceType": "VACATION",
+                          "category": "HOLIDAY",
+                          "typeId": 1,
+                          "status": "WAITING",
+                          "links": []
+                        },
+                        {
+                          "date": "2016-01-02",
+                          "id": 42,
+                          "absent": "NOON",
+                          "absentNumeric": 0.5,
+                          "absenceType": "SICK_NOTE",
+                          "category": "SICK_NOTE",
+                          "typeId": 1,
+                          "status": "ACTIVE",
+                          "links": []
+                        }
+                    ]
+                }
+                """, STRICT));
     }
 
     @Test
@@ -437,39 +448,40 @@ class AbsenceApiControllerTest {
 
         perform(
             get("/api/persons/23/absences")
+                .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
                 .param("from", "2016-01-01")
                 .param("to", "2016-12-31")
         )
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(content().json("""
-            {
-                "absences": [
-                    {
-                      "date": "2016-01-02",
-                      "id": 42,
-                      "absent": "MORNING",
-                      "absentNumeric": 0.5,
-                      "absenceType": "SICK_NOTE",
-                      "category": "SICK_NOTE",
-                      "typeId": 1,
-                      "status": "ACTIVE",
-                      "links": []
-                    },
-                    {
-                      "date": "2016-01-02",
-                      "id": 1337,
-                      "absent": "NOON",
-                      "absentNumeric": 0.5,
-                      "absenceType": "VACATION",
-                      "category": "HOLIDAY",
-                      "typeId": 1,
-                      "status": "WAITING",
-                      "links": []
-                    }
-                ]
-            }
-            """, STRICT));
+                {
+                    "absences": [
+                        {
+                          "date": "2016-01-02",
+                          "id": 42,
+                          "absent": "MORNING",
+                          "absentNumeric": 0.5,
+                          "absenceType": "SICK_NOTE",
+                          "category": "SICK_NOTE",
+                          "typeId": 1,
+                          "status": "ACTIVE",
+                          "links": []
+                        },
+                        {
+                          "date": "2016-01-02",
+                          "id": 1337,
+                          "absent": "NOON",
+                          "absentNumeric": 0.5,
+                          "absenceType": "VACATION",
+                          "category": "HOLIDAY",
+                          "typeId": 1,
+                          "status": "WAITING",
+                          "links": []
+                        }
+                    ]
+                }
+                """, STRICT));
     }
 
     // VACATION / PUBLIC-HOLIDAY - COMBINATION -------------------------------------------------------------------------
@@ -491,39 +503,40 @@ class AbsenceApiControllerTest {
 
         perform(
             get("/api/persons/23/absences")
+                .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
                 .param("from", "2016-01-01")
                 .param("to", "2016-12-31")
         )
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(content().json("""
-            {
-                "absences": [
-                    {
-                      "date": "2016-12-24",
-                      "id": 42,
-                      "absent": "MORNING",
-                      "absentNumeric": 0.5,
-                      "absenceType": "VACATION",
-                      "category": "HOLIDAY",
-                      "typeId": 1,
-                      "status": "WAITING",
-                      "links": []
-                    },
-                    {
-                      "date": "2016-12-24",
-                      "id": null,
-                      "absent": "NOON",
-                      "absentNumeric": 0.5,
-                      "absenceType": "PUBLIC_HOLIDAY",
-                      "category": null,
-                      "typeId": null,
-                      "status": "ACTIVE",
-                      "links": []
-                    }
-                ]
-            }
-            """, STRICT));
+                {
+                    "absences": [
+                        {
+                          "date": "2016-12-24",
+                          "id": 42,
+                          "absent": "MORNING",
+                          "absentNumeric": 0.5,
+                          "absenceType": "VACATION",
+                          "category": "HOLIDAY",
+                          "typeId": 1,
+                          "status": "WAITING",
+                          "links": []
+                        },
+                        {
+                          "date": "2016-12-24",
+                          "id": null,
+                          "absent": "NOON",
+                          "absentNumeric": 0.5,
+                          "absenceType": "PUBLIC_HOLIDAY",
+                          "category": null,
+                          "typeId": null,
+                          "status": "ACTIVE",
+                          "links": []
+                        }
+                    ]
+                }
+                """, STRICT));
     }
 
 
@@ -545,6 +558,7 @@ class AbsenceApiControllerTest {
 
         perform(
             get("/api/persons/23/absences")
+                .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
                 .param("from", "2016-01-01")
                 .param("to", "2016-12-31")
                 .param("absence-types", "VACATION")
@@ -552,22 +566,22 @@ class AbsenceApiControllerTest {
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(content().json("""
-            {
-                "absences": [
-                    {
-                      "date": "2016-01-12",
-                      "id": 42,
-                      "absent": "MORNING",
-                      "absentNumeric": 0.5,
-                      "absenceType": "VACATION",
-                      "category": "HOLIDAY",
-                      "typeId": 1,
-                      "status": "WAITING",
-                      "links": []
-                    }
-                ]
-            }
-            """, STRICT));
+                {
+                    "absences": [
+                        {
+                          "date": "2016-01-12",
+                          "id": 42,
+                          "absent": "MORNING",
+                          "absentNumeric": 0.5,
+                          "absenceType": "VACATION",
+                          "category": "HOLIDAY",
+                          "typeId": 1,
+                          "status": "WAITING",
+                          "links": []
+                        }
+                    ]
+                }
+                """, STRICT));
     }
 
     @Test
@@ -587,6 +601,7 @@ class AbsenceApiControllerTest {
 
         perform(
             get("/api/persons/23/absences")
+                .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
                 .param("from", "2016-01-01")
                 .param("to", "2016-12-31")
                 .param("absence-types", "SICK_NOTE")
@@ -594,22 +609,22 @@ class AbsenceApiControllerTest {
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(content().json("""
-            {
-                "absences": [
-                    {
-                      "date": "2016-02-12",
-                      "id": 42,
-                      "absent": "MORNING",
-                      "absentNumeric": 0.5,
-                      "absenceType": "SICK_NOTE",
-                      "category": "SICK_NOTE",
-                      "typeId": 1,
-                      "status": "ACTIVE",
-                      "links": []
-                    }
-                ]
-            }
-            """, STRICT));
+                {
+                    "absences": [
+                        {
+                          "date": "2016-02-12",
+                          "id": 42,
+                          "absent": "MORNING",
+                          "absentNumeric": 0.5,
+                          "absenceType": "SICK_NOTE",
+                          "category": "SICK_NOTE",
+                          "typeId": 1,
+                          "status": "ACTIVE",
+                          "links": []
+                        }
+                    ]
+                }
+                """, STRICT));
     }
 
     @Test
@@ -638,6 +653,7 @@ class AbsenceApiControllerTest {
 
         perform(
             get("/api/persons/23/absences")
+                .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
                 .param("from", "2016-01-01")
                 .param("to", "2016-12-31")
                 .param("absence-types", "PUBLIC_HOLIDAY", "NO_WORKDAY")
@@ -645,33 +661,33 @@ class AbsenceApiControllerTest {
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(content().json("""
-            {
-                "absences": [
-                    {
-                      "date": "2016-01-06",
-                      "id": null,
-                      "absent": "FULL",
-                      "absentNumeric": 1,
-                      "absenceType": "PUBLIC_HOLIDAY",
-                      "category": null,
-                      "typeId": null,
-                      "status": "ACTIVE",
-                      "links": []
-                    },
-                    {
-                      "date": "2016-01-07",
-                      "id": null,
-                      "absent": "FULL",
-                      "absentNumeric": 1,
-                      "absenceType": "NO_WORKDAY",
-                      "category": null,
-                      "typeId": null,
-                      "status": "ACTIVE",
-                      "links": []
-                    }
-                ]
-            }
-            """, STRICT));
+                {
+                    "absences": [
+                        {
+                          "date": "2016-01-06",
+                          "id": null,
+                          "absent": "FULL",
+                          "absentNumeric": 1,
+                          "absenceType": "PUBLIC_HOLIDAY",
+                          "category": null,
+                          "typeId": null,
+                          "status": "ACTIVE",
+                          "links": []
+                        },
+                        {
+                          "date": "2016-01-07",
+                          "id": null,
+                          "absent": "FULL",
+                          "absentNumeric": 1,
+                          "absenceType": "NO_WORKDAY",
+                          "category": null,
+                          "typeId": null,
+                          "status": "ACTIVE",
+                          "links": []
+                        }
+                    ]
+                }
+                """, STRICT));
     }
 
     @Test
@@ -691,39 +707,40 @@ class AbsenceApiControllerTest {
 
         perform(
             get("/api/persons/23/absences")
+                .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
                 .param("from", "2016-01-01")
                 .param("to", "2016-12-31")
         )
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(content().json("""
-            {
-                "absences": [
-                    {
-                      "date": "2016-01-12",
-                      "id": 42,
-                      "absent": "MORNING",
-                      "absentNumeric": 0.5,
-                      "absenceType": "VACATION",
-                      "category": "HOLIDAY",
-                      "typeId": 1,
-                      "status": "WAITING",
-                      "links": []
-                    },
-                    {
-                      "date": "2016-02-12",
-                      "id": 42,
-                      "absent": "MORNING",
-                      "absentNumeric": 0.5,
-                      "absenceType": "SICK_NOTE",
-                      "category": "SICK_NOTE",
-                      "typeId": 1,
-                      "status": "ACTIVE",
-                      "links": []
-                    }
-                ]
-            }
-            """, STRICT));
+                {
+                    "absences": [
+                        {
+                          "date": "2016-01-12",
+                          "id": 42,
+                          "absent": "MORNING",
+                          "absentNumeric": 0.5,
+                          "absenceType": "VACATION",
+                          "category": "HOLIDAY",
+                          "typeId": 1,
+                          "status": "WAITING",
+                          "links": []
+                        },
+                        {
+                          "date": "2016-02-12",
+                          "id": 42,
+                          "absent": "MORNING",
+                          "absentNumeric": 0.5,
+                          "absenceType": "SICK_NOTE",
+                          "category": "SICK_NOTE",
+                          "typeId": 1,
+                          "status": "ACTIVE",
+                          "links": []
+                        }
+                    ]
+                }
+                """, STRICT));
     }
 
     @Test
@@ -744,44 +761,46 @@ class AbsenceApiControllerTest {
         when(absenceService.getOpenAbsences(person, date, date)).thenReturn(List.of(absencePeriodMorning, absencePeriodNoon));
 
         perform(get("/api/persons/23/absences")
+            .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
             .param("from", "2016-01-01")
             .param("to", "2016-01-01")
             .param("noWorkdaysInclusive", "true"))
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(content().json("""
-            {
-                "absences": [
-                    {
-                      "date": "2016-01-01",
-                      "id": 42,
-                      "absent": "MORNING",
-                      "absentNumeric": 0.5,
-                      "absenceType": "VACATION",
-                      "category": "HOLIDAY",
-                      "typeId": 1,
-                      "status": "WAITING",
-                      "links": []
-                    },
-                    {
-                      "date": "2016-01-01",
-                      "id": 43,
-                      "absent": "NOON",
-                      "absentNumeric": 0.5,
-                      "absenceType": "VACATION",
-                      "status": "WAITING",
-                      "category": "HOLIDAY",
-                      "typeId": 1,
-                      "links": []
-                    }
-                ]
-            }
-            """, STRICT));
+                {
+                    "absences": [
+                        {
+                          "date": "2016-01-01",
+                          "id": 42,
+                          "absent": "MORNING",
+                          "absentNumeric": 0.5,
+                          "absenceType": "VACATION",
+                          "category": "HOLIDAY",
+                          "typeId": 1,
+                          "status": "WAITING",
+                          "links": []
+                        },
+                        {
+                          "date": "2016-01-01",
+                          "id": 43,
+                          "absent": "NOON",
+                          "absentNumeric": 0.5,
+                          "absenceType": "VACATION",
+                          "status": "WAITING",
+                          "category": "HOLIDAY",
+                          "typeId": 1,
+                          "links": []
+                        }
+                    ]
+                }
+                """, STRICT));
     }
 
     @Test
     void ensureBadRequestForInvalidFromParameter() throws Exception {
         perform(get("/api/persons/23/absences")
+            .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
             .param("from", "2016-01")
             .param("to", "2016-01-31"))
             .andExpect(status().isBadRequest());
@@ -790,6 +809,7 @@ class AbsenceApiControllerTest {
     @Test
     void ensureBadRequestForInvalidToParameter() throws Exception {
         perform(get("/api/persons/23/absences")
+            .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
             .param("from", "2016-01-01")
             .param("to", "2016-01"))
             .andExpect(status().isBadRequest());
@@ -798,6 +818,7 @@ class AbsenceApiControllerTest {
     @Test
     void ensureBadRequestForInvalidPersonParameter() throws Exception {
         perform(get("/api/persons/foo/absences")
+            .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
             .param("from", "2016-01-01")
             .param("to", "2016-01-31"))
             .andExpect(status().isBadRequest());
@@ -806,6 +827,7 @@ class AbsenceApiControllerTest {
     @Test
     void ensureBadRequestForMissingFromParameter() throws Exception {
         perform(get("/api/persons/23/absences")
+            .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
             .param("to", "2016-01-31"))
             .andExpect(status().isBadRequest());
     }
@@ -814,6 +836,7 @@ class AbsenceApiControllerTest {
     void ensureBadRequestForMissingToParameter() throws Exception {
 
         perform(get("/api/persons/23/absences")
+            .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
             .param("from", "2016-01-31"))
             .andExpect(status().isBadRequest());
     }
@@ -821,19 +844,21 @@ class AbsenceApiControllerTest {
     @Test
     void ensureBadRequestForMissingPersonParameter() throws Exception {
         perform(get("/api/persons//absences")
+            .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
             .param("from", "2016-01-01")
             .param("to", "2016-01-31")
-        ).andExpect(status().isNotFound());
+        ).andExpect(status().isBadRequest());
     }
 
     @Test
-    void ensureBadRequestIfThereIsNoPersonForGivenID() throws Exception {
+    void ensureForbiddenIfThereIsNoPersonForGivenID() throws Exception {
         when(personService.getPersonByID(anyLong())).thenReturn(Optional.empty());
 
         perform(get("/api/persons/23/absences")
+            .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
             .param("from", "2016-01-01")
             .param("to", "2016-01-31"))
-            .andExpect(status().isBadRequest());
+            .andExpect(status().isForbidden());
     }
 
     @Test
@@ -842,6 +867,7 @@ class AbsenceApiControllerTest {
             .thenReturn(Optional.of(new Person("muster", "Muster", "Marlene", "muster@example.org")));
 
         perform(get("/api/persons/23/absences")
+            .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
             .param("from", "2016-01-01")
             .param("to", "2016-01-31")
             .param("absence-types", "FOO"))
@@ -850,7 +876,11 @@ class AbsenceApiControllerTest {
 
     @Test
     void ensureBadRequestForInvalidPeriod() throws Exception {
+        when(personService.getPersonByID(anyLong()))
+            .thenReturn(Optional.of(new Person("muster", "Muster", "Marlene", "muster@example.org")));
+
         perform(get("/api/persons/23/absences")
+            .with(oidcLogin().idToken(builder -> builder.subject("muster")).authorities(new SimpleGrantedAuthority("USER")))
             .param("from", "2016-01-01")
             .param("to", "2015-01-01"))
             .andExpect(status().isBadRequest());
@@ -867,6 +897,6 @@ class AbsenceApiControllerTest {
     }
 
     private ResultActions perform(MockHttpServletRequestBuilder builder) throws Exception {
-        return MockMvcBuilders.standaloneSetup(sut).setControllerAdvice(new RestControllerAdviceExceptionHandler()).build().perform(builder);
+        return MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build().perform(builder);
     }
 }


### PR DESCRIPTION
<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->

The HATEOAS links for the the `/api/persons/{personId}/absences` endpoint were formatted incorrectly. This due to the `AbsencesDto` not extending `org.springframework.hateoas.RepresentationModel<AbsencesDto>`.

The first commit on this branche (*Convert AbsenceApiControllerTest to an integration test*) also fixes some tests expected wrong HTTP codes in failure cases.

The last commit (*Move HATEOAS link creation to AbsenceDto*) is just a simple refactoring. I feel like it improves readability, but I'm fine with dropping it from this branch