### PR TITLE
performance: fix n+1 queries by batching holidays account, federal st…

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewController.java
@@ -26,6 +26,7 @@ import org.synyx.urlaubsverwaltung.publicholiday.PublicHolidaysService;
 import org.synyx.urlaubsverwaltung.search.HasPersonSearch;
 import org.synyx.urlaubsverwaltung.search.PersonSearchUiFragmentSupplier;
 import org.synyx.urlaubsverwaltung.search.PersonSuggestionUrlStrategy;
+import org.synyx.urlaubsverwaltung.workingtime.FederalState;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTime;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeService;
 
@@ -224,9 +225,12 @@ public class AbsenceOverviewViewController implements HasLaunchpad, HasPersonSea
             .flatMap(List::stream)
             .collect(groupingBy(AbsencePeriod.Record::getPerson));
 
+        // load the federal states of all persons with a single query instead of one query per person
+        final Map<Person, Map<DateRange, FederalState>> federalStatesByPerson = workingTimeService.getFederalStatesByPersons(personList, dateRange);
+
         final Map<Person, Map<LocalDate, PublicHoliday>> publicHolidaysOfAllPersons = new HashMap<>();
         for (Person person : personList) {
-            publicHolidaysOfAllPersons.put(person, getPublicHolidaysOfPerson(dateRange, person));
+            publicHolidaysOfAllPersons.put(person, getPublicHolidaysOfPerson(federalStatesByPerson.getOrDefault(person, Map.of())));
         }
 
         for (LocalDate date : dateRange) {
@@ -282,8 +286,8 @@ public class AbsenceOverviewViewController implements HasLaunchpad, HasPersonSea
             .orElse(false);
     }
 
-    private Map<LocalDate, PublicHoliday> getPublicHolidaysOfPerson(DateRange dateRange, Person person) {
-        return workingTimeService.getFederalStatesByPersonAndDateRange(person, dateRange)
+    private Map<LocalDate, PublicHoliday> getPublicHolidaysOfPerson(Map<DateRange, FederalState> federalStatesByDateRange) {
+        return federalStatesByDateRange
             .entrySet().stream()
             .map(entry -> publicHolidaysService.getPublicHolidays(entry.getKey().startDate(), entry.getKey().endDate(), entry.getValue()))
             .flatMap(List::stream)

--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewController.java
@@ -26,6 +26,7 @@ import org.synyx.urlaubsverwaltung.publicholiday.PublicHolidaysService;
 import org.synyx.urlaubsverwaltung.search.HasPersonSearch;
 import org.synyx.urlaubsverwaltung.search.PersonSearchUiFragmentSupplier;
 import org.synyx.urlaubsverwaltung.search.PersonSuggestionUrlStrategy;
+import org.synyx.urlaubsverwaltung.workingtime.FederalState;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTime;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeService;
 
@@ -222,9 +223,12 @@ public class AbsenceOverviewViewController implements HasLaunchpad, HasPersonSea
             .flatMap(List::stream)
             .collect(groupingBy(AbsencePeriod.Record::getPerson));
 
+        // load the federal states of all persons with a single query instead of one query per person
+        final Map<Person, Map<DateRange, FederalState>> federalStatesByPerson = workingTimeService.getFederalStatesByPersons(personList, dateRange);
+
         final Map<Person, Map<LocalDate, PublicHoliday>> publicHolidaysOfAllPersons = new HashMap<>();
         for (Person person : personList) {
-            publicHolidaysOfAllPersons.put(person, getPublicHolidaysOfPerson(dateRange, person));
+            publicHolidaysOfAllPersons.put(person, getPublicHolidaysOfPerson(federalStatesByPerson.getOrDefault(person, Map.of())));
         }
 
         for (LocalDate date : dateRange) {
@@ -280,8 +284,8 @@ public class AbsenceOverviewViewController implements HasLaunchpad, HasPersonSea
             .orElse(false);
     }
 
-    private Map<LocalDate, PublicHoliday> getPublicHolidaysOfPerson(DateRange dateRange, Person person) {
-        return workingTimeService.getFederalStatesByPersonAndDateRange(person, dateRange)
+    private Map<LocalDate, PublicHoliday> getPublicHolidaysOfPerson(Map<DateRange, FederalState> federalStatesByDateRange) {
+        return federalStatesByDateRange
             .entrySet().stream()
             .map(entry -> publicHolidaysService.getPublicHolidays(entry.getKey().startDate(), entry.getKey().endDate(), entry.getValue()))
             .flatMap(List::stream)

--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewController.java
@@ -26,7 +26,6 @@ import org.synyx.urlaubsverwaltung.publicholiday.PublicHolidaysService;
 import org.synyx.urlaubsverwaltung.search.HasPersonSearch;
 import org.synyx.urlaubsverwaltung.search.PersonSearchUiFragmentSupplier;
 import org.synyx.urlaubsverwaltung.search.PersonSuggestionUrlStrategy;
-import org.synyx.urlaubsverwaltung.workingtime.FederalState;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTime;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeService;
 
@@ -213,7 +212,6 @@ public class AbsenceOverviewViewController implements HasLaunchpad, HasPersonSea
                                                                         Function<AbsencePeriod.RecordInfo, VacationTypeColor> recordInfoToColor) {
 
         final LocalDate today = LocalDate.now(clock);
-        final List<WorkingTime> workingTimeList = workingTimeService.getByPersons(personList);
         final List<AbsencePeriod> openAbsences = absenceService.getOpenAbsences(personList, dateRange.startDate(), dateRange.endDate());
 
         final HashMap<Integer, AbsenceOverviewMonthDto> monthsByNr = new HashMap<>();
@@ -223,12 +221,12 @@ public class AbsenceOverviewViewController implements HasLaunchpad, HasPersonSea
             .flatMap(List::stream)
             .collect(groupingBy(AbsencePeriod.Record::getPerson));
 
-        // load the federal states of all persons with a single query instead of one query per person
-        final Map<Person, Map<DateRange, FederalState>> federalStatesByPerson = workingTimeService.getFederalStatesByPersons(personList, dateRange);
+        // load the working times of all persons with a single query instead of one query per person
+        final Map<Person, Map<DateRange, WorkingTime>> workingTimesByPerson = workingTimeService.getWorkingTimesByPersonsAndDateRange(personList, dateRange);
 
         final Map<Person, Map<LocalDate, PublicHoliday>> publicHolidaysOfAllPersons = new HashMap<>();
         for (Person person : personList) {
-            publicHolidaysOfAllPersons.put(person, getPublicHolidaysOfPerson(federalStatesByPerson.getOrDefault(person, Map.of())));
+            publicHolidaysOfAllPersons.put(person, getPublicHolidaysOfPerson(workingTimesByPerson.getOrDefault(person, Map.of())));
         }
 
         for (LocalDate date : dateRange) {
@@ -251,11 +249,7 @@ public class AbsenceOverviewViewController implements HasLaunchpad, HasPersonSea
 
                 final Person person = personByView.get(personView);
 
-                final List<WorkingTime> personWorkingTimeList = workingTimeList
-                    .stream()
-                    .filter(workingTime -> workingTime.getPerson().equals(person))
-                    .sorted(comparing(WorkingTime::getValidFrom).reversed())
-                    .toList();
+                final Map<DateRange, WorkingTime> personWorkingTimes = workingTimesByPerson.getOrDefault(person, Map.of());
 
                 final List<AbsencePeriod.Record> personAbsenceRecordsForDate = Optional.ofNullable(absencePeriodRecordsByPerson.get(person))
                     .stream()
@@ -268,26 +262,25 @@ public class AbsenceOverviewViewController implements HasLaunchpad, HasPersonSea
                     .orElseGet(() -> getAbsenceOverviewDayType(personAbsenceRecordsForDate, shouldAnonymizeAbsenceType, recordInfoToColor))
                     .build();
 
-                personView.getDays().add(new AbsenceOverviewPersonDayDto(personViewDayType, isWorkday(date, personWorkingTimeList)));
+                personView.getDays().add(new AbsenceOverviewPersonDayDto(personViewDayType, isWorkday(date, personWorkingTimes)));
             }
         }
 
         return new ArrayList<>(monthsByNr.values());
     }
 
-    private boolean isWorkday(LocalDate date, List<WorkingTime> workingTimeList) {
-        return workingTimeList
-            .stream()
-            .filter(w -> w.getValidFrom().isBefore(date) || w.getValidFrom().isEqual(date))
+    private boolean isWorkday(LocalDate date, Map<DateRange, WorkingTime> workingTimesByDateRange) {
+        return workingTimesByDateRange.entrySet().stream()
+            .filter(entry -> entry.getKey().isOverlapping(new DateRange(date, date)))
             .findFirst()
-            .map(w -> w.isWorkingDay(date.getDayOfWeek()))
+            .map(entry -> entry.getValue().isWorkingDay(date.getDayOfWeek()))
             .orElse(false);
     }
 
-    private Map<LocalDate, PublicHoliday> getPublicHolidaysOfPerson(Map<DateRange, FederalState> federalStatesByDateRange) {
-        return federalStatesByDateRange
+    private Map<LocalDate, PublicHoliday> getPublicHolidaysOfPerson(Map<DateRange, WorkingTime> workingTimesByDateRange) {
+        return workingTimesByDateRange
             .entrySet().stream()
-            .map(entry -> publicHolidaysService.getPublicHolidays(entry.getKey().startDate(), entry.getKey().endDate(), entry.getValue()))
+            .map(entry -> publicHolidaysService.getPublicHolidays(entry.getKey().startDate(), entry.getKey().endDate(), entry.getValue().getFederalState()))
             .flatMap(List::stream)
             .collect(toMap(PublicHoliday::date, Function.identity(), (publicHoliday, publicHoliday2) -> new PublicHoliday(publicHoliday.date(), publicHoliday.dayLength(), publicHoliday.description().concat("/").concat(publicHoliday2.description()))));
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/account/TurnOfTheYearAccountUpdaterService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/account/TurnOfTheYearAccountUpdaterService.java
@@ -18,6 +18,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.invoke.MethodHandles.lookup;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.synyx.urlaubsverwaltung.person.Role.OFFICE;
 
@@ -58,10 +60,14 @@ public class TurnOfTheYearAccountUpdaterService {
         final int year = Year.now(clock).getValue();
         final List<Person> activePersons = personService.getActivePersons();
 
+        // load all last year's accounts with a single query instead of one query per person
+        final Map<Person, Account> lastYearAccountByPerson = accountService.getHolidaysAccount(year - 1, activePersons).stream()
+            .collect(toMap(Account::getPerson, identity(), (first, second) -> first));
+
         // get all their accounts and calculate the remaining vacation days for the new year
         final List<Account> updatedAccounts = new ArrayList<>();
         for (Person person : activePersons) {
-            final Optional<Account> accountLastYear = accountService.getHolidaysAccount(year - 1, person);
+            final Optional<Account> accountLastYear = Optional.ofNullable(lastYearAccountByPerson.get(person));
             if (accountLastYear.isPresent() && accountLastYear.get().getAnnualVacationDays() != null) {
                 LOG.info("Updating account of person with id {}", person.getId());
                 final Account holidaysAccount = accountInteractionService.autoCreateOrUpdateNextYearsHolidaysAccount(accountLastYear.get());

--- a/src/main/java/org/synyx/urlaubsverwaltung/account/VacationDaysReminderService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/account/VacationDaysReminderService.java
@@ -19,6 +19,8 @@ import java.util.Optional;
 
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.math.BigDecimal.ZERO;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
 import static org.slf4j.LoggerFactory.getLogger;
 
 @Service
@@ -53,12 +55,16 @@ public class VacationDaysReminderService {
         final Year nextYear = year.plusYears(1);
         final List<Person> persons = personService.getActivePersons();
 
+        // load next year's accounts of all persons with a single query instead of one query per person
+        final Map<Person, Account> nextYearAccountByPerson = accountService.getHolidaysAccount(nextYear.getValue(), persons).stream()
+            .collect(toMap(Account::getPerson, identity(), (first, second) -> first));
+
         accountService.getHolidaysAccount(year.getValue(), persons)
             .forEach(holidayAccountThisYear -> {
                 final BigDecimal vacationDaysLeft = vacationDaysService.getTotalLeftVacationDays(holidayAccountThisYear);
                 if (vacationDaysLeft.compareTo(ZERO) > 0) {
 
-                    final Optional<Account> holidaysAccountsNextYear = accountService.getHolidaysAccount(nextYear.getValue(), holidayAccountThisYear.getPerson());
+                    final Optional<Account> holidaysAccountsNextYear = Optional.ofNullable(nextYearAccountByPerson.get(holidayAccountThisYear.getPerson()));
                     final Account holidayAccountNextWithFallbackThisYear = holidaysAccountsNextYear.orElse(holidayAccountThisYear);
                     if (holidayAccountNextWithFallbackThisYear.doRemainingVacationDaysExpire()) {
                         final LocalDate expiryDate = holidayAccountNextWithFallbackThisYear.getExpiryDate().withYear(nextYear.getValue());

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendar/CalendarSharingViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendar/CalendarSharingViewController.java
@@ -24,8 +24,11 @@ import org.synyx.urlaubsverwaltung.search.PersonSuggestionUrlStrategy;
 import java.time.Period;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.synyx.urlaubsverwaltung.person.Role.BOSS;
 import static org.synyx.urlaubsverwaltung.person.Role.OFFICE;
@@ -249,6 +252,10 @@ public class CalendarSharingViewController implements HasLaunchpad, HasPersonSea
             throw new ResponseStatusException(BAD_REQUEST, "person=%s is not a member of department=%s".formatted(personId, activeDepartmentId));
         }
 
+        // load all department calendars of the person with a single query instead of one query per department
+        final Map<Long, DepartmentCalendar> departmentCalendarByDepartmentId = departmentCalendarService.getCalendarsForPerson(personId).stream()
+            .collect(toMap(DepartmentCalendar::getDepartmentId, identity(), (first, second) -> first));
+
         for (Department department : departments) {
 
             final var departmentId = department.getId();
@@ -258,7 +265,7 @@ public class CalendarSharingViewController implements HasLaunchpad, HasPersonSea
             departmentCalendarDto.setDepartmentName(department.getName());
             departmentCalendarDto.setActive(departmentId.equals(activeDepartmentId));
 
-            final var maybeDepartmentCalendar = departmentCalendarService.getCalendarForDepartment(departmentId, personId);
+            final var maybeDepartmentCalendar = Optional.ofNullable(departmentCalendarByDepartmentId.get(departmentId));
             if (maybeDepartmentCalendar.isPresent()) {
                 final var departmentCalendar = maybeDepartmentCalendar.get();
                 final var path = "web/departments/%s/persons/%s/calendar?secret=%s".formatted(departmentId, personId, departmentCalendar.getSecret());

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeService.java
@@ -70,6 +70,22 @@ public interface WorkingTimeService {
     Map<DateRange, FederalState> getFederalStatesByPersonAndDateRange(Person person, DateRange dateRange);
 
     /**
+     * Returns, for each of the given persons, a map of date ranges and the associated federal state.
+     * <p>
+     * The working times of all persons are loaded with a single query, so this is the batch variant of
+     * {@link #getFederalStatesByPersonAndDateRange(Person, DateRange)} to avoid one query per person.
+     * <p>
+     * Note: The federal state of the {@link DateRange} is either
+     * the default federate state based on the settings
+     * or the user specific. But never empty.
+     *
+     * @param persons   to get the federal states of
+     * @param dateRange to specify the
+     * @return map of persons and their associated date ranges and federal states
+     */
+    Map<Person, Map<DateRange, FederalState>> getFederalStatesByPersons(List<Person> persons, DateRange dateRange);
+
+    /**
      * Returns the federal state of a person.
      * <p>
      * Note: That the federal state is either

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeService.java
@@ -70,20 +70,20 @@ public interface WorkingTimeService {
     Map<DateRange, FederalState> getFederalStatesByPersonAndDateRange(Person person, DateRange dateRange);
 
     /**
-     * Returns, for each of the given persons, a map of date ranges and the associated federal state.
+     * Returns, for each of the given persons, a map of date ranges and the associated working time.
      * <p>
      * The working times of all persons are loaded with a single query, so this is the batch variant of
-     * {@link #getFederalStatesByPersonAndDateRange(Person, DateRange)} to avoid one query per person.
+     * {@link #getWorkingTimesByPersonAndDateRange(Person, DateRange)} to avoid one query per person.
      * <p>
-     * Note: The federal state of the {@link DateRange} is either
+     * Note: The federal state of the working time is either
      * the default federate state based on the settings
      * or the user specific. But never empty.
      *
-     * @param persons   to get the federal states of
+     * @param persons   to get the working times of
      * @param dateRange to specify the
-     * @return map of persons and their associated date ranges and federal states
+     * @return map of persons and their associated date ranges and working times, persons without working times are mapped to an empty map
      */
-    Map<Person, Map<DateRange, FederalState>> getFederalStatesByPersons(List<Person> persons, DateRange dateRange);
+    Map<Person, Map<DateRange, WorkingTime>> getWorkingTimesByPersonsAndDateRange(List<Person> persons, DateRange dateRange);
 
     /**
      * Returns the federal state of a person.

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImpl.java
@@ -23,6 +23,8 @@ import java.util.function.Supplier;
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.time.format.DateTimeFormatter.ofPattern;
 import static java.time.temporal.TemporalAdjusters.firstDayOfYear;
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toMap;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.synyx.urlaubsverwaltung.util.DateAndTimeFormat.DD_MM_YYYY;
@@ -101,9 +103,51 @@ class WorkingTimeServiceImpl implements WorkingTimeService, WorkingTimeWriteServ
 
     @Override
     public Map<DateRange, WorkingTime> getWorkingTimesByPersonAndDateRange(Person person, DateRange dateRange) {
-
         final List<WorkingTime> workingTimesByPerson = toWorkingTimes(workingTimeRepository.findByPersonOrderByValidFromDesc(person));
-        final List<WorkingTime> workingTimeList = workingTimesByPerson.stream()
+        return workingTimesByDateRange(workingTimesByPerson, dateRange);
+    }
+
+    @Override
+    public Map<DateRange, FederalState> getFederalStatesByPersonAndDateRange(Person person, DateRange dateRange) {
+        return toFederalStateByDateRange(getWorkingTimesByPersonAndDateRange(person, dateRange));
+    }
+
+    @Override
+    public Map<Person, Map<DateRange, FederalState>> getFederalStatesByPersons(List<Person> persons, DateRange dateRange) {
+
+        // load the working times of all persons with a single query instead of one query per person
+        final Map<Person, List<WorkingTime>> workingTimesByPerson = toWorkingTimes(workingTimeRepository.findByPersonIn(persons)).stream()
+            .collect(groupingBy(WorkingTime::getPerson));
+
+        final Map<Person, Map<DateRange, FederalState>> federalStatesByPerson = new HashMap<>();
+        for (Person person : persons) {
+            final List<WorkingTime> personWorkingTimes = workingTimesByPerson.getOrDefault(person, List.of());
+            federalStatesByPerson.put(person, toFederalStateByDateRange(workingTimesByDateRange(personWorkingTimes, dateRange)));
+        }
+
+        return federalStatesByPerson;
+    }
+
+    private static Map<DateRange, FederalState> toFederalStateByDateRange(Map<DateRange, WorkingTime> workingTimesByDateRange) {
+        return workingTimesByDateRange.entrySet().stream()
+            .collect(toMap(Map.Entry::getKey, dateRangeWorkingTimeEntry -> dateRangeWorkingTimeEntry.getValue().getFederalState()));
+    }
+
+    /**
+     * Maps the given working times of a single person to the date ranges they apply to within the given date range.
+     * <p>
+     * This is the in-memory part of {@link #getWorkingTimesByPersonAndDateRange(Person, DateRange)} extracted so that
+     * callers which loaded the working times of (potentially many) persons with a single query can reuse it without
+     * issuing one query per person.
+     *
+     * @param workingTimes all working times of a single person (in any order)
+     * @param dateRange    the date range of interest
+     * @return map of date ranges and the associated working time of the person
+     */
+    static Map<DateRange, WorkingTime> workingTimesByDateRange(List<WorkingTime> workingTimes, DateRange dateRange) {
+
+        final List<WorkingTime> workingTimeList = workingTimes.stream()
+            .sorted(comparing(WorkingTime::getValidFrom).reversed())
             .filter(workingTime -> !workingTime.getValidFrom().isAfter(dateRange.endDate()))
             .toList();
 
@@ -129,12 +173,6 @@ class WorkingTimeServiceImpl implements WorkingTimeService, WorkingTimeWriteServ
         }
 
         return workingTimesOfPersonByDateRange;
-    }
-
-    @Override
-    public Map<DateRange, FederalState> getFederalStatesByPersonAndDateRange(Person person, DateRange dateRange) {
-        return getWorkingTimesByPersonAndDateRange(person, dateRange).entrySet().stream()
-            .collect(toMap(Map.Entry::getKey, dateRangeWorkingTimeEntry -> dateRangeWorkingTimeEntry.getValue().getFederalState()));
     }
 
     @Override

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImpl.java
@@ -24,6 +24,7 @@ import static java.lang.invoke.MethodHandles.lookup;
 import static java.time.format.DateTimeFormatter.ofPattern;
 import static java.time.temporal.TemporalAdjusters.firstDayOfYear;
 import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toMap;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.synyx.urlaubsverwaltung.util.DateAndTimeFormat.DD_MM_YYYY;
@@ -106,6 +107,32 @@ class WorkingTimeServiceImpl implements WorkingTimeService, WorkingTimeWriteServ
         return workingTimesByDateRange(workingTimesByPerson, dateRange);
     }
 
+    @Override
+    public Map<DateRange, FederalState> getFederalStatesByPersonAndDateRange(Person person, DateRange dateRange) {
+        return toFederalStateByDateRange(getWorkingTimesByPersonAndDateRange(person, dateRange));
+    }
+
+    @Override
+    public Map<Person, Map<DateRange, FederalState>> getFederalStatesByPersons(List<Person> persons, DateRange dateRange) {
+
+        // load the working times of all persons with a single query instead of one query per person
+        final Map<Person, List<WorkingTime>> workingTimesByPerson = toWorkingTimes(workingTimeRepository.findByPersonIn(persons)).stream()
+            .collect(groupingBy(WorkingTime::getPerson));
+
+        final Map<Person, Map<DateRange, FederalState>> federalStatesByPerson = new HashMap<>();
+        for (Person person : persons) {
+            final List<WorkingTime> personWorkingTimes = workingTimesByPerson.getOrDefault(person, List.of());
+            federalStatesByPerson.put(person, toFederalStateByDateRange(workingTimesByDateRange(personWorkingTimes, dateRange)));
+        }
+
+        return federalStatesByPerson;
+    }
+
+    private static Map<DateRange, FederalState> toFederalStateByDateRange(Map<DateRange, WorkingTime> workingTimesByDateRange) {
+        return workingTimesByDateRange.entrySet().stream()
+            .collect(toMap(Map.Entry::getKey, dateRangeWorkingTimeEntry -> dateRangeWorkingTimeEntry.getValue().getFederalState()));
+    }
+
     /**
      * Maps the given working times of a single person to the date ranges they apply to within the given date range.
      * <p>
@@ -146,12 +173,6 @@ class WorkingTimeServiceImpl implements WorkingTimeService, WorkingTimeWriteServ
         }
 
         return workingTimesOfPersonByDateRange;
-    }
-
-    @Override
-    public Map<DateRange, FederalState> getFederalStatesByPersonAndDateRange(Person person, DateRange dateRange) {
-        return getWorkingTimesByPersonAndDateRange(person, dateRange).entrySet().stream()
-            .collect(toMap(Map.Entry::getKey, dateRangeWorkingTimeEntry -> dateRangeWorkingTimeEntry.getValue().getFederalState()));
     }
 
     @Override

--- a/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImpl.java
@@ -113,19 +113,19 @@ class WorkingTimeServiceImpl implements WorkingTimeService, WorkingTimeWriteServ
     }
 
     @Override
-    public Map<Person, Map<DateRange, FederalState>> getFederalStatesByPersons(List<Person> persons, DateRange dateRange) {
+    public Map<Person, Map<DateRange, WorkingTime>> getWorkingTimesByPersonsAndDateRange(List<Person> persons, DateRange dateRange) {
 
         // load the working times of all persons with a single query instead of one query per person
         final Map<Person, List<WorkingTime>> workingTimesByPerson = toWorkingTimes(workingTimeRepository.findByPersonIn(persons)).stream()
             .collect(groupingBy(WorkingTime::getPerson));
 
-        final Map<Person, Map<DateRange, FederalState>> federalStatesByPerson = new HashMap<>();
+        final Map<Person, Map<DateRange, WorkingTime>> workingTimesByPersonAndDateRange = new HashMap<>();
         for (Person person : persons) {
             final List<WorkingTime> personWorkingTimes = workingTimesByPerson.getOrDefault(person, List.of());
-            federalStatesByPerson.put(person, toFederalStateByDateRange(workingTimesByDateRange(personWorkingTimes, dateRange)));
+            workingTimesByPersonAndDateRange.put(person, workingTimesByDateRange(personWorkingTimes, dateRange));
         }
 
-        return federalStatesByPerson;
+        return workingTimesByPersonAndDateRange;
     }
 
     private static Map<DateRange, FederalState> toFederalStateByDateRange(Map<DateRange, WorkingTime> workingTimesByDateRange) {

--- a/src/test/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewControllerTest.java
@@ -57,7 +57,9 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -3968,8 +3970,8 @@ class AbsenceOverviewViewControllerTest {
 
         when(vacationTypeService.getAllVacationTypes()).thenReturn(List.of());
 
-        when(workingTimeService.getFederalStatesByPersonAndDateRange(person, dateRange))
-            .thenReturn(Map.of(dateRange, GERMANY_BADEN_WUERTTEMBERG));
+        when(workingTimeService.getFederalStatesByPersons(anyList(), eq(dateRange)))
+            .thenReturn(Map.of(person, Map.of(dateRange, GERMANY_BADEN_WUERTTEMBERG)));
 
         when(publicHolidaysService.getPublicHolidays(firstOfMonth, lastOfMonth, GERMANY_BADEN_WUERTTEMBERG))
             .thenReturn(List.of(new PublicHoliday(december24, MORNING, "Heiligabend")));
@@ -4031,8 +4033,8 @@ class AbsenceOverviewViewControllerTest {
 
         when(vacationTypeService.getAllVacationTypes()).thenReturn(List.of());
 
-        when(workingTimeService.getFederalStatesByPersonAndDateRange(person, dateRange))
-            .thenReturn(Map.of(dateRange, GERMANY_BADEN_WUERTTEMBERG));
+        when(workingTimeService.getFederalStatesByPersons(anyList(), eq(dateRange)))
+            .thenReturn(Map.of(person, Map.of(dateRange, GERMANY_BADEN_WUERTTEMBERG)));
 
         when(publicHolidaysService.getPublicHolidays(firstOfMonth, lastOfMonth, GERMANY_BADEN_WUERTTEMBERG))
             .thenReturn(List.of(new PublicHoliday(december24, NOON, "Heiligabend")));
@@ -5123,8 +5125,10 @@ class AbsenceOverviewViewControllerTest {
         final LocalDate start = LocalDate.of(2022, JANUARY, 1);
         final LocalDate end = LocalDate.of(2022, JANUARY, 31);
         final DateRange dateRange = new DateRange(start, end);
-        when(workingTimeService.getFederalStatesByPersonAndDateRange(personWithCustomPublicHolidays, dateRange)).thenReturn(Map.of(dateRange, GERMANY_BADEN_WUERTTEMBERG));
-        when(workingTimeService.getFederalStatesByPersonAndDateRange(personDefaultPublicHolidays, dateRange)).thenReturn(Map.of(dateRange, GERMANY_RHEINLAND_PFALZ));
+        when(workingTimeService.getFederalStatesByPersons(anyList(), eq(dateRange))).thenReturn(Map.of(
+            personWithCustomPublicHolidays, Map.of(dateRange, GERMANY_BADEN_WUERTTEMBERG),
+            personDefaultPublicHolidays, Map.of(dateRange, GERMANY_RHEINLAND_PFALZ)
+        ));
 
         when(publicHolidaysService.getPublicHolidays(start, end, GERMANY_BADEN_WUERTTEMBERG)).thenReturn(List.of(new PublicHoliday(LocalDate.of(2022, JANUARY, 6), FULL, "")));
         when(publicHolidaysService.getPublicHolidays(start, end, GERMANY_RHEINLAND_PFALZ)).thenReturn(emptyList());

--- a/src/test/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewControllerTest.java
@@ -31,6 +31,7 @@ import org.synyx.urlaubsverwaltung.publicholiday.PublicHoliday;
 import org.synyx.urlaubsverwaltung.publicholiday.PublicHolidaysService;
 import org.synyx.urlaubsverwaltung.search.PersonSearchUiFragmentSupplier;
 import org.synyx.urlaubsverwaltung.search.PersonSuggestionUrlStrategy;
+import org.synyx.urlaubsverwaltung.workingtime.WorkingTime;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeService;
 
 import java.time.Clock;
@@ -3970,8 +3971,8 @@ class AbsenceOverviewViewControllerTest {
 
         when(vacationTypeService.getAllVacationTypes()).thenReturn(List.of());
 
-        when(workingTimeService.getFederalStatesByPersons(anyList(), eq(dateRange)))
-            .thenReturn(Map.of(person, Map.of(dateRange, GERMANY_BADEN_WUERTTEMBERG)));
+        when(workingTimeService.getWorkingTimesByPersonsAndDateRange(anyList(), eq(dateRange)))
+            .thenReturn(Map.of(person, Map.of(dateRange, new WorkingTime(person, firstOfMonth, GERMANY_BADEN_WUERTTEMBERG, false))));
 
         when(publicHolidaysService.getPublicHolidays(firstOfMonth, lastOfMonth, GERMANY_BADEN_WUERTTEMBERG))
             .thenReturn(List.of(new PublicHoliday(december24, MORNING, "Heiligabend")));
@@ -4033,8 +4034,8 @@ class AbsenceOverviewViewControllerTest {
 
         when(vacationTypeService.getAllVacationTypes()).thenReturn(List.of());
 
-        when(workingTimeService.getFederalStatesByPersons(anyList(), eq(dateRange)))
-            .thenReturn(Map.of(person, Map.of(dateRange, GERMANY_BADEN_WUERTTEMBERG)));
+        when(workingTimeService.getWorkingTimesByPersonsAndDateRange(anyList(), eq(dateRange)))
+            .thenReturn(Map.of(person, Map.of(dateRange, new WorkingTime(person, firstOfMonth, GERMANY_BADEN_WUERTTEMBERG, false))));
 
         when(publicHolidaysService.getPublicHolidays(firstOfMonth, lastOfMonth, GERMANY_BADEN_WUERTTEMBERG))
             .thenReturn(List.of(new PublicHoliday(december24, NOON, "Heiligabend")));
@@ -5125,9 +5126,9 @@ class AbsenceOverviewViewControllerTest {
         final LocalDate start = LocalDate.of(2022, JANUARY, 1);
         final LocalDate end = LocalDate.of(2022, JANUARY, 31);
         final DateRange dateRange = new DateRange(start, end);
-        when(workingTimeService.getFederalStatesByPersons(anyList(), eq(dateRange))).thenReturn(Map.of(
-            personWithCustomPublicHolidays, Map.of(dateRange, GERMANY_BADEN_WUERTTEMBERG),
-            personDefaultPublicHolidays, Map.of(dateRange, GERMANY_RHEINLAND_PFALZ)
+        when(workingTimeService.getWorkingTimesByPersonsAndDateRange(anyList(), eq(dateRange))).thenReturn(Map.of(
+            personWithCustomPublicHolidays, Map.of(dateRange, new WorkingTime(personWithCustomPublicHolidays, start, GERMANY_BADEN_WUERTTEMBERG, false)),
+            personDefaultPublicHolidays, Map.of(dateRange, new WorkingTime(personDefaultPublicHolidays, start, GERMANY_RHEINLAND_PFALZ, false))
         ));
 
         when(publicHolidaysService.getPublicHolidays(start, end, GERMANY_BADEN_WUERTTEMBERG)).thenReturn(List.of(new PublicHoliday(LocalDate.of(2022, JANUARY, 6), FULL, "")));

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/TurnOfTheYearAccountUpdaterServiceIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/TurnOfTheYearAccountUpdaterServiceIT.java
@@ -24,7 +24,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
-import java.util.Optional;
 
 import static java.math.BigDecimal.TEN;
 import static java.math.BigDecimal.TWO;
@@ -67,10 +66,8 @@ class TurnOfTheYearAccountUpdaterServiceIT extends SingleTenantTestContainersBas
         when(personService.getActivePersons()).thenReturn(List.of(person, person2));
 
         final Account account1 = createHolidaysAccount(person, 2021);
-        when(accountService.getHolidaysAccount(2021, person)).thenReturn(Optional.of(account1));
-
         final Account account2 = createHolidaysAccount(person2, 2021);
-        when(accountService.getHolidaysAccount(2021, person2)).thenReturn(Optional.of(account2));
+        when(accountService.getHolidaysAccount(2021, List.of(person, person2))).thenReturn(List.of(account1, account2));
 
         final Account newAccount1 = createHolidaysAccount(person, 2022);
         newAccount1.setRemainingVacationDays(TEN);

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/TurnOfTheYearAccountUpdaterServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/TurnOfTheYearAccountUpdaterServiceTest.java
@@ -15,13 +15,11 @@ import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Year;
 import java.util.List;
-import java.util.Optional;
 
 import static java.util.Arrays.asList;
 import static java.util.Locale.GERMAN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -69,9 +67,8 @@ class TurnOfTheYearAccountUpdaterServiceTest {
         account3.setId(3L);
 
         when(personService.getActivePersons()).thenReturn(asList(user1, user2, user3));
-        when(accountService.getHolidaysAccount(LAST_YEAR, user1)).thenReturn(Optional.of(account1));
-        when(accountService.getHolidaysAccount(LAST_YEAR, user2)).thenReturn(Optional.of(account2));
-        when(accountService.getHolidaysAccount(LAST_YEAR, user3)).thenReturn(Optional.of(account3));
+        when(accountService.getHolidaysAccount(LAST_YEAR, asList(user1, user2, user3)))
+            .thenReturn(asList(account1, account2, account3));
 
         final Account newAccount = mock(Account.class);
         when(newAccount.getRemainingVacationDays()).thenReturn(BigDecimal.TEN);
@@ -85,11 +82,8 @@ class TurnOfTheYearAccountUpdaterServiceTest {
 
         verify(personService).getActivePersons();
 
-        verify(accountService, times(3))
-            .getHolidaysAccount(anyInt(), any(Person.class));
-        verify(accountService).getHolidaysAccount(LAST_YEAR, user1);
-        verify(accountService).getHolidaysAccount(LAST_YEAR, user2);
-        verify(accountService).getHolidaysAccount(LAST_YEAR, user3);
+        // all last year's accounts are loaded with a single query instead of one query per person
+        verify(accountService).getHolidaysAccount(LAST_YEAR, asList(user1, user2, user3));
 
         verify(accountInteractionService, times(3))
             .autoCreateOrUpdateNextYearsHolidaysAccount(any(Account.class));

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/VacationDaysReminderServiceIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/VacationDaysReminderServiceIT.java
@@ -25,7 +25,6 @@ import java.time.Year;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static com.icegreen.greenmail.util.ServerSetupTest.SMTP_IMAP;
 import static java.math.BigDecimal.TEN;
@@ -73,7 +72,7 @@ class VacationDaysReminderServiceIT extends SingleTenantTestContainersBase {
         accountNextYear.setPerson(person);
         accountNextYear.setExpiryDateLocally(LocalDate.of(2023, APRIL, 10));
         accountNextYear.setDoRemainingVacationDaysExpireLocally(true);
-        when(accountService.getHolidaysAccount(2023, person)).thenReturn(Optional.of(accountNextYear));
+        when(accountService.getHolidaysAccount(2023, List.of(person))).thenReturn(List.of(accountNextYear));
 
         sut.remindForCurrentlyLeftVacationDays();
 
@@ -114,7 +113,7 @@ class VacationDaysReminderServiceIT extends SingleTenantTestContainersBase {
         when(accountService.getHolidaysAccount(2022, List.of(person))).thenReturn(List.of(account));
         when(vacationDaysService.getTotalLeftVacationDays(account)).thenReturn(TEN);
 
-        when(accountService.getHolidaysAccount(2023, person)).thenReturn(Optional.empty());
+        when(accountService.getHolidaysAccount(2023, List.of(person))).thenReturn(List.of());
 
         sut.remindForCurrentlyLeftVacationDays();
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/VacationDaysReminderServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/VacationDaysReminderServiceTest.java
@@ -18,7 +18,6 @@ import java.time.Year;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.TEN;
@@ -56,6 +55,7 @@ class VacationDaysReminderServiceTest {
         final Account account = new Account();
         account.setExpiryDateLocally(LocalDate.of(2022, 4, 1));
         when(accountService.getHolidaysAccount(2022, List.of(person))).thenReturn(List.of(account));
+        when(accountService.getHolidaysAccount(2023, List.of(person))).thenReturn(List.of());
         when(vacationDaysService.getTotalLeftVacationDays(account)).thenReturn(ZERO);
 
         sut.remindForCurrentlyLeftVacationDays();
@@ -80,7 +80,7 @@ class VacationDaysReminderServiceTest {
         final Account accountNextYear = new Account();
         accountNextYear.setPerson(person);
         accountNextYear.setDoRemainingVacationDaysExpireGlobally(false);
-        when(accountService.getHolidaysAccount(2023, person)).thenReturn(Optional.of(accountNextYear));
+        when(accountService.getHolidaysAccount(2023, List.of(person))).thenReturn(List.of(accountNextYear));
 
         sut.remindForCurrentlyLeftVacationDays();
 
@@ -97,6 +97,7 @@ class VacationDaysReminderServiceTest {
         when(personService.getActivePersons()).thenReturn(List.of(person));
 
         when(accountService.getHolidaysAccount(2022, List.of(person))).thenReturn(List.of());
+        when(accountService.getHolidaysAccount(2023, List.of(person))).thenReturn(List.of());
 
         sut.remindForCurrentlyLeftVacationDays();
 
@@ -117,6 +118,7 @@ class VacationDaysReminderServiceTest {
         account.setDoRemainingVacationDaysExpireGlobally(true);
         account.setExpiryDateLocally(LocalDate.of(2022, 4, 1));
         when(accountService.getHolidaysAccount(2022, List.of(person))).thenReturn(List.of(account));
+        when(accountService.getHolidaysAccount(2023, List.of(person))).thenReturn(List.of());
         when(vacationDaysService.getTotalLeftVacationDays(account)).thenReturn(TEN);
 
         sut.remindForCurrentlyLeftVacationDays();

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/VacationDaysReminderServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/VacationDaysReminderServiceTest.java
@@ -18,7 +18,6 @@ import java.time.Year;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.TEN;
@@ -58,6 +57,7 @@ class VacationDaysReminderServiceTest {
         final Account account = new Account();
         account.setExpiryDateLocally(LocalDate.of(2022, APRIL, 1));
         when(accountService.getHolidaysAccount(2022, List.of(person))).thenReturn(List.of(account));
+        when(accountService.getHolidaysAccount(2023, List.of(person))).thenReturn(List.of());
         when(vacationDaysService.getTotalLeftVacationDays(account)).thenReturn(ZERO);
 
         sut.remindForCurrentlyLeftVacationDays();
@@ -82,7 +82,7 @@ class VacationDaysReminderServiceTest {
         final Account accountNextYear = new Account();
         accountNextYear.setPerson(person);
         accountNextYear.setDoRemainingVacationDaysExpireGlobally(false);
-        when(accountService.getHolidaysAccount(2023, person)).thenReturn(Optional.of(accountNextYear));
+        when(accountService.getHolidaysAccount(2023, List.of(person))).thenReturn(List.of(accountNextYear));
 
         sut.remindForCurrentlyLeftVacationDays();
 
@@ -99,6 +99,7 @@ class VacationDaysReminderServiceTest {
         when(personService.getActivePersons()).thenReturn(List.of(person));
 
         when(accountService.getHolidaysAccount(2022, List.of(person))).thenReturn(List.of());
+        when(accountService.getHolidaysAccount(2023, List.of(person))).thenReturn(List.of());
 
         sut.remindForCurrentlyLeftVacationDays();
 
@@ -119,6 +120,7 @@ class VacationDaysReminderServiceTest {
         account.setDoRemainingVacationDaysExpireGlobally(true);
         account.setExpiryDateLocally(LocalDate.of(2022, APRIL, 1));
         when(accountService.getHolidaysAccount(2022, List.of(person))).thenReturn(List.of(account));
+        when(accountService.getHolidaysAccount(2023, List.of(person))).thenReturn(List.of());
         when(vacationDaysService.getTotalLeftVacationDays(account)).thenReturn(TEN);
 
         sut.remindForCurrentlyLeftVacationDays();

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendar/CalendarSharingViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendar/CalendarSharingViewControllerTest.java
@@ -329,8 +329,10 @@ class CalendarSharingViewControllerTest {
         when(personService.getSignedInUser()).thenReturn(person);
         when(departmentService.getAssignedDepartmentsOfMember(person)).thenReturn(List.of(sockentraeger, barfuslaeufer));
         when(personCalendarService.getPersonCalendar(1L)).thenReturn(Optional.of(anyPersonCalendar()));
-        when(departmentCalendarService.getCalendarForDepartment(1337L, 1L)).thenReturn(Optional.of(anyDepartmentCalendar()));
-        when(departmentCalendarService.getCalendarForDepartment(42L, 1L)).thenReturn(Optional.empty());
+        final DepartmentCalendar barfuslaeuferCalendar = anyDepartmentCalendar();
+        barfuslaeuferCalendar.setDepartmentId(1337L);
+        barfuslaeuferCalendar.setPerson(person);
+        when(departmentCalendarService.getCalendarsForPerson(1L)).thenReturn(List.of(barfuslaeuferCalendar));
 
         perform(get("/web/calendars/share/persons/1/departments/1337"))
             .andExpect(view().name("calendarsharing/index"))

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImplTest.java
@@ -30,6 +30,7 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -366,6 +367,41 @@ class WorkingTimeServiceImplTest {
                 entry(new DateRange(LocalDate.of(2021, 11, 1), LocalDate.of(2021, 11, 14)), GERMANY_BADEN_WUERTTEMBERG),
                 entry(new DateRange(LocalDate.of(2021, 11, 15), LocalDate.of(2021, 11, 30)), GERMANY_RHEINLAND_PFALZ)
             );
+    }
+
+    @Test
+    void getFederalStatesByPersonsLoadsWorkingTimesOfAllPersonsWithASingleQuery() {
+
+        final Person marlene = new Person();
+        marlene.setId(1L);
+        final Person peter = new Person();
+        peter.setId(2L);
+
+        final WorkingTimeEntity marleneWorkingTime = new WorkingTimeEntity();
+        marleneWorkingTime.setId(1L);
+        marleneWorkingTime.setPerson(marlene);
+        marleneWorkingTime.setValidFrom(LocalDate.of(2020, 1, 1));
+        marleneWorkingTime.setFederalStateOverride(GERMANY_BADEN_WUERTTEMBERG);
+
+        final WorkingTimeEntity peterWorkingTime = new WorkingTimeEntity();
+        peterWorkingTime.setId(2L);
+        peterWorkingTime.setPerson(peter);
+        peterWorkingTime.setValidFrom(LocalDate.of(2020, 1, 1));
+        peterWorkingTime.setFederalStateOverride(GERMANY_BAYERN);
+
+        when(workingTimeRepository.findByPersonIn(List.of(marlene, peter)))
+            .thenReturn(List.of(marleneWorkingTime, peterWorkingTime));
+
+        final DateRange dateRange = new DateRange(LocalDate.of(2022, 1, 1), LocalDate.of(2022, 1, 31));
+        final Map<Person, Map<DateRange, FederalState>> federalStatesByPerson = sut.getFederalStatesByPersons(List.of(marlene, peter), dateRange);
+
+        assertThat(federalStatesByPerson).containsOnlyKeys(marlene, peter);
+        assertThat(federalStatesByPerson.get(marlene)).containsExactly(entry(dateRange, GERMANY_BADEN_WUERTTEMBERG));
+        assertThat(federalStatesByPerson.get(peter)).containsExactly(entry(dateRange, GERMANY_BAYERN));
+
+        // batched: a single query for all persons instead of one query per person
+        verify(workingTimeRepository).findByPersonIn(List.of(marlene, peter));
+        verify(workingTimeRepository, never()).findByPersonOrderByValidFromDesc(any());
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImplTest.java
@@ -34,6 +34,7 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -370,6 +371,41 @@ class WorkingTimeServiceImplTest {
                 entry(new DateRange(LocalDate.of(2021, NOVEMBER, 1), LocalDate.of(2021, NOVEMBER, 14)), GERMANY_BADEN_WUERTTEMBERG),
                 entry(new DateRange(LocalDate.of(2021, NOVEMBER, 15), LocalDate.of(2021, NOVEMBER, 30)), GERMANY_RHEINLAND_PFALZ)
             );
+    }
+
+    @Test
+    void getFederalStatesByPersonsLoadsWorkingTimesOfAllPersonsWithASingleQuery() {
+
+        final Person marlene = new Person();
+        marlene.setId(1L);
+        final Person peter = new Person();
+        peter.setId(2L);
+
+        final WorkingTimeEntity marleneWorkingTime = new WorkingTimeEntity();
+        marleneWorkingTime.setId(1L);
+        marleneWorkingTime.setPerson(marlene);
+        marleneWorkingTime.setValidFrom(LocalDate.of(2020, 1, 1));
+        marleneWorkingTime.setFederalStateOverride(GERMANY_BADEN_WUERTTEMBERG);
+
+        final WorkingTimeEntity peterWorkingTime = new WorkingTimeEntity();
+        peterWorkingTime.setId(2L);
+        peterWorkingTime.setPerson(peter);
+        peterWorkingTime.setValidFrom(LocalDate.of(2020, 1, 1));
+        peterWorkingTime.setFederalStateOverride(GERMANY_BAYERN);
+
+        when(workingTimeRepository.findByPersonIn(List.of(marlene, peter)))
+            .thenReturn(List.of(marleneWorkingTime, peterWorkingTime));
+
+        final DateRange dateRange = new DateRange(LocalDate.of(2022, 1, 1), LocalDate.of(2022, 1, 31));
+        final Map<Person, Map<DateRange, FederalState>> federalStatesByPerson = sut.getFederalStatesByPersons(List.of(marlene, peter), dateRange);
+
+        assertThat(federalStatesByPerson).containsOnlyKeys(marlene, peter);
+        assertThat(federalStatesByPerson.get(marlene)).containsExactly(entry(dateRange, GERMANY_BADEN_WUERTTEMBERG));
+        assertThat(federalStatesByPerson.get(peter)).containsExactly(entry(dateRange, GERMANY_BAYERN));
+
+        // batched: a single query for all persons instead of one query per person
+        verify(workingTimeRepository).findByPersonIn(List.of(marlene, peter));
+        verify(workingTimeRepository, never()).findByPersonOrderByValidFromDesc(any());
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImplTest.java
@@ -374,7 +374,7 @@ class WorkingTimeServiceImplTest {
     }
 
     @Test
-    void getFederalStatesByPersonsLoadsWorkingTimesOfAllPersonsWithASingleQuery() {
+    void getWorkingTimesByPersonsAndDateRangeLoadsWorkingTimesOfAllPersonsWithASingleQuery() {
 
         final Person marlene = new Person();
         marlene.setId(1L);
@@ -384,28 +384,74 @@ class WorkingTimeServiceImplTest {
         final WorkingTimeEntity marleneWorkingTime = new WorkingTimeEntity();
         marleneWorkingTime.setId(1L);
         marleneWorkingTime.setPerson(marlene);
-        marleneWorkingTime.setValidFrom(LocalDate.of(2020, 1, 1));
+        marleneWorkingTime.setValidFrom(LocalDate.of(2020, JANUARY, 1));
         marleneWorkingTime.setFederalStateOverride(GERMANY_BADEN_WUERTTEMBERG);
 
         final WorkingTimeEntity peterWorkingTime = new WorkingTimeEntity();
         peterWorkingTime.setId(2L);
         peterWorkingTime.setPerson(peter);
-        peterWorkingTime.setValidFrom(LocalDate.of(2020, 1, 1));
+        peterWorkingTime.setValidFrom(LocalDate.of(2020, JANUARY, 1));
         peterWorkingTime.setFederalStateOverride(GERMANY_BAYERN);
 
         when(workingTimeRepository.findByPersonIn(List.of(marlene, peter)))
             .thenReturn(List.of(marleneWorkingTime, peterWorkingTime));
 
-        final DateRange dateRange = new DateRange(LocalDate.of(2022, 1, 1), LocalDate.of(2022, 1, 31));
-        final Map<Person, Map<DateRange, FederalState>> federalStatesByPerson = sut.getFederalStatesByPersons(List.of(marlene, peter), dateRange);
+        final DateRange dateRange = new DateRange(LocalDate.of(2022, JANUARY, 1), LocalDate.of(2022, JANUARY, 31));
+        final Map<Person, Map<DateRange, WorkingTime>> workingTimesByPerson = sut.getWorkingTimesByPersonsAndDateRange(List.of(marlene, peter), dateRange);
 
-        assertThat(federalStatesByPerson).containsOnlyKeys(marlene, peter);
-        assertThat(federalStatesByPerson.get(marlene)).containsExactly(entry(dateRange, GERMANY_BADEN_WUERTTEMBERG));
-        assertThat(federalStatesByPerson.get(peter)).containsExactly(entry(dateRange, GERMANY_BAYERN));
+        assertThat(workingTimesByPerson).containsOnlyKeys(marlene, peter);
+        assertThat(workingTimesByPerson.get(marlene)).containsOnlyKeys(dateRange);
+        assertThat(workingTimesByPerson.get(marlene).get(dateRange).getFederalState()).isEqualTo(GERMANY_BADEN_WUERTTEMBERG);
+        assertThat(workingTimesByPerson.get(peter)).containsOnlyKeys(dateRange);
+        assertThat(workingTimesByPerson.get(peter).get(dateRange).getFederalState()).isEqualTo(GERMANY_BAYERN);
 
         // batched: a single query for all persons instead of one query per person
         verify(workingTimeRepository).findByPersonIn(List.of(marlene, peter));
         verify(workingTimeRepository, never()).findByPersonOrderByValidFromDesc(any());
+    }
+
+    @Test
+    void getWorkingTimesByPersonsAndDateRangeSplitsTheDateRangeOnEveryWorkingTimeOfAPerson() {
+
+        final Person marlene = new Person();
+        marlene.setId(1L);
+
+        final WorkingTimeEntity older = new WorkingTimeEntity();
+        older.setId(1L);
+        older.setPerson(marlene);
+        older.setValidFrom(LocalDate.of(2020, JANUARY, 1));
+        older.setFederalStateOverride(GERMANY_BADEN_WUERTTEMBERG);
+
+        final WorkingTimeEntity newer = new WorkingTimeEntity();
+        newer.setId(2L);
+        newer.setPerson(marlene);
+        newer.setValidFrom(LocalDate.of(2022, JANUARY, 15));
+        newer.setFederalStateOverride(GERMANY_BAYERN);
+
+        when(workingTimeRepository.findByPersonIn(List.of(marlene))).thenReturn(List.of(older, newer));
+
+        final DateRange dateRange = new DateRange(LocalDate.of(2022, JANUARY, 1), LocalDate.of(2022, JANUARY, 31));
+        final Map<Person, Map<DateRange, WorkingTime>> workingTimesByPerson = sut.getWorkingTimesByPersonsAndDateRange(List.of(marlene), dateRange);
+
+        final DateRange olderDateRange = new DateRange(LocalDate.of(2022, JANUARY, 1), LocalDate.of(2022, JANUARY, 14));
+        final DateRange newerDateRange = new DateRange(LocalDate.of(2022, JANUARY, 15), LocalDate.of(2022, JANUARY, 31));
+        assertThat(workingTimesByPerson.get(marlene)).containsOnlyKeys(olderDateRange, newerDateRange);
+        assertThat(workingTimesByPerson.get(marlene).get(olderDateRange).getFederalState()).isEqualTo(GERMANY_BADEN_WUERTTEMBERG);
+        assertThat(workingTimesByPerson.get(marlene).get(newerDateRange).getFederalState()).isEqualTo(GERMANY_BAYERN);
+    }
+
+    @Test
+    void getWorkingTimesByPersonsAndDateRangeMapsPersonsWithoutWorkingTimesToAnEmptyMap() {
+
+        final Person marlene = new Person();
+        marlene.setId(1L);
+
+        when(workingTimeRepository.findByPersonIn(List.of(marlene))).thenReturn(List.of());
+
+        final DateRange dateRange = new DateRange(LocalDate.of(2022, JANUARY, 1), LocalDate.of(2022, JANUARY, 31));
+        final Map<Person, Map<DateRange, WorkingTime>> workingTimesByPerson = sut.getWorkingTimesByPersonsAndDateRange(List.of(marlene), dateRange);
+
+        assertThat(workingTimesByPerson).containsExactly(entry(marlene, Map.of()));
     }
 
     @Test


### PR DESCRIPTION
…ate and department calendar lookups

  ### Problem                                                                                                                                                                                                                                                                                                      
  Four places issued one query per person/entity inside a loop:                                                                                                                                                                                                                                                    
  1. `TurnOfTheYearAccountUpdaterService` — `getHolidaysAccount(year-1, person)` per active person (scheduled job over everyone).                                                                                                                                                                                  
  2. `VacationDaysReminderService.remindForCurrentlyLeftVacationDays` — `getHolidaysAccount(nextYear, person)` per account (its sibling methods already batched this).                                                                                                                                             
  3. `AbsenceOverviewViewController` — `getFederalStatesByPersonAndDateRange(person, …)` per person.                                                                                                                                                                                                               
  4. `CalendarSharingViewController` — `getCalendarForDepartment(departmentId, personId)` per department.                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                   
  ### Change                                                                                                                                                                                                                                                                                                       
  1. Load all last-year accounts once via `getHolidaysAccount(year-1, activePersons)`, look up per person.                                                                                                                                                                                                         
  2. Pre-fetch next-year accounts for all persons once (mirrors the sibling methods).                                                                                                                                                                                                                              
  3. New `WorkingTimeService.getFederalStatesByPersons(persons, dateRange)` — one `findByPersonIn`                                                                                                                                                                                                                 
     query, sliced per person in memory (batch variant of `getFederalStatesByPersonAndDateRange`).                                                                                                                                                                                                                 
  4. Use the existing `getCalendarsForPerson(personId)` (single `findByPersonId`) and look up by                                                                                                                                                                                                                   
     department id in memory.                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                   
  Each fix turns **N queries → 1**; all changes are behaviour-preserving (same per-key results,                                                                                                                                                                                                                    
  same `Optional.empty()`/absent fallbacks).                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                   
  ### Testing                                                                                                                                                                                                                                                                                                      
  - Mock-based tests updated to the batch calls.                                                                                                                                                                                                                                                                   
  - Added a `getFederalStatesByPersons` test asserting a single `findByPersonIn` and **no**                                                                                                                                                                                                                        
    per-person query.                                                                                                                                                                                                                                                                                              
  - All tests in the `account`, `calendar`, `absence` and `workingtime` packages pass.                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                   
  > Note: this branch and the Tier 1 branch both extract the same                                                                                                                                                                                                                                                  
  > `WorkingTimeServiceImpl.workingTimesByDateRange(...)` helper. If both are merged, expect a                                                                                                                                                                                                                     
  > trivial conflict in that one region (keep a single copy of the helper).