### PR TITLE
Filter external overtime records with zero duration

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimeServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimeServiceImpl.java
@@ -88,6 +88,7 @@ class OvertimeServiceImpl implements OvertimeService {
         final LocalDate lastDayOfYear = firstDayOfYear.with(lastDayOfYear());
         return overtimeRepository.findByPersonAndEndDateIsGreaterThanEqualAndStartDateIsLessThanEqual(person, firstDayOfYear, lastDayOfYear)
             .stream()
+            .filter(overtimeEntity -> !overtimeEntity.isExternal() || (overtimeEntity.isExternal() && !overtimeEntity.getDuration().isZero()))
             .map(OvertimeServiceImpl::entityToOvertime)
             .toList();
     }

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeServiceImplTest.java
@@ -48,6 +48,7 @@ import static java.time.temporal.TemporalAdjusters.lastDayOfMonth;
 import static java.time.temporal.TemporalAdjusters.lastDayOfYear;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.inOrder;
@@ -56,6 +57,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.synyx.urlaubsverwaltung.application.vacationtype.VacationCategory.OVERTIME;
 import static org.synyx.urlaubsverwaltung.overtime.OvertimeType.EXTERNAL;
+import static org.synyx.urlaubsverwaltung.overtime.OvertimeType.UV_INTERNAL;
 import static org.synyx.urlaubsverwaltung.person.Role.OFFICE;
 import static org.synyx.urlaubsverwaltung.person.Role.USER;
 import static org.synyx.urlaubsverwaltung.workingtime.WorkingTimeCalendarFactory.fullWorkday;
@@ -894,7 +896,7 @@ class OvertimeServiceImplTest {
             personOfOvertime.getIdAsPersonId(),
             new DateRange(LocalDate.now(clock), LocalDate.now(clock)),
             Duration.ofHours(1),
-            OvertimeType.UV_INTERNAL,
+            UV_INTERNAL,
             Instant.now(clock)
         );
 
@@ -919,7 +921,7 @@ class OvertimeServiceImplTest {
             personOfOvertime.getIdAsPersonId(),
             new DateRange(LocalDate.now(clock), LocalDate.now(clock)),
             Duration.ofHours(1),
-            OvertimeType.UV_INTERNAL,
+            UV_INTERNAL,
             Instant.now(clock)
         );
 
@@ -940,7 +942,7 @@ class OvertimeServiceImplTest {
             person.getIdAsPersonId(),
             new DateRange(LocalDate.now(clock), LocalDate.now(clock)),
             Duration.ofHours(1),
-            OvertimeType.UV_INTERNAL,
+            UV_INTERNAL,
             Instant.now(clock)
         );
 
@@ -962,7 +964,7 @@ class OvertimeServiceImplTest {
             person.getIdAsPersonId(),
             new DateRange(LocalDate.now(clock), LocalDate.now(clock)),
             Duration.ofHours(1),
-            OvertimeType.UV_INTERNAL,
+            UV_INTERNAL,
             Instant.now(clock)
         );
 
@@ -984,7 +986,7 @@ class OvertimeServiceImplTest {
             person.getIdAsPersonId(),
             new DateRange(LocalDate.now(clock), LocalDate.now(clock)),
             Duration.ofHours(1),
-            OvertimeType.UV_INTERNAL,
+            UV_INTERNAL,
             Instant.now(clock)
         );
 
@@ -1009,7 +1011,7 @@ class OvertimeServiceImplTest {
             other.getIdAsPersonId(),
             new DateRange(LocalDate.now(clock), LocalDate.now(clock)),
             Duration.ofHours(1),
-            OvertimeType.UV_INTERNAL,
+            UV_INTERNAL,
             Instant.now(clock)
         );
 
@@ -1034,7 +1036,7 @@ class OvertimeServiceImplTest {
             personOfOvertime.getIdAsPersonId(),
             new DateRange(LocalDate.now(clock), LocalDate.now(clock)),
             Duration.ofHours(1),
-            OvertimeType.UV_INTERNAL,
+            UV_INTERNAL,
             Instant.now(clock)
         );
 
@@ -1379,6 +1381,45 @@ class OvertimeServiceImplTest {
         sut.getExternalOvertimeByDate(date, person.getIdAsPersonId());
 
         verify(overtimeRepository).findByPersonIdAndStartDateAndEndDateAndExternalIsTrue(person.getId(), date, date);
+    }
+
+    @Test
+    void ensureToRetrieveOnlyNotZeroExternalOvertime() {
+        final LocalDate date = LocalDate.now(clock).withMonth(AUGUST.getValue()).with(firstDayOfMonth());
+
+        final Person person = new Person();
+        person.setId(1L);
+        final OvertimeEntity overtimeNegative = new OvertimeEntity(person, date, date, Duration.ofHours(-1), false);
+        overtimeNegative.setId(1L);
+        final OvertimeEntity overtimeZero = new OvertimeEntity(person, date, date, Duration.ZERO, false);
+        overtimeZero.setId(2L);
+        final OvertimeEntity overtimePositive = new OvertimeEntity(person, date, date, Duration.ofHours(1), false);
+        overtimePositive.setId(3L);
+        final OvertimeEntity externalOvertimeNegative = new OvertimeEntity(person, date, date, Duration.ofHours(-1), true);
+        externalOvertimeNegative.setId(4L);
+        final OvertimeEntity externalOvertimeZero = new OvertimeEntity(person, date, date, Duration.ZERO, true);
+        externalOvertimeZero.setId(5L);
+        final OvertimeEntity externalOvertimePositive = new OvertimeEntity(person, date, date, Duration.ofHours(1), true);
+        externalOvertimePositive.setId(6L);
+
+        final LocalDate firstDayOfYear = date.with(firstDayOfYear());
+        final LocalDate lastDayOfYear = date.with(lastDayOfYear());
+        when(overtimeRepository.findByPersonAndEndDateIsGreaterThanEqualAndStartDateIsLessThanEqual(person, firstDayOfYear, lastDayOfYear))
+            .thenReturn(List.of(overtimeNegative, overtimeZero, overtimePositive, externalOvertimeNegative, externalOvertimeZero, externalOvertimePositive));
+
+        final List<Overtime> overtimeRecordsForPersonAndYear = sut.getOvertimeRecordsForPersonAndYear(person, date.getYear());
+
+        assertThat(overtimeRecordsForPersonAndYear)
+            .hasSize(5)
+            .extracting(Overtime::type, Overtime::duration)
+            .containsExactlyInAnyOrder(
+                tuple(UV_INTERNAL, Duration.ofHours(-1)),
+                tuple(UV_INTERNAL, Duration.ZERO),
+                tuple(UV_INTERNAL, Duration.ofHours(1)),
+                tuple(EXTERNAL, Duration.ofHours(-1)),
+                tuple(EXTERNAL, Duration.ofHours(1))
+            )
+            .doesNotContain(tuple(EXTERNAL, Duration.ZERO));
     }
 
     private Settings overtimeSettings(boolean overtimeWritePrivilegedOnly, boolean overtimeActive, boolean overtimeSyncActive) {


### PR DESCRIPTION
No need to display them because additional overtime information

closes #6001 

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
