### PR TITLE
Synchronize oidc roles with permissions on oidc login

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/person/Role.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/person/Role.java
@@ -1,5 +1,6 @@
 package org.synyx.urlaubsverwaltung.person;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -25,5 +26,12 @@ public enum Role {
 
     public static List<Role> privilegedRoles() {
         return List.of(DEPARTMENT_HEAD, SECOND_STAGE_AUTHORITY, BOSS, OFFICE);
+    }
+
+    public static boolean validRole(String rolename) {
+        return Arrays.stream(values())
+            .filter(role -> role.name().equalsIgnoreCase(rolename))
+            .findAny()
+            .isPresent();
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/OidcSecurityConfiguration.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/OidcSecurityConfiguration.java
@@ -20,8 +20,8 @@ import java.util.List;
 class OidcSecurityConfiguration {
 
     @Bean
-    PersonOnSuccessfullyOidcLoginEventHandler personOnSuccessfullyOidcLoginEventHandler(final PersonService personService) {
-        return new PersonOnSuccessfullyOidcLoginEventHandler(personService);
+    PersonOnSuccessfullyOidcLoginEventHandler personOnSuccessfullyOidcLoginEventHandler(final PersonService personService, final RolesFromClaimMappersProperties rolesFromClaimMappersProperties) {
+        return new PersonOnSuccessfullyOidcLoginEventHandler(personService, rolesFromClaimMappersProperties);
     }
 
     @Bean


### PR DESCRIPTION
Synchronize matching OIDC roles with user permissions (as already documented) (fixes  #4587)

As far as I can see, enabling the OIDC role mapping (either via `uv.security.oidc.claim-mappers.resource-access-claim.enabled = true` or `uv.security.oidc.claim-mappers.group-claim.enabled = true`) should override the internal permission mechanism and always keep the permissions in sync with those in OIDC (otherwise, maintenance would not be predictable).

Therefore, I implemented it so the permissions are completely overwritten on OIDC login, and assignment of the OFFICE role (if not assigned to anyone) is disabled.
