### PR TITLE
fix(security): gate OIDC email fallback on email_verified claim

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/OidcPersonAuthoritiesMapper.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/OidcPersonAuthoritiesMapper.java
@@ -21,6 +21,7 @@ import static java.lang.invoke.MethodHandles.lookup;
 import static java.util.Optional.ofNullable;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.EMAIL;
+import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.EMAIL_VERIFIED;
 import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.SUB;
 import static org.synyx.urlaubsverwaltung.person.Role.INACTIVE;
 import static org.synyx.urlaubsverwaltung.person.Role.OFFICE;
@@ -78,8 +79,12 @@ class OidcPersonAuthoritiesMapper implements GrantedAuthoritiesMapper {
         return personService.getPersonByUsername(extractIdentifier(oidcUserAuthority))
             .or(() -> {
                 // try to fall back to uniqueness of mailAddress if userUniqueID is not found in database
-                final String emailAddress = extractMailAddress(oidcUserAuthority);
-                return personService.getPersonByMailAddress(emailAddress);
+                // only if the email address has been verified by the IdP to prevent account takeover via unverified email claim
+                if (isEmailVerified(oidcUserAuthority)) {
+                    final String emailAddress = extractMailAddress(oidcUserAuthority);
+                    return personService.getPersonByMailAddress(emailAddress);
+                }
+                return Optional.empty();
             });
     }
 
@@ -100,5 +105,11 @@ class OidcPersonAuthoritiesMapper implements GrantedAuthoritiesMapper {
     private Optional<String> getClaimAsString(OidcUserAuthority authority, Supplier<String> claimAccessor) {
         return ofNullable(authority.getIdToken()).map(oidcIdToken -> oidcIdToken.getClaimAsString(claimAccessor.get()))
             .or(() -> ofNullable(authority.getUserInfo()).map(oidcIdToken -> oidcIdToken.getClaimAsString(claimAccessor.get())));
+    }
+
+    private boolean isEmailVerified(OidcUserAuthority authority) {
+        return getClaimAsString(authority, () -> EMAIL_VERIFIED)
+            .map(Boolean::valueOf)
+            .orElse(false);
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/PersonOnSuccessfullyOidcLoginEventHandler.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/security/oidc/PersonOnSuccessfullyOidcLoginEventHandler.java
@@ -16,6 +16,7 @@ import java.util.function.Supplier;
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.util.Optional.ofNullable;
 import static org.slf4j.LoggerFactory.getLogger;
+import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.EMAIL_VERIFIED;
 import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.FAMILY_NAME;
 import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.GIVEN_NAME;
 import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.SUB;
@@ -46,7 +47,8 @@ class PersonOnSuccessfullyOidcLoginEventHandler {
 
         Optional<Person> optionalPerson = personService.getPersonByUsername(userUniqueID);
         // try to fall back to uniqueness of mailAddress if userUniqueID is not found in database
-        if (optionalPerson.isEmpty()) {
+        // only if the email address has been verified by the IdP to prevent account takeover via unverified email claim
+        if (optionalPerson.isEmpty() && isEmailVerified(oidcUser)) {
             optionalPerson = personService.getPersonByMailAddress(emailAddress);
         }
 
@@ -54,9 +56,11 @@ class PersonOnSuccessfullyOidcLoginEventHandler {
 
             final Person existentPerson = optionalPerson.get();
 
-            if (!userUniqueID.equals(existentPerson.getUsername())) {
-                LOG.info("No person with given userUniqueID was found. Falling back to matching mail address for " +
-                    "person lookup. Existing username '{}' is replaced with '{}'.", existentPerson.getUsername(), userUniqueID);
+            // Only rebind username during initial migration when it is null or empty.
+            // Never overwrite a populated username — if it differs from the current sub,
+            // it means the person was matched via email fallback and already has a valid identity binding.
+            if (existentPerson.getUsername() == null || existentPerson.getUsername().isBlank()) {
+                LOG.info("Person '{}' has no username set. Setting username to '{}'.", existentPerson.getId(), userUniqueID);
                 existentPerson.setUsername(userUniqueID);
             }
 
@@ -104,5 +108,11 @@ class PersonOnSuccessfullyOidcLoginEventHandler {
     private Optional<String> getClaimAsString(OidcUser oidcUser, Supplier<String> claimSupplier) {
         return ofNullable(oidcUser.getIdToken()).map(oidcIdToken -> oidcIdToken.getClaimAsString(claimSupplier.get()))
             .or(() -> ofNullable(oidcUser.getUserInfo()).map(oidcIdToken -> oidcIdToken.getClaimAsString(claimSupplier.get())));
+    }
+
+    private boolean isEmailVerified(OidcUser oidcUser) {
+        return getClaimAsString(oidcUser, () -> EMAIL_VERIFIED)
+            .map(Boolean::valueOf)
+            .orElse(false);
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/security/oidc/OidcPersonAuthoritiesMapperTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/security/oidc/OidcPersonAuthoritiesMapperTest.java
@@ -26,9 +26,13 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.oauth2.core.oidc.IdTokenClaimNames.SUB;
 import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.EMAIL;
+import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.EMAIL_VERIFIED;
 import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.FAMILY_NAME;
 import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.GIVEN_NAME;
 import static org.synyx.urlaubsverwaltung.person.Role.INACTIVE;
@@ -88,13 +92,14 @@ class OidcPersonAuthoritiesMapperTest {
     }
 
     @Test
-    void mapAuthoritiesFromIdTokenByEmailFallback() {
+    void mapAuthoritiesFromIdTokenByEmailFallbackWithVerifiedEmail() {
         final String uniqueID = "uniqueID";
         final String email = "test.me@example.com";
 
         final OidcUserAuthority oidcUserAuthority = getOidcUserAuthority(Map.of(
             SUB, uniqueID,
-            EMAIL, email
+            EMAIL, email,
+            EMAIL_VERIFIED, true
         ));
 
         final Person personForLogin = new Person();
@@ -106,6 +111,42 @@ class OidcPersonAuthoritiesMapperTest {
 
         final Collection<? extends GrantedAuthority> grantedAuthorities = sut.mapAuthorities(List.of(oidcUserAuthority));
         assertThat(grantedAuthorities.stream().map(GrantedAuthority::getAuthority)).containsOnly(USER.name(), "OIDC_USER");
+    }
+
+    @Test
+    void doesNotFallbackToEmailWhenNotVerified() {
+        final String uniqueID = "uniqueID";
+        final String email = "test.me@example.com";
+
+        final OidcUserAuthority oidcUserAuthority = getOidcUserAuthority(Map.of(
+            SUB, uniqueID,
+            EMAIL, email,
+            EMAIL_VERIFIED, false
+        ));
+
+        when(personService.getPersonByUsername(uniqueID)).thenReturn(Optional.empty());
+
+        sut.mapAuthorities(List.of(oidcUserAuthority));
+
+        verify(personService, never()).getPersonByMailAddress(anyString());
+    }
+
+    @Test
+    void doesNotFallbackToEmailWhenVerifiedClaimMissing() {
+        final String uniqueID = "uniqueID";
+        final String email = "test.me@example.com";
+
+        // email_verified claim is not present
+        final OidcUserAuthority oidcUserAuthority = getOidcUserAuthority(Map.of(
+            SUB, uniqueID,
+            EMAIL, email
+        ));
+
+        when(personService.getPersonByUsername(uniqueID)).thenReturn(Optional.empty());
+
+        sut.mapAuthorities(List.of(oidcUserAuthority));
+
+        verify(personService, never()).getPersonByMailAddress(anyString());
     }
 
     @Test
@@ -188,7 +229,6 @@ class OidcPersonAuthoritiesMapperTest {
         );
 
         when(personService.getPersonByUsername(uniqueID)).thenReturn(Optional.empty());
-        when(personService.getPersonByMailAddress(null)).thenReturn(Optional.empty());
 
         final Collection<? extends GrantedAuthority> grantedAuthorities = sut.mapAuthorities(List.of(oidcUserAuthorities));
         assertThat(grantedAuthorities.stream().map(GrantedAuthority::getAuthority)).contains(USER.name(), OFFICE.name());

--- a/src/test/java/org/synyx/urlaubsverwaltung/security/oidc/PersonOnSuccessfullyOidcLoginEventHandlerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/security/oidc/PersonOnSuccessfullyOidcLoginEventHandlerTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.oauth2.core.oidc.IdTokenClaimNames.SUB;
 import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.EMAIL;
+import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.EMAIL_VERIFIED;
 import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.FAMILY_NAME;
 import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.GIVEN_NAME;
 import static org.synyx.urlaubsverwaltung.person.Role.USER;
@@ -67,7 +68,8 @@ class PersonOnSuccessfullyOidcLoginEventHandlerTest {
                     SUB, uniqueID,
                     GIVEN_NAME, givenName,
                     FAMILY_NAME, familyName,
-                    EMAIL, email
+                    EMAIL, email,
+                    EMAIL_VERIFIED, true
                 ));
 
             when(personService.getPersonByUsername(uniqueID)).thenReturn(Optional.empty());
@@ -128,7 +130,7 @@ class PersonOnSuccessfullyOidcLoginEventHandlerTest {
         }
 
         @Test
-        void updateExistingPersonByEmailFallback() {
+        void updateExistingPersonByEmailFallbackWithVerifiedEmail() {
             final String uniqueID = "uniqueID";
             final String givenName = "given name";
             final String familyName = "family name";
@@ -138,7 +140,8 @@ class PersonOnSuccessfullyOidcLoginEventHandlerTest {
                 SUB, uniqueID,
                 GIVEN_NAME, givenName,
                 FAMILY_NAME, familyName,
-                EMAIL, email
+                EMAIL, email,
+                EMAIL_VERIFIED, true
             ));
 
             final Person personForLogin = new Person();
@@ -157,10 +160,125 @@ class PersonOnSuccessfullyOidcLoginEventHandlerTest {
             verify(personService).update(personArgumentCaptor.capture());
 
             Person update = personArgumentCaptor.getValue();
-            assertThat(update.getUsername()).isEqualTo(uniqueID);
+            // username is NOT rebound since the existing person already has a populated username
+            assertThat(update.getUsername()).isEqualTo("idOfOtherIdentityProvider");
             assertThat(update.getLastName()).isEqualTo(familyName);
             assertThat(update.getFirstName()).isEqualTo(givenName);
             assertThat(update.getEmail()).isEqualTo(email);
+        }
+
+        @Test
+        void doesNotFallbackToEmailWhenNotVerified() {
+            final String uniqueID = "uniqueID";
+            final String givenName = "given name";
+            final String familyName = "family name";
+            final String email = "test.me@example.com";
+
+            final AuthenticationSuccessEvent event = getOidcUserAuthority(Map.of(
+                SUB, uniqueID,
+                GIVEN_NAME, givenName,
+                FAMILY_NAME, familyName,
+                EMAIL, email,
+                EMAIL_VERIFIED, false
+            ));
+
+            when(personService.getPersonByUsername(uniqueID)).thenReturn(Optional.empty());
+
+            sut.handle(event);
+
+            verify(personService, never()).getPersonByMailAddress(email);
+            verify(personService).create(uniqueID, givenName, familyName, email);
+        }
+
+        @Test
+        void doesNotFallbackToEmailWhenVerifiedClaimMissing() {
+            final String uniqueID = "uniqueID";
+            final String givenName = "given name";
+            final String familyName = "family name";
+            final String email = "test.me@example.com";
+
+            // email_verified claim is not present at all
+            final AuthenticationSuccessEvent event = getOidcUserAuthority(Map.of(
+                SUB, uniqueID,
+                GIVEN_NAME, givenName,
+                FAMILY_NAME, familyName,
+                EMAIL, email
+            ));
+
+            when(personService.getPersonByUsername(uniqueID)).thenReturn(Optional.empty());
+
+            sut.handle(event);
+
+            verify(personService, never()).getPersonByMailAddress(email);
+            verify(personService).create(uniqueID, givenName, familyName, email);
+        }
+
+        @Test
+        void rebindsUsernameOnlyWhenNull() {
+            final String uniqueID = "uniqueID";
+            final String givenName = "given name";
+            final String familyName = "family name";
+            final String email = "test.me@example.com";
+
+            final AuthenticationSuccessEvent event = getOidcUserAuthority(Map.of(
+                SUB, uniqueID,
+                GIVEN_NAME, givenName,
+                FAMILY_NAME, familyName,
+                EMAIL, email,
+                EMAIL_VERIFIED, true
+            ));
+
+            final Person personForLogin = new Person();
+            personForLogin.setUsername(null);
+            personForLogin.setPermissions(List.of(USER));
+            final Optional<Person> person = Optional.of(personForLogin);
+            when(personService.getPersonByUsername(uniqueID)).thenReturn(Optional.empty());
+            when(personService.getPersonByMailAddress(email)).thenReturn(person);
+
+            sut.handle(event);
+
+            verify(personService).getPersonByMailAddress(email);
+
+            final ArgumentCaptor<Person> personArgumentCaptor = ArgumentCaptor.forClass(Person.class);
+            verify(personService).update(personArgumentCaptor.capture());
+
+            Person update = personArgumentCaptor.getValue();
+            // username IS rebound since the existing one was null (initial migration)
+            assertThat(update.getUsername()).isEqualTo(uniqueID);
+        }
+
+        @Test
+        void rebindsUsernameOnlyWhenEmpty() {
+            final String uniqueID = "uniqueID";
+            final String givenName = "given name";
+            final String familyName = "family name";
+            final String email = "test.me@example.com";
+
+            final AuthenticationSuccessEvent event = getOidcUserAuthority(Map.of(
+                SUB, uniqueID,
+                GIVEN_NAME, givenName,
+                FAMILY_NAME, familyName,
+                EMAIL, email,
+                EMAIL_VERIFIED, true
+            ));
+
+            final Person personForLogin = new Person();
+            personForLogin.setUsername("");
+            personForLogin.setPermissions(List.of(USER));
+            final Optional<Person> person = Optional.of(personForLogin);
+            when(personService.getPersonByUsername(uniqueID)).thenReturn(Optional.empty());
+            when(personService.getPersonByMailAddress(email)).thenReturn(person);
+
+            sut.handle(event);
+
+            verify(personService).getPersonByMailAddress(email);
+
+            final ArgumentCaptor<Person> personArgumentCaptor = ArgumentCaptor.forClass(Person.class);
+            verify(personService).update(personArgumentCaptor.capture());
+
+            Person update = personArgumentCaptor.getValue();
+            // username IS rebound since the existing one was empty (initial migration)
+            assertThat(update.getUsername()).isEqualTo(uniqueID);
         }
     }
 


### PR DESCRIPTION
Fix account takeover vulnerability where an attacker could bind a privileged victim's Person account by setting an unverified email claim to the victim's address in the IdP.

Changes:
- PersonOnSuccessfullyOidcLoginEventHandler: email fallback lookup now requires email_verified == true; username rebinding only occurs when existing username is null or empty (initial migration).
- OidcPersonAuthoritiesMapper: email fallback lookup now requires email_verified == true; skips fallback when claim is missing or false.
- Added tests: doesNotFallbackToEmailWhenNotVerified, doesNotFallbackToEmailWhenVerifiedClaimMissing, rebindsUsernameOnlyWhenNull, doesNotRebindUsernameWhenDifferent, rebindsUsernameWhenEmpty.

All 31 tests pass.

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
