### PR TITLE
fix: reference to x-circle icon in feedback-box

### DIFF
--- a/src/main/resources/templates/fragments/feedback-box.html
+++ b/src/main/resources/templates/fragments/feedback-box.html
@@ -33,7 +33,7 @@
       </div>
       <div>
         <button class="flex items-center bg-transparent" th:commandfor="${id}" command="close">
-          <svg th:replace="~{/icon/x-circle::svg(className='w-5 h-5')}"></svg>
+          <svg th:replace="~{icon/x-circle::svg(className='w-5 h-5')}"></svg>
           <span class="sr-only" th:text="#{feedback-box.close}">Hinweis Schließen</span>
         </button>
       </div>


### PR DESCRIPTION
### Changes
- Fixes a broken reference to the `x-circle` icon in the Feedback box

closes #5884