### PR TITLE
fix: correctly hightlight current date

### DIFF
--- a/src/main/javascript/components/datepicker/datepicker-css-classes.js
+++ b/src/main/javascript/components/datepicker/datepicker-css-classes.js
@@ -81,7 +81,7 @@ function getCssClassesForDate(date, absences, publicHolidays) {
   return [
     css.day,
     isToday(date) && css.today,
-    isPast() && css.past,
+    isPast(date) && css.past,
     isWeekend(date) && css.weekend,
     isPublicHoliday(publicHolidays) && css.publicHolidayFull,
     isPublicHolidayMorning(publicHolidays) && css.publicHolidayMorning,

--- a/src/main/javascript/components/datepicker/datepicker.css
+++ b/src/main/javascript/components/datepicker/datepicker.css
@@ -156,7 +156,7 @@ duet-date-picker[disabled] input {
 }
 
 .duet-date__day.datepicker-day-today {
-  box-shadow: inset 0 0 0 var(--uv-cal-selection-box-width) var(--tw-shadow);
+  box-shadow: inset 0 0 0 var(--uv-cal-selection-box-width) var(--tw-shadow-color);
   @apply shadow-cyan-600;
   @apply dark:shadow-sky-400;
 }
@@ -180,13 +180,13 @@ duet-date-picker[disabled] input {
 }
 
 .duet-date__day:hover:before,
-.duet-date__day.is-today::before {
+.duet-date__day.datepicker-day-today::before {
   border-radius: 0;
 }
 
 /* override @duetds styling to not hide the absence-bars */
 .duet-date__day:hover:before,
-.duet-date__day.is-today::before {
+.duet-date__day.datepicker-day-today::before {
   opacity: 1; /* would be nearly opaque */
   top: auto; /* absence-bar should be shown at the bottom */
 }


### PR DESCRIPTION
closes #5849

# Changes

Fix the highlighting of the current day in the date picker.

Before:
<img width="1286" height="582" alt="Screenshot 2026-01-21 105428" src="https://github.com/user-attachments/assets/1ed6a714-8110-42ef-8af1-b54ade519ba5" />

After:
<img width="637" height="472" alt="image" src="https://github.com/user-attachments/assets/887ceabc-3625-4e0a-9031-00c1606bfe6c" />
