### PR TITLE
backup an inactive person with permission "INACTIVE"

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/extension/backup/backup/PersonDataCollectionService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/extension/backup/backup/PersonDataCollectionService.java
@@ -48,7 +48,7 @@ class PersonDataCollectionService {
     List<PersonDTO> collectPersons(List<Person> persons) {
         return persons.stream().map(person -> {
 
-            final List<RoleDTO> permissions = person.isActive() ? person.getPermissions().stream().map(role -> RoleDTO.valueOf(role.name())).toList() : List.of();
+            final List<RoleDTO> permissions = person.getPermissions().stream().map(role -> RoleDTO.valueOf(role.name())).toList();
             final List<MailNotificationDTO> mailNotificationDTOS = person.getNotifications().stream().map(notification -> MailNotificationDTO.valueOf(notification.name())).toList();
             final PersonBaseDataDTO personBaseDataDTO = personBasedataService.getBasedataByPersonId(person.getId()).map(personBasedata -> new PersonBaseDataDTO(personBasedata.getPersonnelNumber(), personBasedata.getAdditionalInformation())).orElse(null);
 


### PR DESCRIPTION
when a person is inactive / deactivated, that person receives the permission "INACTIVE" instead of having no permission.

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
