### PR TITLE
fix department membership events

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentMembershipServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentMembershipServiceImpl.java
@@ -151,7 +151,7 @@ class DepartmentMembershipServiceImpl implements DepartmentMembershipService {
      * @param nextMembers person IDs of the members that should be in the department after the update
      * @param nextDepartmentHeads person IDs of the department heads that should be in the department after the update
      * @param nextSecondStageAuthorities person IDs of the second stage authorities that should be in the department after the update
-     * @return a {@link DepartmentStaff} containing the updated membership information
+     * @return a {@link DepartmentStaff} containing the complete current membership information after applying changes
      */
     DepartmentStaff updateDepartmentMemberships(
         Long departmentId,
@@ -169,7 +169,7 @@ class DepartmentMembershipServiceImpl implements DepartmentMembershipService {
 
         final List<DepartmentMembershipEntity> toSave = Stream.concat(toUpdate.stream(), newMemberships.stream()).toList();
 
-        final DepartmentStaff departmentStaff = saveAll(departmentId, toSave);
+        saveAll(departmentId, toSave);
 
         LOG.info("updated memberships for department with id {}: {}/{} members, {}/{} department heads, {}/{} second stage authorities.",
             departmentId,
@@ -178,7 +178,7 @@ class DepartmentMembershipServiceImpl implements DepartmentMembershipService {
             nextSecondStageAuthorities.size(), memberIdsDiff.currentSecondStageAuthorityIds.size()
         );
 
-        return departmentStaff;
+        return getDepartmentStaff(departmentId);
     }
 
     DepartmentStaff getDepartmentStaff(Long departmentId) {

--- a/src/test/java/org/synyx/urlaubsverwaltung/department/DepartmentMembershipServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/department/DepartmentMembershipServiceTest.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -292,7 +293,8 @@ class DepartmentMembershipServiceTest {
             sut.updateDepartmentMemberships(1L, currentStaff, List.of(), List.of(), List.of());
 
             verify(repository).saveAll(saveAllCaptor.capture());
-            verifyNoMoreInteractions(repository);
+            verify(repository).findAllByDepartmentIdIsInAndValidToIsNull(List.of(1L));
+            verify(repository, never()).deleteAll(anyList());
 
             final List<DepartmentMembershipEntity> actualSaved = saveAllCaptor.getValue();
             assertThat(actualSaved).satisfiesExactly(
@@ -400,7 +402,8 @@ class DepartmentMembershipServiceTest {
             sut.updateDepartmentMemberships(1L, currentStaff, List.of(personId), List.of(), List.of());
 
             verify(repository).saveAll(saveAllCaptor.capture());
-            verifyNoMoreInteractions(repository);
+            verify(repository).findAllByDepartmentIdIsInAndValidToIsNull(List.of(1L));
+            verify(repository, never()).deleteAll(anyList());
 
             final List<DepartmentMembershipEntity> actualSaved = saveAllCaptor.getValue();
             assertThat(actualSaved).satisfiesExactly(
@@ -508,7 +511,8 @@ class DepartmentMembershipServiceTest {
             sut.updateDepartmentMemberships(1L, currentStaff, List.of(personId), List.of(), List.of());
 
             verify(repository).saveAll(saveAllCaptor.capture());
-            verifyNoMoreInteractions(repository);
+            verify(repository).findAllByDepartmentIdIsInAndValidToIsNull(List.of(1L));
+            verify(repository, never()).deleteAll(anyList());
 
             final List<DepartmentMembershipEntity> actualSaved = saveAllCaptor.getValue();
             assertThat(actualSaved).satisfiesExactly(
@@ -521,6 +525,91 @@ class DepartmentMembershipServiceTest {
                     assertThat(entry.getValidTo()).isEqualTo(Instant.now(fixedClock));
                 }
             );
+        }
+
+        @Test
+        void ensureReturnsCompleteStaffWhenNothingChanged() {
+
+            final Instant now = Instant.now(fixedClock);
+            final PersonId personId = new PersonId(1L);
+
+            final DepartmentMembershipEntity existingEntity = new DepartmentMembershipEntity();
+            existingEntity.setId(42L);
+            existingEntity.setPersonId(1L);
+            existingEntity.setDepartmentId(1L);
+            existingEntity.setMembershipKind(DepartmentMembershipKind.MEMBER);
+            existingEntity.setValidFrom(now.minus(Duration.ofDays(10)));
+            existingEntity.setValidTo(null);
+
+            when(repository.findAllByDepartmentId(1L)).thenReturn(List.of(existingEntity));
+            when(repository.findAllByDepartmentIdIsInAndValidToIsNull(List.of(1L))).thenReturn(List.of(existingEntity));
+
+            final DepartmentMembership currentMembership = new DepartmentMembership(personId, 1L, DepartmentMembershipKind.MEMBER, now);
+            final DepartmentStaff currentStaff = DepartmentStaff.ofMemberships(1L, List.of(currentMembership));
+
+            final DepartmentStaff actual = sut.updateDepartmentMemberships(1L, currentStaff, List.of(personId), List.of(), List.of());
+
+            assertThat(actual.departmentId()).isEqualTo(1L);
+            assertThat(actual.members()).hasSize(1);
+            assertThat(actual.members().getFirst().personId()).isEqualTo(personId);
+            assertThat(actual.departmentHeads()).isEmpty();
+            assertThat(actual.secondStageAuthorities()).isEmpty();
+        }
+
+        @Test
+        void ensureReturnsCompleteStaffWhenMemberAdded() {
+
+            final PersonId personId = new PersonId(1L);
+
+            final DepartmentMembershipEntity savedEntity = new DepartmentMembershipEntity();
+            savedEntity.setId(1L);
+            savedEntity.setPersonId(1L);
+            savedEntity.setDepartmentId(42L);
+            savedEntity.setMembershipKind(DepartmentMembershipKind.MEMBER);
+            savedEntity.setValidFrom(Instant.now(fixedClock));
+            savedEntity.setValidTo(null);
+
+            when(repository.findAllByDepartmentId(42L)).thenReturn(List.of());
+            when(repository.findAllByDepartmentIdIsInAndValidToIsNull(List.of(42L))).thenReturn(List.of(savedEntity));
+
+            final DepartmentStaff currentStaff = DepartmentStaff.empty(42L);
+
+            final DepartmentStaff actual = sut.updateDepartmentMemberships(42L, currentStaff, List.of(personId), List.of(), List.of());
+
+            assertThat(actual.departmentId()).isEqualTo(42L);
+            assertThat(actual.members()).hasSize(1);
+            assertThat(actual.members().getFirst().personId()).isEqualTo(personId);
+            assertThat(actual.departmentHeads()).isEmpty();
+            assertThat(actual.secondStageAuthorities()).isEmpty();
+        }
+
+        @Test
+        void ensureReturnsCompleteStaffWhenMemberRemoved() {
+
+            final Instant now = Instant.now(fixedClock);
+            final PersonId personId = new PersonId(1L);
+
+            final DepartmentMembershipEntity existingEntity = new DepartmentMembershipEntity();
+            existingEntity.setId(42L);
+            existingEntity.setPersonId(1L);
+            existingEntity.setDepartmentId(1L);
+            existingEntity.setMembershipKind(DepartmentMembershipKind.MEMBER);
+            existingEntity.setValidFrom(now.minus(Duration.ofDays(10)));
+            existingEntity.setValidTo(null);
+
+            when(repository.findAllByDepartmentId(1L)).thenReturn(List.of(existingEntity));
+            // after removal, the entity has validTo set, so findAllByValidToIsNull returns empty
+            when(repository.findAllByDepartmentIdIsInAndValidToIsNull(List.of(1L))).thenReturn(List.of());
+
+            final DepartmentMembership currentMembership = new DepartmentMembership(personId, 1L, DepartmentMembershipKind.MEMBER, now);
+            final DepartmentStaff currentStaff = DepartmentStaff.ofMemberships(1L, List.of(currentMembership));
+
+            final DepartmentStaff actual = sut.updateDepartmentMemberships(1L, currentStaff, List.of(), List.of(), List.of());
+
+            assertThat(actual.departmentId()).isEqualTo(1L);
+            assertThat(actual.members()).isEmpty();
+            assertThat(actual.departmentHeads()).isEmpty();
+            assertThat(actual.secondStageAuthorities()).isEmpty();
         }
 
         @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImplTest.java
@@ -1643,7 +1643,6 @@ class DepartmentServiceImplTest {
         when(personService.getAllPersonsByIds(Set.of(personId, personThatWillLeftId))).thenReturn(List.of(person, personThatWillLeft));
 
         final DepartmentStaff updatedStaff = new DepartmentStaff(42L, List.of(personMembership), List.of(), List.of());
-
         when(departmentMembershipService.updateDepartmentMemberships(any(Long.class), any(DepartmentStaff.class), any(List.class), any(List.class), any(List.class)))
             .thenReturn(updatedStaff);
 
@@ -1812,7 +1811,6 @@ class DepartmentServiceImplTest {
 
         final DepartmentMembership newMembership = new DepartmentMembership(newMemberId, 42L, DepartmentMembershipKind.MEMBER, Instant.now(clock));
         final DepartmentStaff updatedStaff = new DepartmentStaff(42L, List.of(existingMembership, newMembership), List.of(), List.of());
-
         when(departmentMembershipService.updateDepartmentMemberships(any(Long.class), any(DepartmentStaff.class), any(List.class), any(List.class), any(List.class)))
             .thenReturn(updatedStaff);
 
@@ -1823,6 +1821,91 @@ class DepartmentServiceImplTest {
         verify(applicationEventPublisher).publishEvent(any(DepartmentUpdatedEvent.class));
         verify(applicationEventPublisher).publishEvent(any(DepartmentMemberAssignedEvent.class));
         verify(applicationEventPublisher).publishEvent(any(DepartmentMemberUnassignedEvent.class));
+    }
+
+    @Test
+    void ensureNoMemberUnassignedEventWhenMembersStayTheSameOnUpdate() {
+
+        final PersonId memberAId = new PersonId(1L);
+        final Person memberA = new Person();
+        memberA.setId(memberAId.value());
+        memberA.setUsername("memberA");
+
+        final PersonId memberBId = new PersonId(2L);
+        final Person memberB = new Person();
+        memberB.setId(memberBId.value());
+        memberB.setUsername("memberB");
+
+        final Department department = new Department();
+        department.setId(42L);
+        department.setName("department");
+        department.setMembers(List.of(memberA, memberB));
+
+        final DepartmentEntity departmentEntity = new DepartmentEntity();
+        departmentEntity.setId(42L);
+        when(departmentRepository.findById(42L)).thenReturn(Optional.of(departmentEntity));
+
+        final DepartmentMembership membershipA = new DepartmentMembership(memberAId, 42L, DepartmentMembershipKind.MEMBER, Instant.now(clock));
+        final DepartmentMembership membershipB = new DepartmentMembership(memberBId, 42L, DepartmentMembershipKind.MEMBER, Instant.now(clock));
+        final DepartmentStaff currentStaff = new DepartmentStaff(42L, List.of(membershipA, membershipB), List.of(), List.of());
+        when(departmentMembershipService.getDepartmentStaff(42L)).thenReturn(currentStaff);
+
+        when(personService.getAllPersonsByIds(anySet())).thenReturn(List.of(memberA, memberB));
+
+        // updateDepartmentMemberships now returns the complete staff after applying changes.
+        // When nothing changed, the returned staff matches the current staff.
+        when(departmentMembershipService.updateDepartmentMemberships(any(Long.class), any(DepartmentStaff.class), any(List.class), any(List.class), any(List.class)))
+            .thenReturn(currentStaff);
+
+        when(departmentRepository.save(any(DepartmentEntity.class))).thenReturn(departmentEntity);
+
+        sut.update(department);
+
+        verify(applicationEventPublisher).publishEvent(any(DepartmentUpdatedEvent.class));
+        verify(applicationEventPublisher, never()).publishEvent(any(DepartmentMemberAssignedEvent.class));
+        verify(applicationEventPublisher, never()).publishEvent(any(DepartmentMemberUnassignedEvent.class));
+    }
+
+    @Test
+    void ensureNoPersonLeftDepartmentEventWhenMembersStayTheSameOnUpdate() {
+
+        final PersonId memberAId = new PersonId(1L);
+        final Person memberA = new Person();
+        memberA.setId(memberAId.value());
+        memberA.setUsername("memberA");
+
+        final PersonId memberBId = new PersonId(2L);
+        final Person memberB = new Person();
+        memberB.setId(memberBId.value());
+        memberB.setUsername("memberB");
+
+        final Department department = new Department();
+        department.setId(42L);
+        department.setName("department");
+        department.setMembers(List.of(memberA, memberB));
+
+        final DepartmentEntity departmentEntity = new DepartmentEntity();
+        departmentEntity.setId(42L);
+        when(departmentRepository.findById(42L)).thenReturn(Optional.of(departmentEntity));
+
+        final DepartmentMembership membershipA = new DepartmentMembership(memberAId, 42L, DepartmentMembershipKind.MEMBER, Instant.now(clock));
+        final DepartmentMembership membershipB = new DepartmentMembership(memberBId, 42L, DepartmentMembershipKind.MEMBER, Instant.now(clock));
+        final DepartmentStaff currentStaff = new DepartmentStaff(42L, List.of(membershipA, membershipB), List.of(), List.of());
+        when(departmentMembershipService.getDepartmentStaff(42L)).thenReturn(currentStaff);
+
+        when(personService.getAllPersonsByIds(anySet())).thenReturn(List.of(memberA, memberB));
+
+        // updateDepartmentMemberships now returns the complete staff after applying changes.
+        // When nothing changed, the returned staff matches the current staff.
+        when(departmentMembershipService.updateDepartmentMemberships(any(Long.class), any(DepartmentStaff.class), any(List.class), any(List.class), any(List.class)))
+            .thenReturn(currentStaff);
+
+        when(departmentRepository.save(any(DepartmentEntity.class))).thenReturn(departmentEntity);
+
+        sut.update(department);
+
+        verify(applicationEventPublisher).publishEvent(any(DepartmentUpdatedEvent.class));
+        verify(applicationEventPublisher, never()).publishEvent(any(PersonLeftDepartmentEvent.class));
     }
 
     @Test


### PR DESCRIPTION
updateDepartmentMemberships() returns  current membership information after applying changes instead just a diff

without that, MemberLeftDepartmentEvent and DepartmentMemberUnassignedEvent where fired and that was wrong if there was no change in memberships