### PR TITLE
fix(text): remove template key that appears inside template message

### DIFF
--- a/src/main/resources/MailMessages_el.properties
+++ b/src/main/resources/MailMessages_el.properties
@@ -30,7 +30,7 @@ application.data.sicknotetype.sicknotechild=Χαρτί άρρωστου παιδ
 account.vacation_entitlement.information=Μπορείτε να βρείτε περισσότερες πληροφορίες σχετικά με το δικαίωμα διακοπών σας εδώ:
 account.remaining_vacation_days=Υπολειπόμενες ημέρες άδειας την {0} (υπολειπόμενες ημέρες άδειας που λήφθηκαν από το προηγούμενο έτος)
 account.remaining_vacation_days.last_year=Συνολικός αριθμός ημερών άδειας που απομένουν από το προηγούμενο έτος:
-account.remaining_vacation_days.last_year.use_until=account.remaining_vacation_days.last_year.use_until=Σου απομένουν {0, choice, 0#{0} υπόλοιπες ημέρες άδειας|1#1 υπόλοιπη ημέρα άδειας|1.5#{0} υπόλοιπες ημέρες άδειας} από το προηγούμενο έτος. Παρακαλώ προγραμμάτισε την υπόλοιπη άδειά σου εγκαίρως, καθώς πρέπει να χρησιμοποιηθεί έως τις {1} και θα λήξει στις {2}.
+account.remaining_vacation_days.last_year.use_until=Σου απομένουν {0, choice, 0#{0} υπόλοιπες ημέρες άδειας|1#1 υπόλοιπη ημέρα άδειας|1.5#{0} υπόλοιπες ημέρες άδειας} από το προηγούμενο έτος. Παρακαλώ προγραμμάτισε την υπόλοιπη άδειά σου εγκαίρως, καθώς πρέπει να χρησιμοποιηθεί έως τις {1} και θα λήξει στις {2}.
 account.remaining_vacation_days.expired=Δυστυχώς, η υπόλοιπη άδεια σας από {0} έχει λήξει στο ποσό των {1, choice, 0#{1} ημέρες|1#1 ημέρα|1.5#{1} ημέρες}.
 account.remaining_vacation_days.expired.vacation=Το τρέχον δικαίωμά σας για διακοπές:
 account.remaining_vacation_days.expired.not_expiring=Υπόλοιπη άδεια που δεν έχει λήξει στις {0}:

--- a/src/main/resources/MailMessages_en.properties
+++ b/src/main/resources/MailMessages_en.properties
@@ -30,7 +30,7 @@ application.data.sicknotetype.sicknotechild=Child sick note
 account.vacation_entitlement.information=You can find more information about your holiday entitlement here:
 account.remaining_vacation_days=Remaining leave days as of {0} (remaining leave days taken from the previous year)
 account.remaining_vacation_days.last_year=Total number of remaining leave days from the previous year:
-account.remaining_vacation_days.last_year.use_until=account.remaining_vacation_days.last_year.use_until=You still have {0, choice, 0#{0} remaining vacation days|1#1 remaining vacation day|1.5#{0} remaining vacation days} from the previous year. Please plan your remaining leave in time, as it must be used by {1} and will expire on {2}.
+account.remaining_vacation_days.last_year.use_until=You still have {0, choice, 0#{0} remaining vacation days|1#1 remaining vacation day|1.5#{0} remaining vacation days} from the previous year. Please plan your remaining leave in time, as it must be used by {1} and will expire on {2}.
 account.remaining_vacation_days.expired=Unfortunately, your remaining leave as of {0} has expired in the amount of {1, choice, 0#{1} days|1#1 day|1.5#{1} days}.
 account.remaining_vacation_days.expired.vacation=Your current holiday entitlement:
 account.remaining_vacation_days.expired.not_expiring=Remaining leave that has not expired on {0}:


### PR DESCRIPTION
fixes #5808

The key `account.remaining_vacation_days.last_year.use_until` appears in its own message, most likely due to a copy-paste issue in the past?

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

The key `account.remaining_vacation_days.last_year.use_until` appears in its own message, most likely due to a copy-paste issue in the past?

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
