### PR TITLE
Fix hash key collisions when multiple absence types lack translations

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsMapper.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsMapper.java
@@ -46,6 +46,6 @@ final class ApplicationForLeaveStatisticsMapper {
     }
 
     private static ApplicationForLeaveStatisticsVacationTypeDto vacationTypeDto(VacationType<?> vacationType, Locale locale) {
-        return new ApplicationForLeaveStatisticsVacationTypeDto(vacationType.getLabel(locale));
+        return new ApplicationForLeaveStatisticsVacationTypeDto(vacationType.getLabel(locale), vacationType.getId());
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsVacationTypeDto.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsVacationTypeDto.java
@@ -5,9 +5,11 @@ import java.util.Objects;
 public class ApplicationForLeaveStatisticsVacationTypeDto {
 
     private final String label;
+    private final Long id;
 
-    ApplicationForLeaveStatisticsVacationTypeDto(String label) {
+    ApplicationForLeaveStatisticsVacationTypeDto(String label, Long id) {
         this.label = label;
+        this.id = id;
     }
 
     public String getLabel() {
@@ -19,11 +21,11 @@ public class ApplicationForLeaveStatisticsVacationTypeDto {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ApplicationForLeaveStatisticsVacationTypeDto that = (ApplicationForLeaveStatisticsVacationTypeDto) o;
-        return Objects.equals(label, that.label);
+        return Objects.equals(label, that.label) && Objects.equals(id, that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(label);
+        return Objects.hash(label, id);
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsViewController.java
@@ -154,7 +154,7 @@ class ApplicationForLeaveStatisticsViewController implements HasLaunchpad {
 
     private List<ApplicationForLeaveStatisticsVacationTypeDto> vacationTypeDtos(Locale locale) {
         return vacationTypeService.getAllVacationTypes().stream()
-            .map(vacationType -> new ApplicationForLeaveStatisticsVacationTypeDto(vacationType.getLabel(locale)))
+            .map(vacationType -> new ApplicationForLeaveStatisticsVacationTypeDto(vacationType.getLabel(locale), vacationType.getId()))
             .toList();
     }
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsVacationTypeDtoTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsVacationTypeDtoTest.java
@@ -1,0 +1,22 @@
+package org.synyx.urlaubsverwaltung.application.statistics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class ApplicationForLeaveStatisticsVacationTypeDtoTest {
+
+    @Test
+    void ensureEquals() {
+        ApplicationForLeaveStatisticsVacationTypeDto dto1 = new ApplicationForLeaveStatisticsVacationTypeDto("label", 1L);
+        ApplicationForLeaveStatisticsVacationTypeDto dto2 = new ApplicationForLeaveStatisticsVacationTypeDto("label", 1L);
+        ApplicationForLeaveStatisticsVacationTypeDto dto3 = new ApplicationForLeaveStatisticsVacationTypeDto("other label", 1L);
+        ApplicationForLeaveStatisticsVacationTypeDto dto4 = new ApplicationForLeaveStatisticsVacationTypeDto("label", 2L);
+
+        assertEquals(dto1, dto2);
+        assertNotEquals(dto1, dto3);
+        assertNotEquals(dto1, dto4);
+    }
+}
+

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsViewControllerTest.java
@@ -147,7 +147,7 @@ class ApplicationForLeaveStatisticsViewControllerTest {
         when(applicationForLeaveStatisticsService.getStatisticsSortedByPerson(signedInUser, filterPeriod, pageRequest, ""))
             .thenReturn(new PageImpl<>(List.of()));
 
-        final List<VacationType<?>> vacationType = List.of(ProvidedVacationType.builder(messageSource).messageKey("vacation-type-label-message-key").build());
+        final List<VacationType<?>> vacationType = List.of(ProvidedVacationType.builder(messageSource).messageKey("vacation-type-label-message-key").id(1L).build());
         when(vacationTypeService.getAllVacationTypes()).thenReturn(vacationType);
 
         when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 1, 1)));
@@ -164,7 +164,7 @@ class ApplicationForLeaveStatisticsViewControllerTest {
             .andExpect(model().attribute("statisticsPagination", hasProperty("page", hasProperty("content", is(List.of())))))
             .andExpect(model().attribute("showPersonnelNumberColumn", false))
             .andExpect(model().attribute("period", filterPeriod))
-            .andExpect(model().attribute("vacationTypes", List.of(new ApplicationForLeaveStatisticsVacationTypeDto("vacation type label"))))
+            .andExpect(model().attribute("vacationTypes", List.of(new ApplicationForLeaveStatisticsVacationTypeDto("vacation type label", 1L))))
             .andExpect(view().name("application/application-statistics"));
     }
 
@@ -179,7 +179,7 @@ class ApplicationForLeaveStatisticsViewControllerTest {
         signedInUser.setId(1L);
         when(personService.getSignedInUser()).thenReturn(signedInUser);
 
-        final VacationType<?> vacationType = ProvidedVacationType.builder(messageSource).messageKey("vacation-type-label-message-key").build();
+        final VacationType<?> vacationType = ProvidedVacationType.builder(messageSource).messageKey("vacation-type-label-message-key").id(2L).build();
         when(vacationTypeService.getAllVacationTypes()).thenReturn(List.of(vacationType));
 
         final LocalDate startDate = LocalDate.parse("2019-01-01");
@@ -233,7 +233,7 @@ class ApplicationForLeaveStatisticsViewControllerTest {
             )))
             .andExpect(model().attribute("showPersonnelNumberColumn", true))
             .andExpect(model().attribute("period", filterPeriod))
-            .andExpect(model().attribute("vacationTypes", List.of(new ApplicationForLeaveStatisticsVacationTypeDto("vacation type label"))))
+            .andExpect(model().attribute("vacationTypes", List.of(new ApplicationForLeaveStatisticsVacationTypeDto("vacation type label", 2L))))
             .andExpect(view().name("application/application-statistics"));
     }
 


### PR DESCRIPTION
closes #5983

siehe
<img width="1612" height="216" alt="image" src="https://github.com/user-attachments/assets/25f99de9-a81a-42ee-8f3a-35ffc9e8e534" />

Mehrere „<absence type>“-Einträge werden nun korrekt angezeigt. Die ID wurde in die Hash-Berechnung aufgenommen, um Eindeutigkeit sicherzustellen.

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
