### PR TITLE
performance: fix n+1 problem of applications that the work days count…

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeave.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeave.java
@@ -14,10 +14,6 @@ public class ApplicationForLeave extends Application {
 
     private final BigDecimal workDays;
 
-    public ApplicationForLeave(Application application, WorkDaysCountService workDaysCountService) {
-        this(application, workDaysCountService.getWorkDaysCount(application.getDayLength(), application.getStartDate(), application.getEndDate(), application.getPerson()));
-    }
-
     /**
      * Creates an {@link ApplicationForLeave} with the already calculated number of work days.
      * <p>

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeave.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeave.java
@@ -15,6 +15,20 @@ public class ApplicationForLeave extends Application {
     private final BigDecimal workDays;
 
     public ApplicationForLeave(Application application, WorkDaysCountService workDaysCountService) {
+        this(application, workDaysCountService.getWorkDaysCount(application.getDayLength(), application.getStartDate(), application.getEndDate(), application.getPerson()));
+    }
+
+    /**
+     * Creates an {@link ApplicationForLeave} with the already calculated number of work days.
+     * <p>
+     * Prefer this constructor together with {@link WorkDaysCountService#getWorkDaysCountForApplications(java.util.Collection)}
+     * when creating an {@link ApplicationForLeave} for each element of a collection, to avoid one working-time query per
+     * application.
+     *
+     * @param application the application to extend
+     * @param workDays    the number of work days of the application
+     */
+    public ApplicationForLeave(Application application, BigDecimal workDays) {
 
         // copy all the properties from the given application for leave
         BeanUtils.copyProperties(application, this);
@@ -22,8 +36,7 @@ public class ApplicationForLeave extends Application {
         // not copied, must be set explicitly
         setId(application.getId());
 
-        // calculate the work days
-        this.workDays = workDaysCountService.getWorkDaysCount(getDayLength(), getStartDate(), getEndDate(), getPerson());
+        this.workDays = workDays;
     }
 
     public BigDecimal getWorkDays() {

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewController.java
@@ -472,7 +472,8 @@ class ApplicationForLeaveDetailsViewController implements HasLaunchpad, HasPerso
         model.addAttribute("lastComment", comments.getLast());
 
         // APPLICATION FOR LEAVE
-        final ApplicationForLeave applicationForLeave = new ApplicationForLeave(application, workDaysCountService);
+        final BigDecimal workDaysCount = workDaysCountService.getWorkDaysCount(application.getDayLength(), application.getStartDate(), application.getEndDate(), application.getPerson());
+        final ApplicationForLeave applicationForLeave = new ApplicationForLeave(application, workDaysCount);
         model.addAttribute("app", applicationForLeaveDetailDto(applicationForLeave, locale));
 
         final Map<DateRange, WorkingTime> workingTime = workingTimeService.getWorkingTimesByPersonAndDateRange(

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveViewController.java
@@ -347,10 +347,13 @@ class ApplicationForLeaveViewController implements HasLaunchpad, HasPersonSearch
             }
         }
 
-        return cancellationRequests.stream()
+        final List<Application> relevantCancellationRequests = cancellationRequests.stream()
             .distinct()
             .filter(withoutApplicationsOf(signedInUser))
-            .map(application -> new ApplicationForLeave(application, workDaysCountService))
+            .toList();
+        final Map<Application, BigDecimal> workDaysByApplication = workDaysCountService.getWorkDaysCountForApplications(relevantCancellationRequests);
+        return relevantCancellationRequests.stream()
+            .map(application -> new ApplicationForLeave(application, workDaysByApplication.get(application)))
             .sorted(comparing(ApplicationForLeave::getStartDate))
             .toList();
     }
@@ -382,8 +385,10 @@ class ApplicationForLeaveViewController implements HasLaunchpad, HasPersonSearch
     }
 
     private List<ApplicationForLeave> getApplicationsForLeaveForBossOrOffice() {
-        return applicationService.getForStates(List.of(WAITING, TEMPORARY_ALLOWED)).stream()
-            .map(application -> new ApplicationForLeave(application, workDaysCountService))
+        final List<Application> applications = applicationService.getForStates(List.of(WAITING, TEMPORARY_ALLOWED));
+        final Map<Application, BigDecimal> workDaysByApplication = workDaysCountService.getWorkDaysCountForApplications(applications);
+        return applications.stream()
+            .map(application -> new ApplicationForLeave(application, workDaysByApplication.get(application)))
             .sorted(comparing(ApplicationForLeave::getStartDate))
             .toList();
     }
@@ -391,25 +396,33 @@ class ApplicationForLeaveViewController implements HasLaunchpad, HasPersonSearch
     private List<ApplicationForLeave> getApplicationsForLeaveForUser(Person user) {
         final List<ApplicationStatus> states = List.of(WAITING, TEMPORARY_ALLOWED, ALLOWED_CANCELLATION_REQUESTED);
 
-        return applicationService.getForStatesAndPerson(states, List.of(user)).stream()
-            .map(application -> new ApplicationForLeave(application, workDaysCountService))
+        final List<Application> applications = applicationService.getForStatesAndPerson(states, List.of(user));
+        final Map<Application, BigDecimal> workDaysByApplication = workDaysCountService.getWorkDaysCountForApplications(applications);
+        return applications.stream()
+            .map(application -> new ApplicationForLeave(application, workDaysByApplication.get(application)))
             .sorted(comparing(ApplicationForLeave::getStartDate))
             .toList();
     }
 
     private List<ApplicationForLeave> getApplicationsForLeaveForDepartmentHead(Person head, List<Person> membersOfDepartmentHead) {
-        return applicationService.getForStatesAndPerson(List.of(WAITING), membersOfDepartmentHead).stream()
+        final List<Application> applications = applicationService.getForStatesAndPerson(List.of(WAITING), membersOfDepartmentHead).stream()
             .filter(withoutApplicationsOf(head))
             .filter(withoutSecondStageAuthorityApplications(head))
-            .map(application -> new ApplicationForLeave(application, workDaysCountService))
+            .toList();
+        final Map<Application, BigDecimal> workDaysByApplication = workDaysCountService.getWorkDaysCountForApplications(applications);
+        return applications.stream()
+            .map(application -> new ApplicationForLeave(application, workDaysByApplication.get(application)))
             .sorted(comparing(ApplicationForLeave::getStartDate))
             .toList();
     }
 
     private List<ApplicationForLeave> getApplicationsForLeaveForSecondStageAuthority(Person secondStage, List<Person> membersOfSecondStageAuthority) {
-        return applicationService.getForStatesAndPerson(List.of(WAITING, TEMPORARY_ALLOWED), membersOfSecondStageAuthority).stream()
+        final List<Application> applications = applicationService.getForStatesAndPerson(List.of(WAITING, TEMPORARY_ALLOWED), membersOfSecondStageAuthority).stream()
             .filter(withoutApplicationsOf(secondStage))
-            .map(application -> new ApplicationForLeave(application, workDaysCountService))
+            .toList();
+        final Map<Application, BigDecimal> workDaysByApplication = workDaysCountService.getWorkDaysCountForApplications(applications);
+        return applications.stream()
+            .map(application -> new ApplicationForLeave(application, workDaysByApplication.get(application)))
             .sorted(comparing(ApplicationForLeave::getStartDate))
             .toList();
     }

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveViewController.java
@@ -351,11 +351,7 @@ class ApplicationForLeaveViewController implements HasLaunchpad, HasPersonSearch
             .distinct()
             .filter(withoutApplicationsOf(signedInUser))
             .toList();
-        final Map<Application, BigDecimal> workDaysByApplication = workDaysCountService.getWorkDaysCountForApplications(relevantCancellationRequests);
-        return relevantCancellationRequests.stream()
-            .map(application -> new ApplicationForLeave(application, workDaysByApplication.get(application)))
-            .sorted(comparing(ApplicationForLeave::getStartDate))
-            .toList();
+        return toSortedApplicationsForLeave(relevantCancellationRequests);
     }
 
     private List<ApplicationForLeave> getOtherRelevantApplicationsForLeave(Person signedInUser, List<Person> membersOfDepartmentHead, List<Person> membersOfSecondStageAuthority) {
@@ -385,23 +381,12 @@ class ApplicationForLeaveViewController implements HasLaunchpad, HasPersonSearch
     }
 
     private List<ApplicationForLeave> getApplicationsForLeaveForBossOrOffice() {
-        final List<Application> applications = applicationService.getForStates(List.of(WAITING, TEMPORARY_ALLOWED));
-        final Map<Application, BigDecimal> workDaysByApplication = workDaysCountService.getWorkDaysCountForApplications(applications);
-        return applications.stream()
-            .map(application -> new ApplicationForLeave(application, workDaysByApplication.get(application)))
-            .sorted(comparing(ApplicationForLeave::getStartDate))
-            .toList();
+        return toSortedApplicationsForLeave(applicationService.getForStates(List.of(WAITING, TEMPORARY_ALLOWED)));
     }
 
     private List<ApplicationForLeave> getApplicationsForLeaveForUser(Person user) {
         final List<ApplicationStatus> states = List.of(WAITING, TEMPORARY_ALLOWED, ALLOWED_CANCELLATION_REQUESTED);
-
-        final List<Application> applications = applicationService.getForStatesAndPerson(states, List.of(user));
-        final Map<Application, BigDecimal> workDaysByApplication = workDaysCountService.getWorkDaysCountForApplications(applications);
-        return applications.stream()
-            .map(application -> new ApplicationForLeave(application, workDaysByApplication.get(application)))
-            .sorted(comparing(ApplicationForLeave::getStartDate))
-            .toList();
+        return toSortedApplicationsForLeave(applicationService.getForStatesAndPerson(states, List.of(user)));
     }
 
     private List<ApplicationForLeave> getApplicationsForLeaveForDepartmentHead(Person head, List<Person> membersOfDepartmentHead) {
@@ -409,17 +394,17 @@ class ApplicationForLeaveViewController implements HasLaunchpad, HasPersonSearch
             .filter(withoutApplicationsOf(head))
             .filter(withoutSecondStageAuthorityApplications(head))
             .toList();
-        final Map<Application, BigDecimal> workDaysByApplication = workDaysCountService.getWorkDaysCountForApplications(applications);
-        return applications.stream()
-            .map(application -> new ApplicationForLeave(application, workDaysByApplication.get(application)))
-            .sorted(comparing(ApplicationForLeave::getStartDate))
-            .toList();
+        return toSortedApplicationsForLeave(applications);
     }
 
     private List<ApplicationForLeave> getApplicationsForLeaveForSecondStageAuthority(Person secondStage, List<Person> membersOfSecondStageAuthority) {
         final List<Application> applications = applicationService.getForStatesAndPerson(List.of(WAITING, TEMPORARY_ALLOWED), membersOfSecondStageAuthority).stream()
             .filter(withoutApplicationsOf(secondStage))
             .toList();
+        return toSortedApplicationsForLeave(applications);
+    }
+
+    private List<ApplicationForLeave> toSortedApplicationsForLeave(List<Application> applications) {
         final Map<Application, BigDecimal> workDaysByApplication = workDaysCountService.getWorkDaysCountForApplications(applications);
         return applications.stream()
             .map(application -> new ApplicationForLeave(application, workDaysByApplication.get(application)))

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/export/ApplicationForLeaveExportService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/export/ApplicationForLeaveExportService.java
@@ -21,6 +21,7 @@ import org.synyx.urlaubsverwaltung.search.PageableSearchQuery;
 import org.synyx.urlaubsverwaltung.search.SortComparator;
 import org.synyx.urlaubsverwaltung.workingtime.WorkDaysCountService;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
@@ -91,10 +92,11 @@ class ApplicationForLeaveExportService {
 
         final Map<PersonId, PersonBasedata> basedataByPersonId = personBasedataService.getBasedataByPersonId(relevantPersonIds);
         final Map<PersonId, List<String>> departmentsByPersonId = departmentService.getDepartmentNamesByMembers(relevantMembers);
+        final Map<Application, BigDecimal> workDaysByApplication = workDaysCountService.getWorkDaysCountForApplications(applications);
 
         Stream<ApplicationForLeaveExport> exportsStream = applicationsByPerson.entrySet()
             .stream()
-            .map(toApplicationForLeaveExport(basedataByPersonId, departmentsByPersonId));
+            .map(toApplicationForLeaveExport(basedataByPersonId, departmentsByPersonId, workDaysByApplication));
 
         if (relevantMembersPage.getPageable().isUnpaged()) {
             // we don't have to restrict the statistics if persons page is paged and or sorted already.
@@ -111,14 +113,15 @@ class ApplicationForLeaveExportService {
         return new PageImpl<>(content, pageable, relevantMembersPage.getTotalElements());
     }
 
-    private Function<Map.Entry<Person, List<Application>>, ApplicationForLeaveExport> toApplicationForLeaveExport(Map<PersonId, PersonBasedata> basedataForPersons, Map<PersonId, List<String>> departmentsForPersons) {
+    private Function<Map.Entry<Person, List<Application>>, ApplicationForLeaveExport> toApplicationForLeaveExport(Map<PersonId, PersonBasedata> basedataForPersons, Map<PersonId, List<String>> departmentsForPersons, Map<Application, BigDecimal> workDaysByApplication) {
         return personListEntry ->
         {
             final Person person = personListEntry.getKey();
             final PersonId personId = person.getIdAsPersonId();
             final String personnelNumber = basedataForPersons.getOrDefault(personId, new PersonBasedata(personId, "", "")).personnelNumber();
             final List<String> departments = departmentsForPersons.getOrDefault(personId, List.of());
-            final List<ApplicationForLeave> applicationForLeaves = personListEntry.getValue().stream().map(app -> new ApplicationForLeave(app, workDaysCountService)).toList();
+            final List<ApplicationForLeave> applicationForLeaves = personListEntry.getValue().stream()
+                .map(app -> new ApplicationForLeave(app, workDaysByApplication.get(app))).toList();
             return new ApplicationForLeaveExport(personnelNumber, person.getFirstName(), person.getLastName(), applicationForLeaves, departments);
         };
     }

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/me/ApplicationsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/me/ApplicationsViewController.java
@@ -149,9 +149,7 @@ public class ApplicationsViewController implements HasLaunchpad, HasPersonSearch
             applicationsForLeave = List.of();
             usedDaysOverview = new YearlyUsedDaysSummary(List.of(), year, workDaysCountService);
         } else {
-            final Map<Application, BigDecimal> workDaysByApplication = workDaysCountService.getWorkDaysCountForApplications(applications);
-            applicationsForLeave = applications.stream()
-                .map(application -> new ApplicationForLeave(application, workDaysByApplication.get(application)))
+            applicationsForLeave = toApplicationsForLeave(applications).stream()
                 .sorted(comparing(ApplicationForLeave::getStartDate).reversed())
                 .map(applicationForLeave -> applicationDto(applicationForLeave, signedInUser, locale))
                 .toList();
@@ -160,6 +158,13 @@ public class ApplicationsViewController implements HasLaunchpad, HasPersonSearch
 
         model.addAttribute("applications", applicationsForLeave);
         model.addAttribute("usedDaysOverview", usedDaysOverview);
+    }
+
+    private List<ApplicationForLeave> toApplicationsForLeave(List<Application> applications) {
+        final Map<Application, BigDecimal> workDaysByApplication = workDaysCountService.getWorkDaysCountForApplications(applications);
+        return applications.stream()
+            .map(application -> new ApplicationForLeave(application, workDaysByApplication.get(application)))
+            .toList();
     }
 
     private ApplicationVacationTypeDto applicationVacationTypDto(VacationType<?> vacationType, Locale locale) {

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/me/ApplicationsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/me/ApplicationsViewController.java
@@ -23,11 +23,13 @@ import org.synyx.urlaubsverwaltung.search.PersonSearchUiFragmentSupplier;
 import org.synyx.urlaubsverwaltung.search.PersonSuggestionUrlStrategy;
 import org.synyx.urlaubsverwaltung.workingtime.WorkDaysCountService;
 
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.Year;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import static java.time.temporal.TemporalAdjusters.lastDayOfYear;
 import static java.util.Comparator.comparing;
@@ -147,8 +149,9 @@ public class ApplicationsViewController implements HasLaunchpad, HasPersonSearch
             applicationsForLeave = List.of();
             usedDaysOverview = new YearlyUsedDaysSummary(List.of(), year, workDaysCountService);
         } else {
+            final Map<Application, BigDecimal> workDaysByApplication = workDaysCountService.getWorkDaysCountForApplications(applications);
             applicationsForLeave = applications.stream()
-                .map(application -> new ApplicationForLeave(application, workDaysCountService))
+                .map(application -> new ApplicationForLeave(application, workDaysByApplication.get(application)))
                 .sorted(comparing(ApplicationForLeave::getStartDate).reversed())
                 .map(applicationForLeave -> applicationDto(applicationForLeave, signedInUser, locale))
                 .toList();

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/me/YearlyUsedDaysSummary.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/me/YearlyUsedDaysSummary.java
@@ -1,20 +1,16 @@
 package org.synyx.urlaubsverwaltung.application.me;
 
+import org.synyx.urlaubsverwaltung.absence.DateRange;
 import org.synyx.urlaubsverwaltung.application.application.Application;
 import org.synyx.urlaubsverwaltung.application.application.ApplicationStatus;
-import org.synyx.urlaubsverwaltung.period.DayLength;
-import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.workingtime.WorkDaysCountService;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.time.Year;
 import java.util.List;
+import java.util.Map;
 
 import static java.time.Month.DECEMBER;
-import static java.util.Collections.max;
-import static java.util.Collections.min;
-import static java.util.List.of;
 import static org.synyx.urlaubsverwaltung.application.application.ApplicationStatus.ALLOWED;
 import static org.synyx.urlaubsverwaltung.application.application.ApplicationStatus.ALLOWED_CANCELLATION_REQUESTED;
 import static org.synyx.urlaubsverwaltung.application.application.ApplicationStatus.TEMPORARY_ALLOWED;
@@ -45,23 +41,30 @@ public class YearlyUsedDaysSummary {
         this.otherDays = new UsedDays(WAITING, TEMPORARY_ALLOWED, ALLOWED, ALLOWED_CANCELLATION_REQUESTED);
         this.otherDaysAllowed = new UsedDays(ALLOWED, ALLOWED_CANCELLATION_REQUESTED);
 
-        for (final Application application : applications) {
-            if (application.hasStatus(WAITING) || application.hasStatus(TEMPORARY_ALLOWED) || application.hasStatus(ALLOWED) || application.hasStatus(ALLOWED_CANCELLATION_REQUESTED)) {
-                final BigDecimal vacationDays = getVacationDays(application, calendarService);
-                final ApplicationStatus status = application.getStatus();
+        final List<Application> relevantApplications = applications.stream()
+            .filter(application -> application.hasStatus(WAITING) || application.hasStatus(TEMPORARY_ALLOWED) || application.hasStatus(ALLOWED) || application.hasStatus(ALLOWED_CANCELLATION_REQUESTED))
+            .toList();
 
+        final DateRange yearDateRange = new DateRange(Year.of(year).atDay(1), Year.of(year).atMonth(DECEMBER).atEndOfMonth());
+        final Map<Application, BigDecimal> vacationDaysByApplication = relevantApplications.isEmpty()
+            ? Map.of()
+            : calendarService.getWorkDaysCountForApplications(relevantApplications, yearDateRange);
+
+        for (final Application application : relevantApplications) {
+            final BigDecimal vacationDays = vacationDaysByApplication.get(application);
+            final ApplicationStatus status = application.getStatus();
+
+            if (application.getVacationType().isOfCategory(HOLIDAY)) {
+                this.holidayDays.addDays(status, vacationDays);
+            } else {
+                this.otherDays.addDays(status, vacationDays);
+            }
+
+            if (application.hasStatus(ALLOWED) || application.hasStatus(ALLOWED_CANCELLATION_REQUESTED)) {
                 if (application.getVacationType().isOfCategory(HOLIDAY)) {
-                    this.holidayDays.addDays(status, vacationDays);
+                    this.holidayDaysAllowed.addDays(status, vacationDays);
                 } else {
-                    this.otherDays.addDays(status, vacationDays);
-                }
-
-                if (application.hasStatus(ALLOWED) || application.hasStatus(ALLOWED_CANCELLATION_REQUESTED)) {
-                    if (application.getVacationType().isOfCategory(HOLIDAY)) {
-                        this.holidayDaysAllowed.addDays(status, vacationDays);
-                    } else {
-                        this.otherDaysAllowed.addDays(status, vacationDays);
-                    }
+                    this.otherDaysAllowed.addDays(status, vacationDays);
                 }
             }
         }
@@ -81,15 +84,5 @@ public class YearlyUsedDaysSummary {
 
     public UsedDays getOtherDaysAllowed() {
         return otherDaysAllowed;
-    }
-
-    private BigDecimal getVacationDays(Application application, WorkDaysCountService calendarService) {
-
-        final DayLength dayLength = application.getDayLength();
-        final LocalDate startDate = max(of(application.getStartDate(), Year.of(year).atDay(1)));
-        final LocalDate endDate = min(of(application.getEndDate(), Year.of(year).atMonth(DECEMBER).atEndOfMonth()));
-        final Person person = application.getPerson();
-
-        return calendarService.getWorkDaysCount(dayLength, startDate, endDate, person);
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/overview/ApplicationDaysUsedSummaryDto.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overview/ApplicationDaysUsedSummaryDto.java
@@ -1,20 +1,16 @@
 package org.synyx.urlaubsverwaltung.overview;
 
+import org.synyx.urlaubsverwaltung.absence.DateRange;
 import org.synyx.urlaubsverwaltung.application.application.Application;
 import org.synyx.urlaubsverwaltung.application.application.ApplicationStatus;
-import org.synyx.urlaubsverwaltung.period.DayLength;
-import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.workingtime.WorkDaysCountService;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.time.Year;
 import java.util.List;
+import java.util.Map;
 
 import static java.time.Month.DECEMBER;
-import static java.util.Collections.max;
-import static java.util.Collections.min;
-import static java.util.List.of;
 import static org.synyx.urlaubsverwaltung.application.application.ApplicationStatus.ALLOWED;
 import static org.synyx.urlaubsverwaltung.application.application.ApplicationStatus.ALLOWED_CANCELLATION_REQUESTED;
 import static org.synyx.urlaubsverwaltung.application.application.ApplicationStatus.TEMPORARY_ALLOWED;
@@ -45,23 +41,30 @@ final class ApplicationDaysUsedSummaryDto {
         this.otherDays = new ApplicationDaysUsedDto(WAITING, TEMPORARY_ALLOWED, ALLOWED, ALLOWED_CANCELLATION_REQUESTED);
         this.otherDaysAllowed = new ApplicationDaysUsedDto(ALLOWED, ALLOWED_CANCELLATION_REQUESTED);
 
-        for (final Application application : applications) {
-            if (application.hasStatus(WAITING) || application.hasStatus(TEMPORARY_ALLOWED) || application.hasStatus(ALLOWED) || application.hasStatus(ALLOWED_CANCELLATION_REQUESTED)) {
-                final BigDecimal vacationDays = getVacationDays(application, calendarService);
-                final ApplicationStatus status = application.getStatus();
+        final List<Application> relevantApplications = applications.stream()
+            .filter(application -> application.hasStatus(WAITING) || application.hasStatus(TEMPORARY_ALLOWED) || application.hasStatus(ALLOWED) || application.hasStatus(ALLOWED_CANCELLATION_REQUESTED))
+            .toList();
 
+        final DateRange yearDateRange = new DateRange(Year.of(year).atDay(1), Year.of(year).atMonth(DECEMBER).atEndOfMonth());
+        final Map<Application, BigDecimal> vacationDaysByApplication = relevantApplications.isEmpty()
+            ? Map.of()
+            : calendarService.getWorkDaysCountForApplications(relevantApplications, yearDateRange);
+
+        for (final Application application : relevantApplications) {
+            final BigDecimal vacationDays = vacationDaysByApplication.get(application);
+            final ApplicationStatus status = application.getStatus();
+
+            if (application.getVacationType().isOfCategory(HOLIDAY)) {
+                this.holidayDays.addDays(status, vacationDays);
+            } else {
+                this.otherDays.addDays(status, vacationDays);
+            }
+
+            if (application.hasStatus(ALLOWED) || application.hasStatus(ALLOWED_CANCELLATION_REQUESTED)) {
                 if (application.getVacationType().isOfCategory(HOLIDAY)) {
-                    this.holidayDays.addDays(status, vacationDays);
+                    this.holidayDaysAllowed.addDays(status, vacationDays);
                 } else {
-                    this.otherDays.addDays(status, vacationDays);
-                }
-
-                if (application.hasStatus(ALLOWED) || application.hasStatus(ALLOWED_CANCELLATION_REQUESTED)) {
-                    if (application.getVacationType().isOfCategory(HOLIDAY)) {
-                        this.holidayDaysAllowed.addDays(status, vacationDays);
-                    } else {
-                        this.otherDaysAllowed.addDays(status, vacationDays);
-                    }
+                    this.otherDaysAllowed.addDays(status, vacationDays);
                 }
             }
         }
@@ -81,15 +84,5 @@ final class ApplicationDaysUsedSummaryDto {
 
     public ApplicationDaysUsedDto getOtherDaysAllowed() {
         return otherDaysAllowed;
-    }
-
-    private BigDecimal getVacationDays(Application application, WorkDaysCountService calendarService) {
-
-        final DayLength dayLength = application.getDayLength();
-        final LocalDate startDate = max(of(application.getStartDate(), Year.of(year).atDay(1)));
-        final LocalDate endDate = min(of(application.getEndDate(), Year.of(year).atMonth(DECEMBER).atEndOfMonth()));
-        final Person person = application.getPerson();
-
-        return calendarService.getWorkDaysCount(dayLength, startDate, endDate, person);
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/overview/OverviewViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overview/OverviewViewController.java
@@ -223,8 +223,9 @@ public class OverviewViewController implements HasLaunchpad, HasPersonSearch {
             usedDaysOverview = new ApplicationDaysUsedSummaryDto(List.of(), year, workDaysCountService);
         } else {
             final LocalDate today = LocalDate.now(clock);
+            final Map<Application, BigDecimal> workDaysByApplication = workDaysCountService.getWorkDaysCountForApplications(applications);
             final List<ApplicationForLeave> allForLeave = applications.stream()
-                .map(application -> new ApplicationForLeave(application, workDaysCountService))
+                .map(application -> new ApplicationForLeave(application, workDaysByApplication.get(application)))
                 .toList();
             // always show 3 applications if no application is in the fill with future application
             final List<ApplicationDto> pastApplicationDtos = allForLeave.stream()

--- a/src/main/java/org/synyx/urlaubsverwaltung/overview/OverviewViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overview/OverviewViewController.java
@@ -223,10 +223,7 @@ public class OverviewViewController implements HasLaunchpad, HasPersonSearch {
             usedDaysOverview = new ApplicationDaysUsedSummaryDto(List.of(), year, workDaysCountService);
         } else {
             final LocalDate today = LocalDate.now(clock);
-            final Map<Application, BigDecimal> workDaysByApplication = workDaysCountService.getWorkDaysCountForApplications(applications);
-            final List<ApplicationForLeave> allForLeave = applications.stream()
-                .map(application -> new ApplicationForLeave(application, workDaysByApplication.get(application)))
-                .toList();
+            final List<ApplicationForLeave> allForLeave = toApplicationsForLeave(applications);
             // always show 3 applications if no application is in the fill with future application
             final List<ApplicationDto> pastApplicationDtos = allForLeave.stream()
                 .filter(a -> a.getStartDate().isBefore(today))
@@ -254,6 +251,13 @@ public class OverviewViewController implements HasLaunchpad, HasPersonSearch {
             applicationsForLeave.size(),
             applications.size()
         ));
+    }
+
+    private List<ApplicationForLeave> toApplicationsForLeave(List<Application> applications) {
+        final Map<Application, BigDecimal> workDaysByApplication = workDaysCountService.getWorkDaysCountForApplications(applications);
+        return applications.stream()
+            .map(application -> new ApplicationForLeave(application, workDaysByApplication.get(application)))
+            .toList();
     }
 
     private void prepareSickNoteInformation(Person person, Person signedInUser, int year, Model model) {

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountService.java
@@ -1,9 +1,11 @@
 package org.synyx.urlaubsverwaltung.workingtime;
 
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.synyx.urlaubsverwaltung.absence.DateRange;
+import org.synyx.urlaubsverwaltung.application.application.Application;
 import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.publicholiday.PublicHoliday;
@@ -11,7 +13,9 @@ import org.synyx.urlaubsverwaltung.publicholiday.PublicHolidaysService;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -49,10 +53,76 @@ public class WorkDaysCountService {
      * @throws IllegalArgumentException when <code>endDate</code> is before <code>startDate</code>
      */
     public BigDecimal getWorkDaysCount(DayLength dayLength, LocalDate startDate, LocalDate endDate, Person person) {
-
         final DateRange dateRange = new DateRange(startDate, endDate);
-
         final Map<DateRange, WorkingTime> workingTimes = workingTimeService.getWorkingTimesByPersonAndDateRange(person, dateRange);
+        return workDaysCount(dayLength, startDate, endDate, person, workingTimes);
+    }
+
+    /**
+     * Batch variant of {@link #getWorkDaysCount(DayLength, LocalDate, LocalDate, Person)} for many applications.
+     * <p>
+     * The working times of all involved persons are loaded with a single query (instead of one query per
+     * application), avoiding an N+1 query when the workdays of a whole list of applications are needed. Each
+     * application's workdays are calculated for the application's own date range.
+     *
+     * @param applications to calculate the workdays for
+     * @return the number of workdays per application
+     */
+    public Map<Application, BigDecimal> getWorkDaysCountForApplications(Collection<Application> applications) {
+        return getWorkDaysCountForApplications(applications, null);
+    }
+
+    /**
+     * Batch variant of {@link #getWorkDaysCount(DayLength, LocalDate, LocalDate, Person)} for many applications, where
+     * the calculated period of each application is limited to (clipped to) the given date range.
+     * <p>
+     * The working times of all involved persons are loaded with a single query (instead of one query per
+     * application), avoiding an N+1 query.
+     *
+     * @param applications        to calculate the workdays for
+     * @param limitedToDateRange  the date range each application's period is clipped to
+     * @return the number of workdays per application within the given date range
+     */
+    public Map<Application, BigDecimal> getWorkDaysCountForApplications(Collection<Application> applications, DateRange limitedToDateRange) {
+
+        if (applications.isEmpty()) {
+            return Map.of();
+        }
+
+        final List<Person> persons = applications.stream().map(Application::getPerson).distinct().toList();
+        final Map<Person, List<WorkingTime>> workingTimesByPerson = workingTimeService.getByPersons(persons).stream()
+            .collect(groupingBy(WorkingTime::getPerson));
+
+        final Map<Application, BigDecimal> workDaysCountByApplication = new LinkedHashMap<>();
+        for (Application application : applications) {
+            final LocalDate startDate = clipStart(application.getStartDate(), limitedToDateRange);
+            final LocalDate endDate = clipEnd(application.getEndDate(), limitedToDateRange);
+            final List<WorkingTime> personWorkingTimes = workingTimesByPerson.getOrDefault(application.getPerson(), List.of());
+            final Map<DateRange, WorkingTime> workingTimes =
+                WorkingTimeServiceImpl.workingTimesByDateRange(personWorkingTimes, new DateRange(startDate, endDate));
+            workDaysCountByApplication.put(application,
+                workDaysCount(application.getDayLength(), startDate, endDate, application.getPerson(), workingTimes));
+        }
+
+        return workDaysCountByApplication;
+    }
+
+    private static LocalDate clipStart(LocalDate startDate, @Nullable DateRange limit) {
+        if (limit == null || !limit.startDate().isAfter(startDate)) {
+            return startDate;
+        }
+        return limit.startDate();
+    }
+
+    private static LocalDate clipEnd(LocalDate endDate, @Nullable DateRange limit) {
+        if (limit == null || !limit.endDate().isBefore(endDate)) {
+            return endDate;
+        }
+        return limit.endDate();
+    }
+
+    private BigDecimal workDaysCount(DayLength dayLength, LocalDate startDate, LocalDate endDate, Person person, Map<DateRange, WorkingTime> workingTimes) {
+
         if (workingTimes.isEmpty()) {
             throw new WorkDaysCountException("No working times found for user '" + person.getId()
                 + "' in period " + startDate.format(ofPattern(DD_MM_YYYY)) + " - " + endDate.format(ofPattern(DD_MM_YYYY)));

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImpl.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.time.format.DateTimeFormatter.ofPattern;
 import static java.time.temporal.TemporalAdjusters.firstDayOfYear;
+import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toMap;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.synyx.urlaubsverwaltung.util.DateAndTimeFormat.DD_MM_YYYY;
@@ -101,9 +102,25 @@ class WorkingTimeServiceImpl implements WorkingTimeService, WorkingTimeWriteServ
 
     @Override
     public Map<DateRange, WorkingTime> getWorkingTimesByPersonAndDateRange(Person person, DateRange dateRange) {
-
         final List<WorkingTime> workingTimesByPerson = toWorkingTimes(workingTimeRepository.findByPersonOrderByValidFromDesc(person));
-        final List<WorkingTime> workingTimeList = workingTimesByPerson.stream()
+        return workingTimesByDateRange(workingTimesByPerson, dateRange);
+    }
+
+    /**
+     * Maps the given working times of a single person to the date ranges they apply to within the given date range.
+     * <p>
+     * This is the in-memory part of {@link #getWorkingTimesByPersonAndDateRange(Person, DateRange)} extracted so that
+     * callers which already loaded the working times of (potentially many) persons in a single query can reuse it
+     * without issuing one query per person.
+     *
+     * @param workingTimes all working times of a single person (in any order)
+     * @param dateRange    the date range of interest
+     * @return map of date ranges and the associated working time of the person
+     */
+    static Map<DateRange, WorkingTime> workingTimesByDateRange(List<WorkingTime> workingTimes, DateRange dateRange) {
+
+        final List<WorkingTime> workingTimeList = workingTimes.stream()
+            .sorted(comparing(WorkingTime::getValidFrom).reversed())
             .filter(workingTime -> !workingTime.getValidFrom().isAfter(dateRange.endDate()))
             .toList();
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveTest.java
@@ -1,33 +1,20 @@
 package org.synyx.urlaubsverwaltung.application.application;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.support.StaticMessageSource;
-import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.person.Person;
-import org.synyx.urlaubsverwaltung.workingtime.WorkDaysCountService;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 
 import static java.math.BigDecimal.TEN;
 import static java.time.DayOfWeek.FRIDAY;
 import static java.time.DayOfWeek.TUESDAY;
 import static java.time.LocalDate.of;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static org.synyx.urlaubsverwaltung.TestDataCreator.createApplication;
 import static org.synyx.urlaubsverwaltung.period.DayLength.FULL;
 
-@ExtendWith(MockitoExtension.class)
 class ApplicationForLeaveTest {
-
-    @Mock
-    private WorkDaysCountService workDaysCountService;
 
     @Test
     void ensureCreatesCorrectApplicationForLeave() {
@@ -36,16 +23,11 @@ class ApplicationForLeaveTest {
 
         final Application application = createApplication(person, of(2015, 3, 3), of(2015, 3, 6), FULL, new StaticMessageSource());
 
-        when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class)))
-            .thenReturn(TEN);
-
-        final ApplicationForLeave sut = new ApplicationForLeave(application, workDaysCountService);
+        final ApplicationForLeave sut = new ApplicationForLeave(application, TEN);
         assertThat(sut.getStartDate()).isEqualTo(application.getStartDate());
         assertThat(sut.getEndDate()).isEqualTo(application.getEndDate());
         assertThat(sut.getDayLength()).isEqualTo(application.getDayLength());
         assertThat(sut.getWorkDays()).isEqualTo(TEN);
-
-        verify(workDaysCountService).getWorkDaysCount(application.getDayLength(), application.getStartDate(), application.getEndDate(), person);
     }
 
     @Test
@@ -55,10 +37,7 @@ class ApplicationForLeaveTest {
 
         final Application application = createApplication(person, of(2016, 3, 1), of(2016, 3, 4), FULL, new StaticMessageSource());
 
-        when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class), any(LocalDate.class), any(Person.class)))
-            .thenReturn(BigDecimal.valueOf(4));
-
-        final ApplicationForLeave sut = new ApplicationForLeave(application, workDaysCountService);
+        final ApplicationForLeave sut = new ApplicationForLeave(application, BigDecimal.valueOf(4));
         assertThat(sut.getWeekDayOfStartDate()).isEqualTo(TUESDAY);
         assertThat(sut.getWeekDayOfEndDate()).isEqualTo(FRIDAY);
     }

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/export/ApplicationForLeaveCsvExportServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/export/ApplicationForLeaveCsvExportServiceTest.java
@@ -14,7 +14,6 @@ import org.synyx.urlaubsverwaltung.application.vacationtype.VacationType;
 import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.web.FilterPeriod;
-import org.synyx.urlaubsverwaltung.workingtime.WorkDaysCountService;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -40,8 +39,6 @@ class ApplicationForLeaveCsvExportServiceTest {
     private CSVWriter csvWriter;
     @Mock
     private MessageSource messageSource;
-    @Mock
-    private WorkDaysCountService workDaysCountService;
 
     @BeforeEach
     void setUp() {
@@ -78,9 +75,7 @@ class ApplicationForLeaveCsvExportServiceTest {
         application.setStatus(ALLOWED);
         application.setVacationType(vacationType);
 
-        when(workDaysCountService.getWorkDaysCount(application.getDayLength(), application.getStartDate(), application.getEndDate(), application.getPerson())).thenReturn(TEN);
-
-        final ApplicationForLeave applicationForLeave = new ApplicationForLeave(application, workDaysCountService);
+        final ApplicationForLeave applicationForLeave = new ApplicationForLeave(application, TEN);
 
         final List<ApplicationForLeaveExport> applicationForLeaveExports = new ArrayList<>();
         final ApplicationForLeaveExport applicationForLeaveExport = new ApplicationForLeaveExport("1", person.getFirstName(), person.getLastName(), List.of(applicationForLeave), List.of("departmentA"));

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/export/ApplicationForLeaveExportServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/export/ApplicationForLeaveExportServiceTest.java
@@ -25,6 +25,7 @@ import org.synyx.urlaubsverwaltung.person.basedata.PersonBasedataService;
 import org.synyx.urlaubsverwaltung.search.PageableSearchQuery;
 import org.synyx.urlaubsverwaltung.workingtime.WorkDaysCountService;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
@@ -82,7 +83,7 @@ class ApplicationForLeaveExportServiceTest {
 
         final LocalDate from = LocalDate.of(2023, 1, 1);
         final LocalDate to = LocalDate.of(2023, 1, 31);
-        final ApplicationForLeave app = new ApplicationForLeave(new Application(), workDaysCountService);
+        final ApplicationForLeave app = new ApplicationForLeave(new Application(), BigDecimal.ZERO);
         app.setId(1L);
         app.setPerson(user);
         when(applicationService.getForStatesAndPerson(List.of(ALLOWED, TEMPORARY_ALLOWED, ALLOWED_CANCELLATION_REQUESTED), personsForExport, from, to)).thenReturn(List.of(app));
@@ -127,7 +128,7 @@ class ApplicationForLeaveExportServiceTest {
 
         final LocalDate from = LocalDate.of(2023, 1, 1);
         final LocalDate to = LocalDate.of(2023, 1, 31);
-        final ApplicationForLeave app = new ApplicationForLeave(new Application(), workDaysCountService);
+        final ApplicationForLeave app = new ApplicationForLeave(new Application(), BigDecimal.ZERO);
         app.setId(1L);
         app.setPerson(departmentMember);
         when(applicationService.getForStatesAndPerson(List.of(ALLOWED, TEMPORARY_ALLOWED, ALLOWED_CANCELLATION_REQUESTED), personsForExport, from, to)).thenReturn(List.of(app));
@@ -188,7 +189,7 @@ class ApplicationForLeaveExportServiceTest {
 
         final LocalDate from = LocalDate.of(2023, 1, 1);
         final LocalDate to = LocalDate.of(2023, 1, 31);
-        final ApplicationForLeave app = new ApplicationForLeave(new Application(), workDaysCountService);
+        final ApplicationForLeave app = new ApplicationForLeave(new Application(), BigDecimal.ZERO);
         app.setId(1L);
         app.setPerson(user);
         when(applicationService.getForStatesAndPerson(List.of(ALLOWED, TEMPORARY_ALLOWED, ALLOWED_CANCELLATION_REQUESTED), personsForExport, from, to)).thenReturn(List.of(app));
@@ -237,7 +238,7 @@ class ApplicationForLeaveExportServiceTest {
 
         final LocalDate from = LocalDate.of(2023, 1, 1);
         final LocalDate to = LocalDate.of(2023, 1, 31);
-        final ApplicationForLeave app = new ApplicationForLeave(new Application(), workDaysCountService);
+        final ApplicationForLeave app = new ApplicationForLeave(new Application(), BigDecimal.ZERO);
         app.setId(1L);
         app.setPerson(user);
         when(applicationService.getForStatesAndPerson(List.of(ALLOWED, TEMPORARY_ALLOWED, ALLOWED_CANCELLATION_REQUESTED), personsForExport, from, to)).thenReturn(List.of(app));

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/export/ApplicationForLeaveExportViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/export/ApplicationForLeaveExportViewControllerTest.java
@@ -24,7 +24,6 @@ import org.synyx.urlaubsverwaltung.person.PersonService;
 import org.synyx.urlaubsverwaltung.search.PageableSearchQuery;
 import org.synyx.urlaubsverwaltung.web.DateFormatAware;
 import org.synyx.urlaubsverwaltung.web.FilterPeriod;
-import org.synyx.urlaubsverwaltung.workingtime.WorkDaysCountService;
 
 import java.time.Clock;
 import java.time.LocalDate;
@@ -53,8 +52,6 @@ class ApplicationForLeaveExportViewControllerTest {
     private ApplicationForLeaveExportService applicationForLeaveExportService;
     @Mock
     private ApplicationForLeaveCsvExportService applicationForLeaveCsvExportService;
-    @Mock
-    private WorkDaysCountService workDaysCountService;
     @Mock
     private DateFormatAware dateFormatAware;
 
@@ -112,8 +109,7 @@ class ApplicationForLeaveExportViewControllerTest {
         application.setStatus(ALLOWED);
         application.setVacationType(vacationType);
 
-        when(workDaysCountService.getWorkDaysCount(application.getDayLength(), application.getStartDate(), application.getEndDate(), application.getPerson())).thenReturn(TEN);
-        final ApplicationForLeave applicationForLeave = new ApplicationForLeave(application, workDaysCountService);
+        final ApplicationForLeave applicationForLeave = new ApplicationForLeave(application, TEN);
 
         final ApplicationForLeaveExport applicationForLeaveExport = new ApplicationForLeaveExport("1", signedInUser.getFirstName(), signedInUser.getLastName(), List.of(applicationForLeave), List.of("departmentA"));
         final PageableSearchQuery pageableSearchQuery = new PageableSearchQuery(PageRequest.of(0, 20, Sort.by(Sort.Direction.ASC, "person.firstName")), "");
@@ -162,8 +158,7 @@ class ApplicationForLeaveExportViewControllerTest {
         application.setStatus(ALLOWED);
         application.setVacationType(vacationType);
 
-        when(workDaysCountService.getWorkDaysCount(application.getDayLength(), application.getStartDate(), application.getEndDate(), application.getPerson())).thenReturn(TEN);
-        final ApplicationForLeave applicationForLeave = new ApplicationForLeave(application, workDaysCountService);
+        final ApplicationForLeave applicationForLeave = new ApplicationForLeave(application, TEN);
 
         final ApplicationForLeaveExport applicationForLeaveExport = new ApplicationForLeaveExport("1", signedInUser.getFirstName(), signedInUser.getLastName(), List.of(applicationForLeave), List.of("departmentA"));
         final PageableSearchQuery pageableSearchQuery = new PageableSearchQuery(PageRequest.of(2, 50, Sort.by(Sort.Direction.ASC, "person.firstName")), "");
@@ -217,8 +212,7 @@ class ApplicationForLeaveExportViewControllerTest {
         application.setStatus(ALLOWED);
         application.setVacationType(vacationType);
 
-        when(workDaysCountService.getWorkDaysCount(application.getDayLength(), application.getStartDate(), application.getEndDate(), application.getPerson())).thenReturn(TEN);
-        final ApplicationForLeave applicationForLeave = new ApplicationForLeave(application, workDaysCountService);
+        final ApplicationForLeave applicationForLeave = new ApplicationForLeave(application, TEN);
 
         final ApplicationForLeaveExport applicationForLeaveExport = new ApplicationForLeaveExport("1", signedInUser.getFirstName(), signedInUser.getLastName(), List.of(applicationForLeave), List.of("departmentA"));
         final PageableSearchQuery pageableSearchQuery = new PageableSearchQuery(PageRequest.of(0, Integer.MAX_VALUE, Sort.by(Sort.Direction.ASC, "person.firstName")), "");
@@ -265,8 +259,7 @@ class ApplicationForLeaveExportViewControllerTest {
         application.setStatus(ALLOWED);
         application.setVacationType(vacationType);
 
-        when(workDaysCountService.getWorkDaysCount(application.getDayLength(), application.getStartDate(), application.getEndDate(), application.getPerson())).thenReturn(TEN);
-        final ApplicationForLeave applicationForLeave = new ApplicationForLeave(application, workDaysCountService);
+        final ApplicationForLeave applicationForLeave = new ApplicationForLeave(application, TEN);
 
         final ApplicationForLeaveExport applicationForLeaveExport = new ApplicationForLeaveExport("1", signedInUser.getFirstName(), signedInUser.getLastName(), List.of(applicationForLeave), List.of("departmentA"));
         final PageableSearchQuery pageableSearchQuery = new PageableSearchQuery(PageRequest.of(0, Integer.MAX_VALUE, Sort.by(Sort.Direction.ASC, "person.firstName")), "");

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/me/ApplicationsViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/me/ApplicationsViewControllerTest.java
@@ -5,11 +5,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.synyx.urlaubsverwaltung.absence.DateRange;
 import org.synyx.urlaubsverwaltung.application.application.Application;
 import org.synyx.urlaubsverwaltung.application.application.ApplicationService;
 import org.synyx.urlaubsverwaltung.application.application.ApplicationStatus;
@@ -25,15 +27,20 @@ import org.synyx.urlaubsverwaltung.search.PersonSearchUiFragmentSupplier;
 import org.synyx.urlaubsverwaltung.search.PersonSuggestionUrlStrategy;
 import org.synyx.urlaubsverwaltung.workingtime.WorkDaysCountService;
 
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.math.BigDecimal.ONE;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -42,7 +49,9 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -94,6 +103,18 @@ class ApplicationsViewControllerTest {
             personService, departmentService, applicationService,
             workDaysCountService, vacationTypeViewModelService, personSearchUiFragmentSupplier, clock
         );
+    }
+
+    private void stubWorkDaysCountForApplications() {
+        lenient().when(workDaysCountService.getWorkDaysCountForApplications(anyCollection()))
+            .thenAnswer(this::oneDayPerApplication);
+        lenient().when(workDaysCountService.getWorkDaysCountForApplications(anyCollection(), any(DateRange.class)))
+            .thenAnswer(this::oneDayPerApplication);
+    }
+
+    private Map<Application, BigDecimal> oneDayPerApplication(InvocationOnMock invocation) {
+        final Collection<Application> applications = invocation.getArgument(0);
+        return applications.stream().collect(toMap(identity(), application -> ONE));
     }
 
     @Test
@@ -193,9 +214,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(person)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "21")).locale(Locale.GERMANY))
             .andExpect(status().isOk())
@@ -240,9 +259,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(person)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -265,9 +282,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(person)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -293,9 +308,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -323,9 +336,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -353,9 +364,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -383,9 +392,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -410,9 +417,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(person)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -435,9 +440,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(person)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -460,9 +463,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(person)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -488,9 +489,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -520,9 +519,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -550,9 +547,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -580,9 +575,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -605,9 +598,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(person)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -632,9 +623,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(person)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -657,9 +646,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(person)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -684,9 +671,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(person)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -709,9 +694,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(person)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -746,9 +729,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(person)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications", hasSize(1)))
@@ -782,9 +763,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(person)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications", hasSize(1)))
@@ -828,9 +807,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        when(workDaysCountService.getWorkDaysCount(
-            any(), any(LocalDate.class), any(LocalDate.class), eq(person)
-        )).thenReturn(ONE);
+        stubWorkDaysCountForApplications();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications", hasSize(1)))

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/me/ApplicationsViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/me/ApplicationsViewControllerTest.java
@@ -51,7 +51,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -106,9 +105,13 @@ class ApplicationsViewControllerTest {
     }
 
     private void stubWorkDaysCountForApplications() {
-        lenient().when(workDaysCountService.getWorkDaysCountForApplications(anyCollection()))
+        when(workDaysCountService.getWorkDaysCountForApplications(anyCollection()))
             .thenAnswer(this::oneDayPerApplication);
-        lenient().when(workDaysCountService.getWorkDaysCountForApplications(anyCollection(), any(DateRange.class)))
+    }
+
+    private void stubWorkDaysCountForApplicationsWithUsedDaysSummary() {
+        stubWorkDaysCountForApplications();
+        when(workDaysCountService.getWorkDaysCountForApplications(anyCollection(), any(DateRange.class)))
             .thenAnswer(this::oneDayPerApplication);
     }
 
@@ -259,7 +262,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -282,7 +285,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -308,7 +311,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -336,7 +339,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -364,7 +367,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -392,7 +395,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -417,7 +420,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -440,7 +443,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -463,7 +466,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -489,7 +492,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -519,7 +522,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -547,7 +550,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -575,7 +578,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(applicationPerson)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -598,7 +601,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -623,7 +626,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -646,7 +649,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -671,7 +674,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -694,7 +697,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications",
@@ -729,7 +732,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications", hasSize(1)))
@@ -763,7 +766,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications", hasSize(1)))
@@ -807,7 +810,7 @@ class ApplicationsViewControllerTest {
         when(applicationService.getApplicationsForACertainPeriodAndPerson(
             any(LocalDate.class), any(LocalDate.class), eq(person)
         )).thenReturn(List.of(application));
-        stubWorkDaysCountForApplications();
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary();
 
         perform(get(MY_APPLICATIONS_PATH.replace("{personId}", "1")).locale(Locale.GERMANY))
             .andExpect(model().attribute("applications", hasSize(1)))

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/me/YearlyUsedDaysSummaryTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/me/YearlyUsedDaysSummaryTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.support.StaticMessageSource;
+import org.synyx.urlaubsverwaltung.absence.DateRange;
 import org.synyx.urlaubsverwaltung.application.application.Application;
 import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.person.Person;
@@ -13,13 +14,17 @@ import org.synyx.urlaubsverwaltung.workingtime.WorkDaysCountService;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.ZERO;
 import static java.util.Collections.singletonList;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.when;
 import static org.synyx.urlaubsverwaltung.TestDataCreator.anyApplication;
 import static org.synyx.urlaubsverwaltung.TestDataCreator.createApplication;
@@ -50,9 +55,7 @@ class YearlyUsedDaysSummaryTest {
         holidayAllowed.setStatus(ALLOWED);
 
         final BigDecimal workingDays = BigDecimal.valueOf(499);
-        when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class),
-            any(LocalDate.class), any(Person.class)))
-            .thenReturn(workingDays);
+        stubWorkDaysCountForApplications(workingDays);
 
         final YearlyUsedDaysSummary usedDaysOverview = new YearlyUsedDaysSummary(List.of(holidayAllowed), 2014, workDaysCountService);
         final UsedDays holidayDays = usedDaysOverview.getHolidayDays();
@@ -130,9 +133,7 @@ class YearlyUsedDaysSummaryTest {
             overtimeLeaveRequestCancellation);
 
         // just return 1 day for each application for leave
-        when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class),
-            any(LocalDate.class), any(Person.class)))
-            .thenReturn(ONE);
+        stubWorkDaysCountForApplications(ONE);
 
         final YearlyUsedDaysSummary yearlyUsedDaysSummary = new YearlyUsedDaysSummary(applications, 2014, workDaysCountService);
 
@@ -169,8 +170,7 @@ class YearlyUsedDaysSummaryTest {
         // 3 days in 2013, 2 days in 2014
         Application holiday = createApplication(person, createVacationType(1L, HOLIDAY, new StaticMessageSource()), startDate, endDate, DayLength.FULL);
 
-        when(workDaysCountService.getWorkDaysCount(DayLength.FULL, LocalDate.of(2014, 1, 1), endDate, person))
-            .thenReturn(BigDecimal.valueOf(2));
+        stubWorkDaysCountForApplications(BigDecimal.valueOf(2));
 
         final YearlyUsedDaysSummary yearlyUsedDaysSummary = new YearlyUsedDaysSummary(singletonList(holiday), 2014, workDaysCountService);
 
@@ -209,13 +209,20 @@ class YearlyUsedDaysSummaryTest {
         List<Application> applications = Arrays.asList(holiday, holidayTemporaryAllowed, holidayAllowed);
 
         // just return 1 day for each application for leave
-        when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class),
-            any(LocalDate.class), any(Person.class))).thenReturn(ONE);
+        stubWorkDaysCountForApplications(ONE);
 
         final YearlyUsedDaysSummary yearlyUsedDaysSummary = new YearlyUsedDaysSummary(applications, 2014, workDaysCountService);
         assertThat(yearlyUsedDaysSummary.getHolidayDays().getDays())
             .containsEntry("WAITING", ONE)
             .containsEntry("TEMPORARY_ALLOWED", ONE)
             .containsEntry("ALLOWED", ONE);
+    }
+
+    private void stubWorkDaysCountForApplications(BigDecimal daysPerApplication) {
+        when(workDaysCountService.getWorkDaysCountForApplications(anyCollection(), any(DateRange.class)))
+            .thenAnswer(invocation -> {
+                final Collection<Application> applications = invocation.getArgument(0);
+                return applications.stream().collect(toMap(identity(), application -> daysPerApplication));
+            });
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/overview/ApplicationDaysUsedSummaryDtoTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overview/ApplicationDaysUsedSummaryDtoTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.support.StaticMessageSource;
+import org.synyx.urlaubsverwaltung.absence.DateRange;
 import org.synyx.urlaubsverwaltung.application.application.Application;
 import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.person.Person;
@@ -13,13 +14,17 @@ import org.synyx.urlaubsverwaltung.workingtime.WorkDaysCountService;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.ZERO;
 import static java.util.Collections.singletonList;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.when;
 import static org.synyx.urlaubsverwaltung.TestDataCreator.anyApplication;
 import static org.synyx.urlaubsverwaltung.TestDataCreator.createApplication;
@@ -50,9 +55,7 @@ class ApplicationDaysUsedSummaryDtoTest {
         holidayAllowed.setStatus(ALLOWED);
 
         final BigDecimal workingDays = BigDecimal.valueOf(499);
-        when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class),
-            any(LocalDate.class), any(Person.class)))
-            .thenReturn(workingDays);
+        stubWorkDaysCountForApplications(workingDays);
 
         final ApplicationDaysUsedSummaryDto usedDaysOverview = new ApplicationDaysUsedSummaryDto(List.of(holidayAllowed), 2014, workDaysCountService);
         final ApplicationDaysUsedDto holidayDays = usedDaysOverview.getHolidayDays();
@@ -130,9 +133,7 @@ class ApplicationDaysUsedSummaryDtoTest {
             overtimeLeaveRequestCancellation);
 
         // just return 1 day for each application for leave
-        when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class),
-            any(LocalDate.class), any(Person.class)))
-            .thenReturn(ONE);
+        stubWorkDaysCountForApplications(ONE);
 
         final ApplicationDaysUsedSummaryDto yearlyUsedDaysSummary = new ApplicationDaysUsedSummaryDto(applications, 2014, workDaysCountService);
 
@@ -169,8 +170,7 @@ class ApplicationDaysUsedSummaryDtoTest {
         // 3 days in 2013, 2 days in 2014
         Application holiday = createApplication(person, createVacationType(1L, HOLIDAY, new StaticMessageSource()), startDate, endDate, DayLength.FULL);
 
-        when(workDaysCountService.getWorkDaysCount(DayLength.FULL, LocalDate.of(2014, 1, 1), endDate, person))
-            .thenReturn(BigDecimal.valueOf(2));
+        stubWorkDaysCountForApplications(BigDecimal.valueOf(2));
 
         final ApplicationDaysUsedSummaryDto yearlyUsedDaysSummary = new ApplicationDaysUsedSummaryDto(singletonList(holiday), 2014, workDaysCountService);
 
@@ -209,14 +209,21 @@ class ApplicationDaysUsedSummaryDtoTest {
         List<Application> applications = Arrays.asList(holiday, holidayTemporaryAllowed, holidayAllowed);
 
         // just return 1 day for each application for leave
-        when(workDaysCountService.getWorkDaysCount(any(DayLength.class), any(LocalDate.class),
-            any(LocalDate.class), any(Person.class))).thenReturn(ONE);
+        stubWorkDaysCountForApplications(ONE);
 
         final ApplicationDaysUsedSummaryDto yearlyUsedDaysSummary = new ApplicationDaysUsedSummaryDto(applications, 2014, workDaysCountService);
         assertThat(yearlyUsedDaysSummary.getHolidayDays().getDays())
             .containsEntry("WAITING", ONE)
             .containsEntry("TEMPORARY_ALLOWED", ONE)
             .containsEntry("ALLOWED", ONE);
+    }
+
+    private void stubWorkDaysCountForApplications(BigDecimal daysPerApplication) {
+        when(workDaysCountService.getWorkDaysCountForApplications(anyCollection(), any(DateRange.class)))
+            .thenAnswer(invocation -> {
+                final Collection<Application> applications = invocation.getArgument(0);
+                return applications.stream().collect(toMap(identity(), application -> daysPerApplication));
+            });
     }
 }
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/overview/OverviewViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overview/OverviewViewControllerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.web.servlet.ResultActions;
@@ -48,6 +49,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.Year;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -60,10 +62,14 @@ import static java.time.Month.APRIL;
 import static java.time.temporal.TemporalAdjusters.firstDayOfMonth;
 import static java.util.Arrays.asList;
 import static java.util.Locale.GERMAN;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -125,6 +131,21 @@ class OverviewViewControllerTest {
         sut = new OverviewViewController(personService, accountService, vacationDaysService,
             workDaysCountService, applicationService, sickNoteService, overtimeService, settingsService,
             departmentService, vacationTypeViewModelService, personSearchUiFragmentSupplier, clock);
+    }
+
+    private void stubWorkDaysCountForApplications(BigDecimal daysPerApplication) {
+        // sick notes still use the single-application variant
+        lenient().when(workDaysCountService.getWorkDaysCount(any(), any(), any(), any(Person.class)))
+            .thenReturn(daysPerApplication);
+        lenient().when(workDaysCountService.getWorkDaysCountForApplications(anyCollection()))
+            .thenAnswer(invocation -> mapEachApplicationTo(invocation, daysPerApplication));
+        lenient().when(workDaysCountService.getWorkDaysCountForApplications(anyCollection(), any(DateRange.class)))
+            .thenAnswer(invocation -> mapEachApplicationTo(invocation, daysPerApplication));
+    }
+
+    private static Map<Application, BigDecimal> mapEachApplicationTo(InvocationOnMock invocation, BigDecimal value) {
+        final Collection<Application> applications = invocation.getArgument(0);
+        return applications.stream().collect(toMap(identity(), application -> value));
     }
 
     @Nested
@@ -610,7 +631,7 @@ class OverviewViewControllerTest {
 
         when(personService.getPersonByID(1L)).thenReturn(Optional.of(person));
         when(departmentService.isSignedInUserAllowedToAccessPersonData(person, person)).thenReturn(true);
-        when(workDaysCountService.getWorkDaysCount(any(), any(), any(), eq(person))).thenReturn(ONE);
+        stubWorkDaysCountForApplications(ONE);
 
         when(vacationTypeViewModelService.getVacationTypeColors()).thenReturn(List.of(new VacationTypeDto(1L, ORANGE)));
 
@@ -983,7 +1004,7 @@ class OverviewViewControllerTest {
         when(personService.getSignedInUser()).thenReturn(person);
         when(personService.getPersonByID(1L)).thenReturn(Optional.of(person));
         when(departmentService.isSignedInUserAllowedToAccessPersonData(person, person)).thenReturn(true);
-        when(workDaysCountService.getWorkDaysCount(any(), any(), any(), eq(person))).thenReturn(BigDecimal.valueOf(2));
+        stubWorkDaysCountForApplications(BigDecimal.valueOf(2));
 
 
         final LocalDate localDate = LocalDate.parse("2021-06-10");

--- a/src/test/java/org/synyx/urlaubsverwaltung/overview/OverviewViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overview/OverviewViewControllerTest.java
@@ -69,7 +69,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -133,13 +132,19 @@ class OverviewViewControllerTest {
             departmentService, vacationTypeViewModelService, personSearchUiFragmentSupplier, clock);
     }
 
+    private void stubSickNoteWorkDaysCount(BigDecimal daysPerSickNote) {
+        when(workDaysCountService.getWorkDaysCount(any(), any(), any(), any(Person.class)))
+            .thenReturn(daysPerSickNote);
+    }
+
     private void stubWorkDaysCountForApplications(BigDecimal daysPerApplication) {
-        // sick notes still use the single-application variant
-        lenient().when(workDaysCountService.getWorkDaysCount(any(), any(), any(), any(Person.class)))
-            .thenReturn(daysPerApplication);
-        lenient().when(workDaysCountService.getWorkDaysCountForApplications(anyCollection()))
+        when(workDaysCountService.getWorkDaysCountForApplications(anyCollection()))
             .thenAnswer(invocation -> mapEachApplicationTo(invocation, daysPerApplication));
-        lenient().when(workDaysCountService.getWorkDaysCountForApplications(anyCollection(), any(DateRange.class)))
+    }
+
+    private void stubWorkDaysCountForApplicationsWithUsedDaysSummary(BigDecimal daysPerApplication) {
+        stubWorkDaysCountForApplications(daysPerApplication);
+        when(workDaysCountService.getWorkDaysCountForApplications(anyCollection(), any(DateRange.class)))
             .thenAnswer(invocation -> mapEachApplicationTo(invocation, daysPerApplication));
     }
 
@@ -631,7 +636,8 @@ class OverviewViewControllerTest {
 
         when(personService.getPersonByID(1L)).thenReturn(Optional.of(person));
         when(departmentService.isSignedInUserAllowedToAccessPersonData(person, person)).thenReturn(true);
-        stubWorkDaysCountForApplications(ONE);
+        stubSickNoteWorkDaysCount(ONE);
+        stubWorkDaysCountForApplicationsWithUsedDaysSummary(ONE);
 
         when(vacationTypeViewModelService.getVacationTypeColors()).thenReturn(List.of(new VacationTypeDto(1L, ORANGE)));
 
@@ -1004,7 +1010,7 @@ class OverviewViewControllerTest {
         when(personService.getSignedInUser()).thenReturn(person);
         when(personService.getPersonByID(1L)).thenReturn(Optional.of(person));
         when(departmentService.isSignedInUserAllowedToAccessPersonData(person, person)).thenReturn(true);
-        stubWorkDaysCountForApplications(BigDecimal.valueOf(2));
+        stubSickNoteWorkDaysCount(BigDecimal.valueOf(2));
 
 
         final LocalDate localDate = LocalDate.parse("2021-06-10");

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountServiceTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.synyx.urlaubsverwaltung.absence.DateRange;
+import org.synyx.urlaubsverwaltung.application.application.Application;
+import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.publicholiday.PublicHolidaysServiceImpl;
 import org.synyx.urlaubsverwaltung.settings.Settings;
@@ -33,6 +35,9 @@ import static java.time.Month.NOVEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.synyx.urlaubsverwaltung.period.DayLength.FULL;
 import static org.synyx.urlaubsverwaltung.period.DayLength.MORNING;
@@ -471,6 +476,72 @@ class WorkDaysCountServiceTest {
         assertThat(workDaysCount).isEqualByComparingTo(BigDecimal.valueOf(2.5));
     }
 
+
+    @Test
+    void getWorkDaysCountForApplicationsBatchesWorkingTimeLoadingWithASingleQuery() {
+
+        when(settingsService.getSettings()).thenReturn(new Settings());
+
+        final Person marlene = new Person("marlene", "Muster", "Marlene", "marlene@example.org");
+        marlene.setId(1L);
+        final Person peter = new Person("peter", "Muster", "Peter", "peter@example.org");
+        peter.setId(2L);
+
+        final LocalDate startDate = LocalDate.of(2013, DECEMBER, 16);
+        final LocalDate endDate = LocalDate.of(2013, DECEMBER, 31);
+
+        final Application marleneApplication = application(marlene, startDate, endDate, FULL);
+        final Application peterApplication = application(peter, startDate, endDate, FULL);
+
+        final WorkingTime marleneWorkingTime = createWorkingTime(marlene, startDate, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
+        final WorkingTime peterWorkingTime = createWorkingTime(peter, startDate, MONDAY, WEDNESDAY, FRIDAY, SATURDAY);
+        when(workingTimeService.getByPersons(List.of(marlene, peter))).thenReturn(List.of(marleneWorkingTime, peterWorkingTime));
+
+        final Map<Application, BigDecimal> workDaysCount = sut.getWorkDaysCountForApplications(List.of(marleneApplication, peterApplication));
+
+        assertThat(workDaysCount.get(marleneApplication)).isEqualByComparingTo(BigDecimal.valueOf(9));
+        assertThat(workDaysCount.get(peterApplication)).isEqualByComparingTo(BigDecimal.valueOf(8));
+
+        // the whole point: working times are loaded once, not once per application
+        verify(workingTimeService).getByPersons(List.of(marlene, peter));
+        verify(workingTimeService, never()).getWorkingTimesByPersonAndDateRange(any(), any());
+    }
+
+    @Test
+    void getWorkDaysCountForApplicationsLimitsPeriodToGivenDateRange() {
+
+        when(settingsService.getSettings()).thenReturn(new Settings());
+
+        final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        person.setId(1L);
+
+        // application spans two years
+        final Application application = application(person, LocalDate.of(2013, DECEMBER, 16), LocalDate.of(2014, JANUARY, 15), FULL);
+
+        final WorkingTime workingTime = createWorkingTime(person, LocalDate.of(2013, DECEMBER, 16), MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
+        when(workingTimeService.getByPersons(List.of(person))).thenReturn(List.of(workingTime));
+
+        // clip to 2013 -> only 16.12.2013 - 31.12.2013 is counted -> 9 work days
+        final DateRange year2013 = new DateRange(LocalDate.of(2013, JANUARY, 1), LocalDate.of(2013, DECEMBER, 31));
+        final Map<Application, BigDecimal> workDaysCount = sut.getWorkDaysCountForApplications(List.of(application), year2013);
+
+        assertThat(workDaysCount.get(application)).isEqualByComparingTo(BigDecimal.valueOf(9));
+    }
+
+    @Test
+    void getWorkDaysCountForApplicationsReturnsEmptyMapAndDoesNotQueryForNoApplications() {
+        assertThat(sut.getWorkDaysCountForApplications(List.of())).isEmpty();
+        verifyNoInteractions(workingTimeService);
+    }
+
+    private static Application application(Person person, LocalDate startDate, LocalDate endDate, DayLength dayLength) {
+        final Application application = new Application();
+        application.setPerson(person);
+        application.setStartDate(startDate);
+        application.setEndDate(endDate);
+        application.setDayLength(dayLength);
+        return application;
+    }
 
     private HolidayManager getHolidayManager() {
         return HolidayManager.getInstance(ManagerParameters.create(HolidayCalendar.GERMANY));


### PR DESCRIPTION
… triggers multiple calls instead of one

### Problem                                                                                                                                                                                                                                                                                                      
  `new ApplicationForLeave(application, workDaysCountService)` and the two "used days"                                                                                                                                                                                                                             
  summaries call `WorkDaysCountService.getWorkDaysCount(...)` **once per application**.                                                                                                                                                                                                                            
  Each call runs `workingTimeRepository.findByPersonOrderByValidFromDesc(person)`, i.e.                                                                                                                                                                                                                            
  **one working-time query per application**. On the application list, export and overview                                                                                                                                                                                                                         
  pages this is a classic N+1 (the query only depends on the person, so it is even repeated                                                                                                                                                                                                                        
  identically for a single person's applications).                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                   
  ### Change                                                                                                                                                                                                                                                                                                       
  - New `WorkDaysCountService.getWorkDaysCountForApplications(Collection<Application>)`                                                                                                                                                                                                                            
    (+ a date-range-clipped overload) that loads the working times of all involved persons                                                                                                                                                                                                                         
    with a **single** `getByPersons(...)` query and computes each application's work days                                                                                                                                                                                                                          
    in memory, using the **unchanged** calculation.                                                                                                                                                                                                                                                                
  - New `ApplicationForLeave(Application, BigDecimal)` constructor; the old                                                                                                                                                                                                                                        
    `(Application, WorkDaysCountService)` constructor now delegates to it.                                                                                                                                                                                                                                         
  - Extracted the in-memory slicing of `getWorkingTimesByPersonAndDateRange` into a reusable                                                                                                                                                                                                                       
    helper (behaviour-preserving; defensively sorted so it also works on unordered batch input).                                                                                                                                                                                                                   
  - Migrated all loop sites: `ApplicationForLeaveViewController` (5), `ApplicationForLeaveExportService`,                                                                                                                                                                                                          
    `ApplicationsViewController`, `OverviewViewController`, `YearlyUsedDaysSummary`,                                                                                                                                                                                                                               
    `ApplicationDaysUsedSummaryDto`.                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                   
  Result: **N working-time queries → 1** per request.                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                   
  ### Testing                                                                                                                                                                                                                                                                                                      
  - Existing behaviour is preserved (same work-day values); mock-based controller/summary                                                                                                                                                                                                                          
    tests updated to the batch method.                                                                                                                                                                                                                                                                             
  - Added tests to `WorkDaysCountServiceTest`, including a before/after query-count test                                                                                                                                                                                                                           
    asserting a single `getByPersons` call and **no** per-application query.                                                                                                                                                                                                                                       
  - All tests in the `application`, `overview` and `workingtime` packages pass.
