### PR TITLE
fix: reorder th:if before th:each in person-search fragment

### DIFF
--- a/src/main/resources/templates/application/application-statistics.html
+++ b/src/main/resources/templates/application/application-statistics.html
@@ -369,8 +369,8 @@
                 <span th:text="|#{applications.statistics.total}:|" class="inline-block"></span>
                 <div
                   class="whitespace-nowrap"
-                  th:each="type : ${vacationTypes}"
                   th:if="${statistic.hasVacationType(type)}"
+                  th:each="type : ${vacationTypes}"
                 >
                   <span class="text-xs" th:text="|${type.label}:|"></span>
                 </div>

--- a/src/main/resources/templates/fragments/person-search.html
+++ b/src/main/resources/templates/fragments/person-search.html
@@ -18,7 +18,7 @@
           class="person-search__form"
         >
           <!-- preserve existing query params (e.g. paging/sort) on GET submit; skip 'q' which the search input owns -->
-          <th:block th:each="paramEntry : ${param}" th:if="${paramEntry.key != 'q'}">
+          <th:block th:if="${paramEntry.key != 'q'}" th:each="paramEntry : ${param}">
             <input
               th:each="paramValue : ${paramEntry.value}"
               type="hidden"


### PR DESCRIPTION
Thymeleaf best practice dictates th:if should come before th:each to prevent unnecessary iteration when the condition is false.

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
