### PR TITLE
backup/restore: fix restore mapping dto -> WorkingTimeSettings

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/extension/backup/model/WorkingTimeSettingsDTO.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/extension/backup/model/WorkingTimeSettingsDTO.java
@@ -1,6 +1,7 @@
 package org.synyx.urlaubsverwaltung.extension.backup.model;
 
 import org.synyx.urlaubsverwaltung.period.DayLength;
+import org.synyx.urlaubsverwaltung.workingtime.FederalState;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeSettings;
 
 public record WorkingTimeSettingsDTO(
@@ -42,6 +43,7 @@ public record WorkingTimeSettingsDTO(
         workingTimeSettings.setSunday(DayLength.valueOf(sunday().name()));
         workingTimeSettings.setWorkingDurationForChristmasEve(DayLength.valueOf(workingDurationForChristmasEve().name()));
         workingTimeSettings.setWorkingDurationForNewYearsEve(DayLength.valueOf(workingDurationForNewYearsEve().name()));
+        workingTimeSettings.setFederalState(FederalState.valueOf(federalState().name()));
         return workingTimeSettings;
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/extension/backup/model/WorkingTimeSettingsDTOTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/extension/backup/model/WorkingTimeSettingsDTOTest.java
@@ -32,7 +32,7 @@ class WorkingTimeSettingsDTOTest {
 
     @Test
     void happyPathDTOToWorkingTimeSettings() {
-        WorkingTimeSettingsDTO dto = new WorkingTimeSettingsDTO(DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.ZERO, DayLengthDTO.ZERO, DayLengthDTO.MORNING, DayLengthDTO.MORNING, FederalStateDTO.GERMANY_BADEN_WUERTTEMBERG);
+        WorkingTimeSettingsDTO dto = new WorkingTimeSettingsDTO(DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.ZERO, DayLengthDTO.ZERO, DayLengthDTO.MORNING, DayLengthDTO.MORNING, FederalStateDTO.GERMANY_RHEINLAND_PFALZ);
 
         final WorkingTimeSettings workingTimeSettings = dto.toWorkingTimeSettings();
 
@@ -45,6 +45,6 @@ class WorkingTimeSettingsDTOTest {
         assertThat(workingTimeSettings.getSunday()).isEqualTo(DayLength.ZERO);
         assertThat(workingTimeSettings.getWorkingDurationForChristmasEve()).isEqualTo(DayLength.MORNING);
         assertThat(workingTimeSettings.getWorkingDurationForNewYearsEve()).isEqualTo(DayLength.MORNING);
-        assertThat(workingTimeSettings.getFederalState()).isEqualTo(FederalState.GERMANY_BADEN_WUERTTEMBERG);
+        assertThat(workingTimeSettings.getFederalState()).isEqualTo(FederalState.GERMANY_RHEINLAND_PFALZ);
     }
 }


### PR DESCRIPTION
default case was GERMANY_BADEN_WUERTTEMBERG - so unit test didn't discover this issue.

using differnt federal state in dto demos the issue.

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
