### PR TITLE
performance: fix n+1 queries by batching department head and second s…

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentService.java
@@ -152,6 +152,19 @@ public interface DepartmentService {
     boolean isDepartmentHeadAllowedToManagePerson(Person departmentHead, Person person);
 
     /**
+     * Batch variant of {@link #isDepartmentHeadAllowedToManagePerson(Person, Person)}: returns the subset of the given
+     * department heads that manage a department the given person is a member of.
+     * <p>
+     * The memberships of all given department heads and the person are loaded with a single query instead of one query
+     * per department head.
+     *
+     * @param departmentHeads to be checked (typically the active persons with role {@code DEPARTMENT_HEAD})
+     * @param person          to be checked if managed by the department heads
+     * @return the given department heads that are allowed to manage the given person, preserving the input order
+     */
+    List<Person> getDepartmentHeadsAllowedToManagePerson(List<Person> departmentHeads, Person person);
+
+    /**
      * Check the role of the given person and return a {@link List} of all managed {@link Person}s.
      * Managed members are all persons for which a privileged person are responsible
      * for and can perform actions for this person.
@@ -247,6 +260,19 @@ public interface DepartmentService {
      * assigned to, else {@code false}
      */
     boolean isSecondStageAuthorityAllowedToManagePerson(Person secondStageAuthority, Person person);
+
+    /**
+     * Batch variant of {@link #isSecondStageAuthorityAllowedToManagePerson(Person, Person)}: returns the subset of the
+     * given second stage authorities that are responsible for a department the given person is a member of.
+     * <p>
+     * The memberships of all given second stage authorities and the person are loaded with a single query instead of
+     * one query per second stage authority.
+     *
+     * @param secondStageAuthorities to be checked (typically the active persons with role {@code SECOND_STAGE_AUTHORITY})
+     * @param person                 to be checked if managed by the second stage authorities
+     * @return the given second stage authorities that are allowed to manage the given person, preserving the input order
+     */
+    List<Person> getSecondStageAuthoritiesAllowedToManagePerson(List<Person> secondStageAuthorities, Person person);
 
     /**
      * Get all distinct managed members of the second stage authority.

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImpl.java
@@ -380,6 +380,53 @@ class DepartmentServiceImpl implements DepartmentService {
     }
 
     @Override
+    public List<Person> getDepartmentHeadsAllowedToManagePerson(List<Person> departmentHeads, Person person) {
+        return managersAllowedToManagePerson(departmentHeads, DepartmentMembershipKind.DEPARTMENT_HEAD, person);
+    }
+
+    @Override
+    public List<Person> getSecondStageAuthoritiesAllowedToManagePerson(List<Person> secondStageAuthorities, Person person) {
+        return managersAllowedToManagePerson(secondStageAuthorities, DepartmentMembershipKind.SECOND_STAGE_AUTHORITY, person);
+    }
+
+    /**
+     * Returns the given managers that manage a department the given person is a {@link DepartmentMembershipKind#MEMBER}
+     * of, i.e. that have a membership of {@code managerKind} in one of the person's member departments.
+     * <p>
+     * This is the batch equivalent of {@link #isDepartmentHeadAllowedToManagePerson(Person, Person)} /
+     * {@link #isSecondStageAuthorityAllowedToManagePerson(Person, Person)} which both boil down to an overlap between
+     * the manager's {@code managerKind} departments and the person's member departments. The memberships of all
+     * managers and the person are loaded with a single query.
+     */
+    private List<Person> managersAllowedToManagePerson(List<Person> managers, DepartmentMembershipKind managerKind, Person person) {
+
+        if (managers.isEmpty()) {
+            return List.of();
+        }
+
+        final PersonId personId = person.getIdAsPersonId();
+        final List<PersonId> personIds = Stream.concat(managers.stream().map(Person::getIdAsPersonId), Stream.of(personId)).toList();
+
+        final Map<PersonId, List<DepartmentMembership>> memberships = departmentMembershipService.getActiveMembershipsOfPersons(personIds);
+
+        final Set<Long> personMemberDepartmentIds = memberships.getOrDefault(personId, List.of()).stream()
+            .filter(membership -> membership.membershipKind().equals(DepartmentMembershipKind.MEMBER))
+            .map(DepartmentMembership::departmentId)
+            .collect(toSet());
+
+        if (personMemberDepartmentIds.isEmpty()) {
+            return List.of();
+        }
+
+        return managers.stream()
+            .filter(manager -> memberships.getOrDefault(manager.getIdAsPersonId(), List.of()).stream()
+                .filter(membership -> membership.membershipKind().equals(managerKind))
+                .map(DepartmentMembership::departmentId)
+                .anyMatch(personMemberDepartmentIds::contains))
+            .toList();
+    }
+
+    @Override
     public List<Person> getManagedMembersForSecondStageAuthority(Person secondStageAuthority) {
         return getManagedDepartmentsOfSecondStageAuthority(secondStageAuthority)
             .stream()

--- a/src/main/java/org/synyx/urlaubsverwaltung/person/ResponsiblePersonServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/person/ResponsiblePersonServiceImpl.java
@@ -39,18 +39,18 @@ class ResponsiblePersonServiceImpl implements ResponsiblePersonService {
 
     @Override
     public List<Person> getResponsibleDepartmentHeads(Person personOfInterest) {
-        return personService.getActivePersonsByRole(DEPARTMENT_HEAD)
+        final List<Person> departmentHeads = personService.getActivePersonsByRole(DEPARTMENT_HEAD);
+        return departmentService.getDepartmentHeadsAllowedToManagePerson(departmentHeads, personOfInterest)
             .stream()
-            .filter(departmentHead -> departmentService.isDepartmentHeadAllowedToManagePerson(departmentHead, personOfInterest))
             .filter(without(personOfInterest))
             .toList();
     }
 
     @Override
     public List<Person> getResponsibleSecondStageAuthorities(Person personOfInterest) {
-        return personService.getActivePersonsByRole(SECOND_STAGE_AUTHORITY)
+        final List<Person> secondStageAuthorities = personService.getActivePersonsByRole(SECOND_STAGE_AUTHORITY);
+        return departmentService.getSecondStageAuthoritiesAllowedToManagePerson(secondStageAuthorities, personOfInterest)
             .stream()
-            .filter(secondStageAuthority -> departmentService.isSecondStageAuthorityAllowedToManagePerson(secondStageAuthority, personOfInterest))
             .filter(without(personOfInterest))
             .toList();
     }

--- a/src/test/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImplTest.java
@@ -2331,6 +2331,81 @@ class DepartmentServiceImplTest {
     }
 
     @Test
+    void ensureGetDepartmentHeadsAllowedToManagePersonReturnsOnlyManagingHeadsWithASingleQuery() {
+
+        final PersonId head1Id = new PersonId(1L);
+        final Person head1 = new Person();
+        head1.setId(head1Id.value());
+        head1.setPermissions(List.of(USER, DEPARTMENT_HEAD));
+
+        final PersonId head2Id = new PersonId(2L);
+        final Person head2 = new Person();
+        head2.setId(head2Id.value());
+        head2.setPermissions(List.of(USER, DEPARTMENT_HEAD));
+
+        final PersonId personId = new PersonId(3L);
+        final Person person = new Person();
+        person.setId(personId.value());
+        person.setPermissions(List.of(USER));
+
+        // head1 is head of department 1 (which the person is a member of), head2 heads department 2 (person is not a member)
+        when(departmentMembershipService.getActiveMembershipsOfPersons(List.of(head1Id, head2Id, personId)))
+            .thenReturn(Map.of(
+                head1Id, List.of(new DepartmentMembership(head1Id, 1L, DepartmentMembershipKind.DEPARTMENT_HEAD, Instant.now(clock))),
+                head2Id, List.of(new DepartmentMembership(head2Id, 2L, DepartmentMembershipKind.DEPARTMENT_HEAD, Instant.now(clock))),
+                personId, List.of(new DepartmentMembership(personId, 1L, DepartmentMembershipKind.MEMBER, Instant.now(clock)))
+            ));
+
+        final List<Person> allowed = sut.getDepartmentHeadsAllowedToManagePerson(List.of(head1, head2), person);
+
+        assertThat(allowed).containsExactly(head1);
+        verify(departmentMembershipService).getActiveMembershipsOfPersons(List.of(head1Id, head2Id, personId));
+    }
+
+    @Test
+    void ensureGetSecondStageAuthoritiesAllowedToManagePersonReturnsOnlyManagingAuthoritiesWithASingleQuery() {
+
+        final PersonId ssa1Id = new PersonId(1L);
+        final Person ssa1 = new Person();
+        ssa1.setId(ssa1Id.value());
+        ssa1.setPermissions(List.of(USER, SECOND_STAGE_AUTHORITY));
+
+        final PersonId ssa2Id = new PersonId(2L);
+        final Person ssa2 = new Person();
+        ssa2.setId(ssa2Id.value());
+        ssa2.setPermissions(List.of(USER, SECOND_STAGE_AUTHORITY));
+
+        final PersonId personId = new PersonId(3L);
+        final Person person = new Person();
+        person.setId(personId.value());
+        person.setPermissions(List.of(USER));
+
+        // ssa1 is second stage authority of department 1 (which the person is a member of), ssa2 of department 2 (person is not a member)
+        when(departmentMembershipService.getActiveMembershipsOfPersons(List.of(ssa1Id, ssa2Id, personId)))
+            .thenReturn(Map.of(
+                ssa1Id, List.of(new DepartmentMembership(ssa1Id, 1L, DepartmentMembershipKind.SECOND_STAGE_AUTHORITY, Instant.now(clock))),
+                ssa2Id, List.of(new DepartmentMembership(ssa2Id, 2L, DepartmentMembershipKind.SECOND_STAGE_AUTHORITY, Instant.now(clock))),
+                personId, List.of(new DepartmentMembership(personId, 1L, DepartmentMembershipKind.MEMBER, Instant.now(clock)))
+            ));
+
+        final List<Person> allowed = sut.getSecondStageAuthoritiesAllowedToManagePerson(List.of(ssa1, ssa2), person);
+
+        assertThat(allowed).containsExactly(ssa1);
+        verify(departmentMembershipService).getActiveMembershipsOfPersons(List.of(ssa1Id, ssa2Id, personId));
+    }
+
+    @Test
+    void ensureGetDepartmentHeadsAllowedToManagePersonReturnsEmptyForNoHeadsWithoutQuery() {
+
+        final Person person = new Person();
+        person.setId(3L);
+
+        assertThat(sut.getDepartmentHeadsAllowedToManagePerson(List.of(), person)).isEmpty();
+
+        verifyNoInteractions(departmentMembershipService);
+    }
+
+    @Test
     void ensureGetApplicationsFromColleaguesOfReturnsEmptyApplicationsBecauseNoDepartmentsAssigned() {
 
         when(departmentRepository.count()).thenReturn(1L);

--- a/src/test/java/org/synyx/urlaubsverwaltung/person/ResponsiblePersonServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/person/ResponsiblePersonServiceImplTest.java
@@ -43,13 +43,13 @@ class ResponsiblePersonServiceImplTest {
         final Person departmentHead = new Person("departmentHead", "departmentHead", "departmentHead", "departmentHead@example.org");
         departmentHead.setPermissions(List.of(USER, DEPARTMENT_HEAD));
         when(personService.getActivePersonsByRole(DEPARTMENT_HEAD)).thenReturn(List.of(departmentHead));
-        when(departmentService.isDepartmentHeadAllowedToManagePerson(departmentHead, person)).thenReturn(true);
+        when(departmentService.getDepartmentHeadsAllowedToManagePerson(List.of(departmentHead), person)).thenReturn(List.of(departmentHead));
 
         // given second stage
         final Person secondStage = new Person("secondStage", "secondStage", "secondStage", "secondStage@example.org");
         secondStage.setPermissions(List.of(USER, SECOND_STAGE_AUTHORITY));
         when(personService.getActivePersonsByRole(SECOND_STAGE_AUTHORITY)).thenReturn(List.of(secondStage));
-        when(departmentService.isSecondStageAuthorityAllowedToManagePerson(secondStage, person)).thenReturn(true);
+        when(departmentService.getSecondStageAuthoritiesAllowedToManagePerson(List.of(secondStage), person)).thenReturn(List.of(secondStage));
 
         final Person boss = new Person("boss", "boss", "senior", "boss@example.org");
         boss.setPermissions(List.of(USER, BOSS));


### PR DESCRIPTION
…tage authority manage checks

### Problem                                                                                                                                                                                                                                                                                                      
  `ResponsiblePersonServiceImpl.getResponsibleDepartmentHeads` /                                                                                                                                                                                                                                                   
  `getResponsibleSecondStageAuthorities` filtered `getActivePersonsByRole(...)` by calling                                                                                                                                                                                                                         
  `isDepartmentHeadAllowedToManagePerson` / `isSecondStageAuthorityAllowedToManagePerson`                                                                                                                                                                                                                          
  **per manager**, each running a membership query. This runs on every mail-notification                                                                                                                                                                                                                           
  recipient resolution and the application detail page → one query per department head / SSA.                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                   
  ### Change                                                                                                                                                                                                                                                                                                       
  - New batch methods `DepartmentService.getDepartmentHeadsAllowedToManagePerson(managers, person)`                                                                                                                                                                                                                
    and `getSecondStageAuthoritiesAllowedToManagePerson(managers, person)` that load the                                                                                                                                                                                                                           
    memberships of all managers **and** the person with a **single**                                                                                                                                                                                                                                               
    `getActiveMembershipsOfPersons(...)` call and filter in memory.                                                                                                                                                                                                                                                
  - `ResponsiblePersonServiceImpl` now uses them → **N queries → 1**.                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                   
  Both checks provably reduce to the same set overlap — *manager's [role]-department-ids ∩                                                                                                                                                                                                                         
  person's MEMBER-department-ids ≠ ∅* — because `Department.getMembers()` is populated from                                                                                                                                                                                                                        
  MEMBER-kind memberships only. The shared logic stays in `DepartmentServiceImpl` next to the                                                                                                                                                                                                                      
  single-person versions.                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                   
  ### Testing                                                                                                                                                                                                                                                                                                      
  - `ResponsiblePersonServiceImplTest` updated to the batch methods.                                                                                                                                                                                                                                               
  - Added `DepartmentServiceImplTest` cases for both batch methods (positive/negative) and a                                                                                                                                                                                                                       
    single-query assertion.                                                                                                                                                                                                                                                                                        
  - All tests in the `department`, `person` and `mail` packages pass.                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                   
  ### Out of scope (intentionally)                                                                                                                                                                                                                                                                                 
  - `OverviewViewController#applicationDto` membership checks — bounded by a small `.limit(...)`,                                                                                                                                                                                                                  
    negligible impact.                                                                                                                                                                                                                                                                                             
  - `ApplicationForLeaveViewController` per-application access checks — security-sensitive and                                                                                                                                                                                                                     
    overlaps the Tier 1 file; better done separately.                                                                                                                                                                                                                                                              
  - `PersonDataCollectionService` (backup export) — only partially batchable (no batch API for                                                                                                                                                                                                                     
    all-year accounts / user settings / pagination) and an infrequent admin path. 