### PR TITLE
Use TaskScheduler interface to get the default TaskScheduler based on…

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/account/TurnOfTheYearAccountUpdaterConfiguration.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/account/TurnOfTheYearAccountUpdaterConfiguration.java
@@ -2,8 +2,8 @@ package org.synyx.urlaubsverwaltung.account;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.SchedulingConfigurer;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.synyx.urlaubsverwaltung.config.ScheduleLocking;
 import org.synyx.urlaubsverwaltung.tenancy.configuration.single.ConditionalOnSingleTenantMode;
@@ -15,10 +15,10 @@ public class TurnOfTheYearAccountUpdaterConfiguration implements SchedulingConfi
     private final AccountProperties accountProperties;
     private final TurnOfTheYearAccountUpdaterService turnOfTheYearAccountUpdaterService;
     private final ScheduleLocking scheduleLocking;
-    private final ThreadPoolTaskScheduler taskScheduler;
+    private final TaskScheduler taskScheduler;
 
     @Autowired
-    public TurnOfTheYearAccountUpdaterConfiguration(AccountProperties accountProperties, TurnOfTheYearAccountUpdaterService turnOfTheYearAccountUpdaterService, ScheduleLocking scheduleLocking, ThreadPoolTaskScheduler taskScheduler) {
+    public TurnOfTheYearAccountUpdaterConfiguration(AccountProperties accountProperties, TurnOfTheYearAccountUpdaterService turnOfTheYearAccountUpdaterService, ScheduleLocking scheduleLocking, TaskScheduler taskScheduler) {
         this.accountProperties = accountProperties;
         this.turnOfTheYearAccountUpdaterService = turnOfTheYearAccountUpdaterService;
         this.scheduleLocking = scheduleLocking;

--- a/src/main/java/org/synyx/urlaubsverwaltung/account/VacationDaysReminderConfiguration.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/account/VacationDaysReminderConfiguration.java
@@ -2,8 +2,8 @@ package org.synyx.urlaubsverwaltung.account;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.SchedulingConfigurer;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.synyx.urlaubsverwaltung.config.ScheduleLocking;
 import org.synyx.urlaubsverwaltung.tenancy.configuration.single.ConditionalOnSingleTenantMode;
@@ -15,10 +15,10 @@ public class VacationDaysReminderConfiguration implements SchedulingConfigurer {
     private final AccountProperties accountProperties;
     private final VacationDaysReminderService vacationDaysReminderService;
     private final ScheduleLocking scheduleLocking;
-    private final ThreadPoolTaskScheduler taskScheduler;
+    private final TaskScheduler taskScheduler;
 
     @Autowired
-    VacationDaysReminderConfiguration(AccountProperties accountProperties, VacationDaysReminderService vacationDaysReminderService, ScheduleLocking scheduleLocking, ThreadPoolTaskScheduler taskScheduler) {
+    VacationDaysReminderConfiguration(AccountProperties accountProperties, VacationDaysReminderService vacationDaysReminderService, ScheduleLocking scheduleLocking, TaskScheduler taskScheduler) {
         this.accountProperties = accountProperties;
         this.vacationDaysReminderService = vacationDaysReminderService;
         this.scheduleLocking = scheduleLocking;

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationReminderMailConfiguration.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationReminderMailConfiguration.java
@@ -2,8 +2,8 @@ package org.synyx.urlaubsverwaltung.application.application;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.SchedulingConfigurer;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.synyx.urlaubsverwaltung.application.ApplicationProperties;
 import org.synyx.urlaubsverwaltung.config.ScheduleLocking;
@@ -16,10 +16,10 @@ class ApplicationReminderMailConfiguration implements SchedulingConfigurer {
     private final ApplicationProperties applicationProperties;
     private final ApplicationReminderMailService applicationReminderMailService;
     private final ScheduleLocking scheduleLocking;
-    private final ThreadPoolTaskScheduler taskScheduler;
+    private final TaskScheduler taskScheduler;
 
     @Autowired
-    ApplicationReminderMailConfiguration(ApplicationProperties applicationProperties, ApplicationReminderMailService applicationReminderMailService, ScheduleLocking scheduleLocking, ThreadPoolTaskScheduler taskScheduler) {
+    ApplicationReminderMailConfiguration(ApplicationProperties applicationProperties, ApplicationReminderMailService applicationReminderMailService, ScheduleLocking scheduleLocking, TaskScheduler taskScheduler) {
         this.applicationProperties = applicationProperties;
         this.applicationReminderMailService = applicationReminderMailService;
         this.scheduleLocking = scheduleLocking;

--- a/src/main/java/org/synyx/urlaubsverwaltung/config/SchedulerConfiguration.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/config/SchedulerConfiguration.java
@@ -3,16 +3,14 @@ package org.synyx.urlaubsverwaltung.config;
 import net.javacrumbs.shedlock.core.DefaultLockingTaskExecutor;
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
-import org.springframework.boot.task.ThreadPoolTaskSchedulerBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import javax.sql.DataSource;
 
-@Configuration
 @EnableScheduling
+@Configuration
 class SchedulerConfiguration {
 
     @Bean
@@ -23,10 +21,5 @@ class SchedulerConfiguration {
     @Bean
     ScheduleLocking scheduleLocking(final LockProvider lockProvider) {
         return new ScheduleLocking(new DefaultLockingTaskExecutor(lockProvider));
-    }
-
-    @Bean
-    ThreadPoolTaskScheduler taskScheduler(ThreadPoolTaskSchedulerBuilder builder) {
-        return builder.build();
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteMailConfiguration.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteMailConfiguration.java
@@ -2,8 +2,8 @@ package org.synyx.urlaubsverwaltung.sicknote.sicknote;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.SchedulingConfigurer;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.synyx.urlaubsverwaltung.config.ScheduleLocking;
 import org.synyx.urlaubsverwaltung.tenancy.configuration.single.ConditionalOnSingleTenantMode;
@@ -15,10 +15,10 @@ class SickNoteMailConfiguration implements SchedulingConfigurer {
     private final SickNoteProperties sickNoteProperties;
     private final SickNoteMailService sickNoteMailService;
     private final ScheduleLocking scheduleLocking;
-    private final ThreadPoolTaskScheduler taskScheduler;
+    private final TaskScheduler taskScheduler;
 
     @Autowired
-    SickNoteMailConfiguration(SickNoteProperties sickNoteProperties, SickNoteMailService sickNoteMailService, ScheduleLocking scheduleLocking, ThreadPoolTaskScheduler taskScheduler) {
+    SickNoteMailConfiguration(SickNoteProperties sickNoteProperties, SickNoteMailService sickNoteMailService, ScheduleLocking scheduleLocking, TaskScheduler taskScheduler) {
         this.sickNoteProperties = sickNoteProperties;
         this.sickNoteMailService = sickNoteMailService;
         this.scheduleLocking = scheduleLocking;

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/TurnOfTheYearAccountUpdaterConfigurationTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/TurnOfTheYearAccountUpdaterConfigurationTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.config.CronTask;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.synyx.urlaubsverwaltung.config.ScheduleLocking;
@@ -26,7 +26,7 @@ class TurnOfTheYearAccountUpdaterConfigurationTest {
     @Mock
     private ScheduleLocking scheduleLocking;
     @Mock
-    private ThreadPoolTaskScheduler taskScheduler;
+    private TaskScheduler taskScheduler;
 
     @Test
     void updatesAccountsWithGivenCronJobInterval() {

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/VacationDaysReminderConfigurationTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/VacationDaysReminderConfigurationTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.config.CronTask;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.synyx.urlaubsverwaltung.config.ScheduleLocking;
@@ -29,7 +29,7 @@ class VacationDaysReminderConfigurationTest {
     @Mock
     private ScheduleLocking scheduleLocking;
     @Mock
-    private ThreadPoolTaskScheduler taskScheduler;
+    private TaskScheduler taskScheduler;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationReminderMailConfigurationTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationReminderMailConfigurationTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.config.CronTask;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.synyx.urlaubsverwaltung.application.ApplicationProperties;
@@ -27,7 +27,7 @@ class ApplicationReminderMailConfigurationTest {
     @Mock
     private ScheduleLocking scheduleLocking;
     @Mock
-    private ThreadPoolTaskScheduler taskScheduler;
+    private TaskScheduler taskScheduler;
 
     @Test
     void sendsWaitingApplicationReminderWithGivenCronJobInterval() {

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteMailConfigurationTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteMailConfigurationTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.config.CronTask;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.synyx.urlaubsverwaltung.config.ScheduleLocking;
@@ -26,7 +26,7 @@ class SickNoteMailConfigurationTest {
     @Mock
     private ScheduleLocking scheduleLocking;
     @Mock
-    private ThreadPoolTaskScheduler taskScheduler;
+    private TaskScheduler taskScheduler;
 
     @Test
     void sendsEMailWithGivenCronJobInterval() {


### PR DESCRIPTION
… springs criteria....

... in our case with virtual threads activated the SimpleAsyncTaskExecutor

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
