### PR TITLE
More resilient CustomVacationType and fallback to default language if…

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/application/vacationtype/CustomVacationType.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/vacationtype/CustomVacationType.java
@@ -54,7 +54,7 @@ public final class CustomVacationType extends VacationType<CustomVacationType> {
                     .map(VacationTypeLabel::label)
                     .filter(StringUtils::hasText)
                     // fallback to base locale (e.g. "de" for incoming "de_DE")
-                    .or(() -> Optional.of(labelByLocale.get(Locale.forLanguageTag(locale.getLanguage()))).map(VacationTypeLabel::label).filter(StringUtils::hasText))
+                    .or(() -> Optional.ofNullable(labelByLocale.get(Locale.forLanguageTag(locale.getLanguage()))).map(VacationTypeLabel::label).filter(StringUtils::hasText))
                     .orElseGet(() -> messageSource.getMessage("vacationtype.label.fallback", new Object[]{}, locale));
             };
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/vacationtype/CustomVacationTypeTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/vacationtype/CustomVacationTypeTest.java
@@ -44,4 +44,17 @@ class CustomVacationTypeTest {
 
         assertThat(vacationType.getLabel(Locale.GERMAN)).isEqualTo("fallback");
     }
+
+    @Test
+    void ensureToFallbackToGermanIfNotSupportedBrowserLanguageIsUsed() {
+
+        final StaticMessageSource messageSource = new StaticMessageSource();
+        messageSource.addMessage("vacationtype.label.fallback", Locale.JAPANESE, "ThisWillBeGermanAsFallbackInIntegrationTests");
+
+        final CustomVacationType vacationType = CustomVacationType.builder(messageSource)
+            .labels(List.of(new VacationTypeLabel(Locale.GERMAN, "")))
+            .build();
+
+        assertThat(vacationType.getLabel(Locale.JAPANESE)).isEqualTo("ThisWillBeGermanAsFallbackInIntegrationTests");
+    }
 }


### PR DESCRIPTION
… labelByLocale was not found...

... e.g. if a not supported language was choosen as browser default.

closes #5741


<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
