### PR TITLE
Fix bottom bar zindex: above regular form elements, but below overlay…

### DIFF
--- a/src/main/css/components/bottom-bar.css
+++ b/src/main/css/components/bottom-bar.css
@@ -1,8 +1,4 @@
 .bottom-bar {
-  /* TODO hm... not sure... */
-  /* bottom bar has to be above "everything" else */
-  z-index: 999999;
-
   /* position is set by javascript, as we need javascript to detect whether sticky or not. */
   /* as soon as firefox, safari supports "container-type: scroll-state" we can get rid of javascript. */
   /* (see git history for css...) */

--- a/src/main/javascript/components/sticky/sticky.js
+++ b/src/main/javascript/components/sticky/sticky.js
@@ -9,6 +9,7 @@ export class Sticky extends HTMLElement {
 
     // set by JavaScript since we only know whether sticky or not with this IntersectionOberserver
     this.style.position = "sticky";
+    this.style.zIndex = "var(--z-index-sticky)";
 
     // kudos https://css-tricks.com/how-to-detect-when-a-sticky-element-gets-pinned/
     this.#intersectionObserver = new IntersectionObserver(


### PR DESCRIPTION
…s like the duet date picker popup

closes #6314 

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
