### PR TITLE
overtime sync can be enabled and disabled via configuration property

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimeProperties.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimeProperties.java
@@ -1,0 +1,22 @@
+package org.synyx.urlaubsverwaltung.overtime;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@ConfigurationProperties("uv.overtime")
+@Validated
+public class OvertimeProperties {
+
+    /**
+     * Indicates if the overtime of the users should be synchronized with the zeiterfassung. By default, this is disabled.
+     */
+    private boolean syncActive = false;
+
+    public boolean isSyncActive() {
+        return syncActive;
+    }
+
+    public void setSyncActive(boolean syncActive) {
+        this.syncActive = syncActive;
+    }
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/settings/SettingsServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/settings/SettingsServiceImpl.java
@@ -2,8 +2,10 @@ package org.synyx.urlaubsverwaltung.settings;
 
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
+import org.synyx.urlaubsverwaltung.overtime.OvertimeProperties;
 
 import static java.lang.invoke.MethodHandles.lookup;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -12,16 +14,23 @@ import static org.slf4j.LoggerFactory.getLogger;
  * Implementation for {@link org.synyx.urlaubsverwaltung.settings.SettingsService}.
  */
 @Service
+@EnableConfigurationProperties(OvertimeProperties.class)
 public class SettingsServiceImpl implements SettingsService {
 
     private static final Logger LOG = getLogger(lookup().lookupClass());
 
     private final SettingsRepository settingsRepository;
+    private final OvertimeProperties overtimeProperties;
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Autowired
-    public SettingsServiceImpl(SettingsRepository settingsRepository, ApplicationEventPublisher applicationEventPublisher) {
+    public SettingsServiceImpl(
+        SettingsRepository settingsRepository,
+        OvertimeProperties overtimeProperties,
+        ApplicationEventPublisher applicationEventPublisher
+    ) {
         this.settingsRepository = settingsRepository;
+        this.overtimeProperties = overtimeProperties;
         this.applicationEventPublisher = applicationEventPublisher;
     }
 
@@ -45,6 +54,9 @@ public class SettingsServiceImpl implements SettingsService {
 
         if (count == 0) {
             final Settings settings = new Settings();
+
+            settings.getOvertimeSettings().setOvertimeSyncActive(overtimeProperties.isSyncActive());
+
             final Settings savedSettings = settingsRepository.save(settings);
             applicationEventPublisher.publishEvent(new InitialDefaultSettingsSavedEvent());
             LOG.info("Saved initial settings {}", savedSettings);

--- a/src/test/java/org/synyx/urlaubsverwaltung/settings/SettingsServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/settings/SettingsServiceImplTest.java
@@ -3,18 +3,20 @@ package org.synyx.urlaubsverwaltung.settings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import org.synyx.urlaubsverwaltung.overtime.OvertimeProperties;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.never;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SettingsServiceImplTest {
@@ -23,13 +25,12 @@ class SettingsServiceImplTest {
 
     @Mock
     private SettingsRepository settingsRepository;
-
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
 
     @BeforeEach
     void setUp() {
-        sut = new SettingsServiceImpl(settingsRepository, applicationEventPublisher);
+        sut = new SettingsServiceImpl(settingsRepository, new OvertimeProperties(), applicationEventPublisher);
     }
 
     @Test
@@ -68,5 +69,36 @@ class SettingsServiceImplTest {
 
         verify(settingsRepository, never()).save(any(Settings.class));
         verify(applicationEventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    void ensureThatSyncIsDeactivatedIfPropertyIsTrue() {
+
+        final ArgumentCaptor<Settings> settingsArgumentCaptor = ArgumentCaptor.forClass(Settings.class);
+
+        final OvertimeProperties overtimeProperties = new OvertimeProperties();
+        overtimeProperties.setSyncActive(true);
+
+        final SettingsServiceImpl settingsService = new SettingsServiceImpl(settingsRepository, overtimeProperties, applicationEventPublisher);
+        settingsService.insertDefaultSettings();
+
+        verify(settingsRepository).save(settingsArgumentCaptor.capture());
+
+        final Settings savedSettings = settingsArgumentCaptor.getValue();
+        assertThat(savedSettings.getOvertimeSettings().isOvertimeSyncActive()).isTrue();
+    }
+
+    @Test
+    void ensureThatSyncIsDeactivatedIfPropertyIsFalseByDefault() {
+
+        final ArgumentCaptor<Settings> settingsArgumentCaptor = ArgumentCaptor.forClass(Settings.class);
+
+        final SettingsServiceImpl settingsService = new SettingsServiceImpl(settingsRepository, new OvertimeProperties(), applicationEventPublisher);
+        settingsService.insertDefaultSettings();
+
+        verify(settingsRepository).save(settingsArgumentCaptor.capture());
+
+        final Settings savedSettings = settingsArgumentCaptor.getValue();
+        assertThat(savedSettings.getOvertimeSettings().isOvertimeSyncActive()).isFalse();
     }
 }


### PR DESCRIPTION
closes #5716

kann via `uv.overtime.sync-active` aktiviert oder deaktiviert werden. Default ist deaktiviert.

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
