### PR TITLE
Add code to inject a html script for all pages based on application.yaml

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/web/headerscript/HeaderScriptConfigProperties.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/headerscript/HeaderScriptConfigProperties.java
@@ -1,0 +1,14 @@
+package org.synyx.urlaubsverwaltung.web.headerscript;
+
+import jakarta.validation.constraints.NotNull;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties("uv.header-script")
+public record HeaderScriptConfigProperties(
+    @DefaultValue("false") boolean enabled,
+    @NotNull @DefaultValue("") String content
+) {
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/headerscript/HeaderScriptConfiguration.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/headerscript/HeaderScriptConfiguration.java
@@ -1,0 +1,38 @@
+package org.synyx.urlaubsverwaltung.web.headerscript;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableConfigurationProperties(HeaderScriptConfigProperties.class)
+@ConditionalOnProperty(prefix = "uv.header-script", name = "enabled", havingValue = "true")
+class HeaderScriptConfiguration implements WebMvcConfigurer {
+
+    @Bean
+    HeaderScriptControllerAdvice headerScriptControllerAdvice(HeaderScriptConfigProperties properties) {
+        return new HeaderScriptControllerAdvice(properties);
+    }
+
+    @Bean
+    WebMvcConfigurer headerScriptWebMvcConfigurer(HeaderScriptControllerAdvice headerScriptControllerAdvice) {
+        return new HeaderScriptWebMvcConfigurer(headerScriptControllerAdvice);
+    }
+
+    static class HeaderScriptWebMvcConfigurer implements WebMvcConfigurer {
+
+        private final HeaderScriptControllerAdvice headerScriptControllerAdvice;
+
+        HeaderScriptWebMvcConfigurer(HeaderScriptControllerAdvice headerScriptControllerAdvice) {
+            this.headerScriptControllerAdvice = headerScriptControllerAdvice;
+        }
+
+        @Override
+        public void addInterceptors(InterceptorRegistry registry) {
+            registry.addInterceptor(headerScriptControllerAdvice);
+        }
+    }
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/headerscript/HeaderScriptControllerAdvice.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/headerscript/HeaderScriptControllerAdvice.java
@@ -1,0 +1,22 @@
+package org.synyx.urlaubsverwaltung.web.headerscript;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.ModelAndView;
+import org.synyx.urlaubsverwaltung.web.DataProviderInterface;
+
+class HeaderScriptControllerAdvice implements DataProviderInterface {
+
+    private final HeaderScriptConfigProperties properties;
+
+    HeaderScriptControllerAdvice(HeaderScriptConfigProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) {
+        if (addDataIf(modelAndView)) {
+            modelAndView.getModelMap().addAttribute("headerScriptContent", properties.content());
+        }
+    }
+}

--- a/src/main/resources/templates/_header-script.html
+++ b/src/main/resources/templates/_header-script.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Header Script</title>
+  </head>
+  <body>
+    <th:block th:ref="script">
+      <th:block th:if="${not #strings.isEmpty(headerScriptContent)}" th:utext="${headerScriptContent}"></th:block>
+    </th:block>
+  </body>
+</html>

--- a/src/main/resources/templates/_layout.html
+++ b/src/main/resources/templates/_layout.html
@@ -123,6 +123,7 @@
     <th:block th:replace="${scriptsDefer}"></th:block>
     <th:block th:replace="${prefetchOrPrerender}"></th:block>
     <th:block th:replace="${additional}"></th:block>
+    <th:block th:replace="~{_header-script::script}"></th:block>
   </head>
   <body th:fragment="body(content, scripts)">
     <div th:replace="~{_info-banner::banner}"></div>

--- a/src/test/java/org/synyx/urlaubsverwaltung/web/headerscript/HeaderScriptConfigurationTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/web/headerscript/HeaderScriptConfigurationTest.java
@@ -1,0 +1,50 @@
+package org.synyx.urlaubsverwaltung.web.headerscript;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HeaderScriptConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withUserConfiguration(HeaderScriptConfiguration.class);
+
+    @Test
+    void ensureHeaderScriptControllerAdviceExists() {
+        contextRunner
+            .withPropertyValues(
+                "uv.header-script.enabled=true",
+                "uv.header-script.content=<script src=\"test.js\"></script>"
+            )
+            .run(context -> {
+                assertThat(context).hasSingleBean(HeaderScriptControllerAdvice.class);
+            });
+    }
+
+    @Test
+    void ensureHeaderScriptControllerAdviceExistsWithEmptyContent() {
+        contextRunner
+            .withPropertyValues("uv.header-script.enabled=true")
+            .run(context -> {
+                assertThat(context).hasSingleBean(HeaderScriptControllerAdvice.class);
+            });
+    }
+
+    @Test
+    void ensureHeaderScriptControllerAdviceDoesNotExistWhenPropertyIsMissing() {
+        contextRunner
+            .run(context -> {
+                assertThat(context).doesNotHaveBean(HeaderScriptControllerAdvice.class);
+            });
+    }
+
+    @Test
+    void ensureHeaderScriptControllerAdviceDoesNotExistWhenPropertyIsSetToDisabled() {
+        contextRunner
+            .withPropertyValues("uv.header-script.enabled=false")
+            .run(context -> {
+                assertThat(context).doesNotHaveBean(HeaderScriptControllerAdvice.class);
+            });
+    }
+}

--- a/src/test/java/org/synyx/urlaubsverwaltung/web/headerscript/HeaderScriptControllerAdviceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/web/headerscript/HeaderScriptControllerAdviceTest.java
@@ -1,0 +1,62 @@
+package org.synyx.urlaubsverwaltung.web.headerscript;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.web.servlet.ModelAndView;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class HeaderScriptControllerAdviceTest {
+
+    private HeaderScriptControllerAdvice sut;
+
+    @BeforeEach
+    void setUp() {
+        final String scriptContent = "<script defer src=\"https://example.com/my-script.js\"></script>";
+        final HeaderScriptConfigProperties properties = new HeaderScriptConfigProperties(true, scriptContent);
+        sut = new HeaderScriptControllerAdvice(properties);
+    }
+
+    @Test
+    void ensureModelAttributeIsNotSetWhenModelAndViewIsNull() {
+        assertThatNoException()
+            .isThrownBy(() -> sut.postHandle(null, null, null, null));
+    }
+
+    @Test
+    void ensureModelAttributeIsNotSetWhenModelAndViewHasNoView() {
+        final ModelAndView modelAndView = new ModelAndView();
+        sut.postHandle(null, null, null, modelAndView);
+        assertThat(modelAndView.getModel()).doesNotContainKey("headerScriptContent");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"forward:view-name", "redirect:view-name"})
+    void ensureModelAttributeIsNotSetWhenViewNameStartsWith(String viewName) {
+        final ModelAndView modelAndView = new ModelAndView();
+        modelAndView.setViewName(viewName);
+
+        sut.postHandle(null, null, null, modelAndView);
+        assertThat(modelAndView.getModel()).doesNotContainKey("headerScriptContent");
+    }
+
+    @Test
+    void ensureModelAttribute() {
+        final ModelAndView modelAndView = new ModelAndView("any-viewname");
+        sut.postHandle(null, null, null, modelAndView);
+        assertThat(modelAndView.getModel()).containsEntry("headerScriptContent", "<script defer src=\"https://example.com/my-script.js\"></script>");
+    }
+
+    @Test
+    void ensureEmptyContentIsAdded() {
+        final HeaderScriptConfigProperties properties = new HeaderScriptConfigProperties(true, "");
+        final HeaderScriptControllerAdvice adviceWithEmptyContent = new HeaderScriptControllerAdvice(properties);
+
+        final ModelAndView modelAndView = new ModelAndView("any-viewname");
+        adviceWithEmptyContent.postHandle(null, null, null, modelAndView);
+        assertThat(modelAndView.getModel()).containsEntry("headerScriptContent", "");
+    }
+}


### PR DESCRIPTION
can be configured like:

Env Example:

```
UV_HEADER_SCRIPT_ENABLED=true
UV_HEADER_SCRIPT_CONTENT=<script defer
src="https://my-script.example.org/js/script.js"></script>
```

Yaml Example:

```yaml
uv:
  header-script:
    enabled: true
content: 'script defer
src="https://my-script.example.org/js/script.js"></script>'
```

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
