### PR TITLE
Helm: Fix documentation bug in Chart Readme, wrong probe endpoints

### DIFF
--- a/charts/urlaubsverwaltung/README.md
+++ b/charts/urlaubsverwaltung/README.md
@@ -173,7 +173,7 @@ customizedManagementServer:
 
 livenessProbe: |
     httpGet:
-      path: /actuator/health
+      path: /actuator/health/liveness
       port: http-management
     initialDelaySeconds: 120
     periodSeconds: 10
@@ -181,7 +181,7 @@ livenessProbe: |
 
 readinessProbe: |
     httpGet:
-      path: /actuator/health
+      path: /actuator/health/readiness
       port: http-management
     initialDelaySeconds: 60
     periodSeconds: 10


### PR DESCRIPTION
The livenessProbe and readinessProbe in the charts value.yaml were changed in ad2a627e8be872e769d1871784a03da77484666c, but the Readme section still has the old path. Using the documented changes leads to a crashing pod since the probe endpoints don't respond as expected.

