### PR TITLE
google calendar: store access token and encrypt the tokens

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/CalendarIntegrationProperties.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/CalendarIntegrationProperties.java
@@ -1,0 +1,26 @@
+package org.synyx.urlaubsverwaltung.calendarintegration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("uv.calendar-integration")
+public class CalendarIntegrationProperties {
+
+    /**
+     * Secret used to encrypt sensitive calendar integration settings at rest
+     * (google oauth client secret, access token and refresh token).
+     * If not set, these values are stored in plaintext.
+     * <p>
+     * Values that were stored in plaintext before the secret was configured are
+     * encrypted transparently with the next save of the calendar settings.
+     * Changing or removing the secret afterwards makes already encrypted values unreadable.
+     */
+    private String encryptionSecret;
+
+    public String getEncryptionSecret() {
+        return encryptionSecret;
+    }
+
+    public void setEncryptionSecret(String encryptionSecret) {
+        this.encryptionSecret = encryptionSecret;
+    }
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/EncryptedSecretConverter.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/EncryptedSecretConverter.java
@@ -1,0 +1,140 @@
+package org.synyx.urlaubsverwaltung.calendarintegration;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.lang.invoke.MethodHandles.lookup;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Encrypts sensitive calendar integration values (google oauth client secret, access token and refresh token)
+ * with AES-256-GCM before they are written to the database.
+ * <p>
+ * The encryption key is derived (PBKDF2) from the configured {@code uv.calendar-integration.encryption-secret}
+ * and a random salt that is generated per value and stored as part of the encrypted payload:
+ * {@code enc:v1:base64(salt || iv || ciphertext)}.
+ * <p>
+ * Encryption is only active when {@code uv.calendar-integration.encryption-secret} is configured.
+ * Legacy plaintext values are read as-is and become encrypted with the next save.
+ */
+@Component
+@Converter
+class EncryptedSecretConverter implements AttributeConverter<String, String> {
+
+    private static final Logger LOG = getLogger(lookup().lookupClass());
+
+    private static final String ENCRYPTED_PREFIX = "enc:v1:";
+    private static final String CIPHER = "AES/GCM/NoPadding";
+    private static final int SALT_LENGTH = 16;
+    private static final int GCM_IV_LENGTH = 12;
+    private static final int GCM_TAG_LENGTH_BITS = 128;
+    private static final int KEY_DERIVATION_ITERATIONS = 65536;
+    private static final int MAX_CACHED_KEYS = 100;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+    private final Map<String, SecretKeySpec> keyCache = new ConcurrentHashMap<>();
+    private final String encryptionSecret;
+
+    EncryptedSecretConverter(CalendarIntegrationProperties properties) {
+        final String secret = properties.getEncryptionSecret();
+        this.encryptionSecret = secret == null || secret.isBlank() ? null : secret;
+        if (this.encryptionSecret == null) {
+            LOG.warn("No encryption secret configured (uv.calendar-integration.encryption-secret) - " +
+                "calendar integration secrets like oauth tokens will be stored in plaintext.");
+        }
+    }
+
+    @Override
+    public String convertToDatabaseColumn(String attribute) {
+
+        if (attribute == null || encryptionSecret == null) {
+            return attribute;
+        }
+
+        try {
+            final byte[] salt = new byte[SALT_LENGTH];
+            secureRandom.nextBytes(salt);
+            final byte[] iv = new byte[GCM_IV_LENGTH];
+            secureRandom.nextBytes(iv);
+
+            final Cipher cipher = Cipher.getInstance(CIPHER);
+            cipher.init(Cipher.ENCRYPT_MODE, deriveKey(salt), new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
+            final byte[] cipherText = cipher.doFinal(attribute.getBytes(UTF_8));
+
+            final byte[] payload = ByteBuffer.allocate(salt.length + iv.length + cipherText.length)
+                .put(salt)
+                .put(iv)
+                .put(cipherText)
+                .array();
+
+            return ENCRYPTED_PREFIX + Base64.getEncoder().encodeToString(payload);
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException("Could not encrypt calendar integration secret", e);
+        }
+    }
+
+    @Override
+    public String convertToEntityAttribute(String dbData) {
+
+        if (dbData == null || !dbData.startsWith(ENCRYPTED_PREFIX)) {
+            // plaintext value (legacy or encryption not enabled) - encrypted with the next save
+            return dbData;
+        }
+
+        if (encryptionSecret == null) {
+            throw new IllegalStateException("Found an encrypted calendar integration secret but no encryption secret " +
+                "is configured. Please configure 'uv.calendar-integration.encryption-secret' with the secret that was " +
+                "used for encryption.");
+        }
+
+        try {
+            final byte[] payload = Base64.getDecoder().decode(dbData.substring(ENCRYPTED_PREFIX.length()));
+
+            final byte[] salt = new byte[SALT_LENGTH];
+            ByteBuffer.wrap(payload).get(salt);
+
+            final Cipher cipher = Cipher.getInstance(CIPHER);
+            cipher.init(Cipher.DECRYPT_MODE, deriveKey(salt), new GCMParameterSpec(GCM_TAG_LENGTH_BITS, payload, SALT_LENGTH, GCM_IV_LENGTH));
+            final int cipherTextOffset = SALT_LENGTH + GCM_IV_LENGTH;
+            final byte[] plainText = cipher.doFinal(payload, cipherTextOffset, payload.length - cipherTextOffset);
+
+            return new String(plainText, UTF_8);
+        } catch (GeneralSecurityException | IllegalArgumentException | IndexOutOfBoundsException e) {
+            throw new IllegalStateException("Could not decrypt calendar integration secret - " +
+                "was 'uv.calendar-integration.encryption-secret' changed?", e);
+        }
+    }
+
+    private SecretKeySpec deriveKey(byte[] salt) {
+
+        // key derivation is expensive - cache derived keys by salt
+        if (keyCache.size() > MAX_CACHED_KEYS) {
+            keyCache.clear();
+        }
+
+        return keyCache.computeIfAbsent(Base64.getEncoder().encodeToString(salt), ignored -> {
+            try {
+                final SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+                final PBEKeySpec spec = new PBEKeySpec(encryptionSecret.toCharArray(), salt, KEY_DERIVATION_ITERATIONS, 256);
+                return new SecretKeySpec(factory.generateSecret(spec).getEncoded(), "AES");
+            } catch (GeneralSecurityException e) {
+                throw new IllegalStateException("Could not derive encryption key from 'uv.calendar-integration.encryption-secret'", e);
+            }
+        });
+    }
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/GoogleApiConfiguration.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/GoogleApiConfiguration.java
@@ -2,10 +2,12 @@ package org.synyx.urlaubsverwaltung.calendarintegration;
 
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@EnableConfigurationProperties(CalendarIntegrationProperties.class)
 public class GoogleApiConfiguration {
 
     @Bean

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/GoogleAuthorizationCodeFlowFactory.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/GoogleAuthorizationCodeFlowFactory.java
@@ -27,8 +27,10 @@ public class GoogleAuthorizationCodeFlowFactory {
         final GoogleClientSecrets clientSecrets = new GoogleClientSecrets();
         clientSecrets.setWeb(web);
 
+        // access type "offline" is required to receive a refresh token.
+        // the consent prompt is set on the authorization url (see GoogleCalendarOAuthHandshakeViewController)
+        // because google's oauth server no longer supports the deprecated approval_prompt=force parameter.
         return new GoogleAuthorizationCodeFlow.Builder(netHttpTransport, jsonFactory, clientSecrets, singleton(CALENDAR))
-            .setApprovalPrompt("force")
             .setAccessType("offline")
             .build();
     }

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/GoogleCalendarClientProvider.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/GoogleCalendarClientProvider.java
@@ -2,6 +2,8 @@ package org.synyx.urlaubsverwaltung.calendarintegration;
 
 import com.google.api.client.auth.oauth2.BearerToken;
 import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.auth.oauth2.CredentialRefreshListener;
+import com.google.api.client.auth.oauth2.TokenErrorResponse;
 import com.google.api.client.auth.oauth2.TokenResponse;
 import com.google.api.client.http.BasicAuthentication;
 import com.google.api.client.http.GenericUrl;
@@ -24,29 +26,35 @@ class GoogleCalendarClientProvider {
     private static final Logger LOG = getLogger(lookup().lookupClass());
 
     private static final String APPLICATION_NAME = "Urlaubsverwaltung";
-    private static final String GOOGLEAPIS_OAUTH2_V4_TOKEN = "https://www.googleapis.com/oauth2/v4/token";
+    private static final String GOOGLEAPIS_TOKEN_SERVER_URL = "https://oauth2.googleapis.com/token";
 
+    private final CalendarSettingsService calendarSettingsService;
+
+    GoogleCalendarClientProvider(CalendarSettingsService calendarSettingsService) {
+        this.calendarSettingsService = calendarSettingsService;
+    }
 
     /**
      * Build and return an authorized google calendar client.
+     * <p>
+     * The client uses the persisted access token as long as it is valid and refreshes it automatically
+     * (with the persisted refresh token) as soon as it is about to expire. Refreshed tokens are persisted.
      *
-     * @return an authorized calendar client service
+     * @return an authorized calendar client service, or {@link Optional#empty()} if no refresh token is available
      */
     Optional<Calendar> getCalendarClient(GoogleCalendarSettings googleCalendarSettings) {
-        return createCalendarClient(googleCalendarSettings);
-    }
-
-    private Optional<Calendar> createCalendarClient(GoogleCalendarSettings googleCalendarSettings) {
 
         final String refreshToken = googleCalendarSettings.getRefreshToken();
-
-        final TokenResponse tokenResponse = new TokenResponse();
-        tokenResponse.setRefreshToken(refreshToken);
+        if (refreshToken == null || refreshToken.isBlank()) {
+            LOG.warn("No google calendar refresh token available - please connect the application " +
+                "with the google calendar again (settings > calendar sync).");
+            return Optional.empty();
+        }
 
         final JsonFactory jsonFactory = GsonFactory.getDefaultInstance();
-
         final NetHttpTransport httpTransport = new NetHttpTransport();
-        final Credential credential = createCredentialWithRefreshToken(httpTransport, jsonFactory, tokenResponse, googleCalendarSettings);
+
+        final Credential credential = createCredential(httpTransport, jsonFactory, googleCalendarSettings);
 
         final Calendar calendar = new Calendar.Builder(httpTransport, jsonFactory, credential)
             .setApplicationName(APPLICATION_NAME)
@@ -57,17 +65,55 @@ class GoogleCalendarClientProvider {
         return Optional.of(calendar);
     }
 
-    private Credential createCredentialWithRefreshToken(HttpTransport transport, JsonFactory jsonFactory, TokenResponse tokenResponse, GoogleCalendarSettings googleCalendarSettings) {
+    private Credential createCredential(HttpTransport transport, JsonFactory jsonFactory, GoogleCalendarSettings googleCalendarSettings) {
 
         final String clientId = googleCalendarSettings.getClientId();
         final String clientSecret = googleCalendarSettings.getClientSecret();
 
-        return new Credential.Builder(BearerToken.authorizationHeaderAccessMethod())
+        final Credential credential = new Credential.Builder(BearerToken.authorizationHeaderAccessMethod())
             .setTransport(transport)
             .setJsonFactory(jsonFactory)
-            .setTokenServerUrl(new GenericUrl(GOOGLEAPIS_OAUTH2_V4_TOKEN))
+            .setTokenServerUrl(new GenericUrl(GOOGLEAPIS_TOKEN_SERVER_URL))
             .setClientAuthentication(new BasicAuthentication(clientId, clientSecret))
-            .build()
-            .setFromTokenResponse(tokenResponse);
+            .addRefreshListener(new PersistTokensRefreshListener())
+            .build();
+
+        // the credential refreshes the access token automatically with the refresh token
+        // as soon as it is missing or about to expire (see Credential#intercept)
+        credential.setRefreshToken(googleCalendarSettings.getRefreshToken());
+        credential.setAccessToken(googleCalendarSettings.getAccessToken());
+        credential.setExpirationTimeMilliseconds(googleCalendarSettings.getAccessTokenExpirationMillis());
+
+        return credential;
+    }
+
+    private class PersistTokensRefreshListener implements CredentialRefreshListener {
+
+        @Override
+        public void onTokenResponse(Credential credential, TokenResponse tokenResponse) {
+
+            LOG.info("Google calendar access token has been refreshed - persisting new access token.");
+
+            final CalendarSettings calendarSettings = calendarSettingsService.getCalendarSettings();
+            final GoogleCalendarSettings googleCalendarSettings = calendarSettings.getGoogleCalendarSettings();
+
+            googleCalendarSettings.setAccessToken(credential.getAccessToken());
+            googleCalendarSettings.setAccessTokenExpirationMillis(credential.getExpirationTimeMilliseconds());
+
+            if (tokenResponse.getRefreshToken() != null) {
+                // google may rotate the refresh token
+                googleCalendarSettings.setRefreshToken(tokenResponse.getRefreshToken());
+            }
+
+            calendarSettingsService.save(calendarSettings);
+        }
+
+        @Override
+        public void onTokenErrorResponse(Credential credential, TokenErrorResponse tokenErrorResponse) {
+            final String error = tokenErrorResponse == null ? "unknown" : tokenErrorResponse.getError();
+            final String description = tokenErrorResponse == null ? "" : tokenErrorResponse.getErrorDescription();
+            LOG.warn("Could not refresh google calendar access token: {} {} - the application probably has to be " +
+                "connected with the google calendar again (settings > calendar sync).", error, description);
+        }
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/GoogleCalendarOAuthHandshakeViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/GoogleCalendarOAuthHandshakeViewController.java
@@ -90,7 +90,10 @@ public class GoogleCalendarOAuthHandshakeViewController {
                 } else {
                     LOG.info("OAuth Handshake was successful!");
                 }
-                calendarSettings.getGoogleCalendarSettings().setRefreshToken(refreshToken);
+                final GoogleCalendarSettings googleCalendarSettings = calendarSettings.getGoogleCalendarSettings();
+                googleCalendarSettings.setRefreshToken(refreshToken);
+                googleCalendarSettings.setAccessToken(credential.getAccessToken());
+                googleCalendarSettings.setAccessTokenExpirationMillis(credential.getExpirationTimeMilliseconds());
                 calendarSettingsService.save(calendarSettings);
                 calendarSyncService.checkCalendarSyncSettings();
             } else {
@@ -106,9 +109,12 @@ public class GoogleCalendarOAuthHandshakeViewController {
 
     private String authorize(String redirectUri) {
 
+        // "prompt=consent" is required, otherwise google only returns a refresh token
+        // on the very first authorization of the oauth client
         final AuthorizationCodeRequestUrl authorizationUrl = createGoogleAuthorizationCodeFlow()
             .newAuthorizationUrl()
-            .setRedirectUri(redirectUri);
+            .setRedirectUri(redirectUri)
+            .set("prompt", "consent");
 
         LOG.info("using authorizationUrl {}", authorizationUrl);
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/GoogleCalendarSettings.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/GoogleCalendarSettings.java
@@ -1,6 +1,7 @@
 package org.synyx.urlaubsverwaltung.calendarintegration;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Embeddable;
 
 import java.util.Objects;
@@ -11,14 +12,23 @@ public class GoogleCalendarSettings {
     @Column(name = "google_client_id")
     private String clientId = null;
 
+    @Convert(converter = EncryptedSecretConverter.class)
     @Column(name = "google_client_secret")
     private String clientSecret = null;
 
     @Column(name = "google_calendar_id")
     private String calendarId = null;
 
+    @Convert(converter = EncryptedSecretConverter.class)
     @Column(name = "google_refresh_token")
     private String refreshToken = null;
+
+    @Convert(converter = EncryptedSecretConverter.class)
+    @Column(name = "google_access_token")
+    private String accessToken = null;
+
+    @Column(name = "google_access_token_expiration")
+    private Long accessTokenExpirationMillis = null;
 
     public String getRefreshToken() {
         return refreshToken;
@@ -26,6 +36,22 @@ public class GoogleCalendarSettings {
 
     public void setRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public Long getAccessTokenExpirationMillis() {
+        return accessTokenExpirationMillis;
+    }
+
+    public void setAccessTokenExpirationMillis(Long accessTokenExpirationMillis) {
+        this.accessTokenExpirationMillis = accessTokenExpirationMillis;
     }
 
     public String getClientId() {
@@ -60,6 +86,8 @@ public class GoogleCalendarSettings {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
+        // the access token is deliberately not part of equals/hashCode -
+        // equality is used to detect configuration changes that invalidate the oauth tokens
         GoogleCalendarSettings that = (GoogleCalendarSettings) o;
         return Objects.equals(getClientId(), that.getClientId()) &&
             Objects.equals(getClientSecret(), that.getClientSecret()) &&

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/SettingsCalendarSyncViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendarintegration/SettingsCalendarSyncViewController.java
@@ -155,10 +155,14 @@ public class SettingsCalendarSyncViewController implements HasLaunchpad, HasPers
         if (storedGoogleSettings != null && settingsUpdate != null) {
             final GoogleCalendarSettings updateGoogleSettings = settingsUpdate.getGoogleCalendarSettings();
             updateGoogleSettings.setRefreshToken(storedGoogleSettings.getRefreshToken());
+            updateGoogleSettings.setAccessToken(storedGoogleSettings.getAccessToken());
+            updateGoogleSettings.setAccessTokenExpirationMillis(storedGoogleSettings.getAccessTokenExpirationMillis());
 
             if (refreshTokenGotInvalid(storedGoogleSettings, updateGoogleSettings)) {
-                // refresh token is invalid if settings changed
+                // tokens are invalid if settings changed
                 updateGoogleSettings.setRefreshToken(null);
+                updateGoogleSettings.setAccessToken(null);
+                updateGoogleSettings.setAccessTokenExpirationMillis(null);
             }
         }
         return settingsUpdate;

--- a/src/main/resources/dbchangelogs/changelog-6.2.0-google-calendar-access-token.xml
+++ b/src/main/resources/dbchangelogs/changelog-6.2.0-google-calendar-access-token.xml
@@ -1,0 +1,15 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-5.0.xsd">
+
+  <changeSet author="schneider" id="6.2.0-google-calendar-access-token">
+    <preConditions onFail="MARK_RAN">
+      <tableExists tableName="calendar_integration_settings"/>
+    </preConditions>
+    <addColumn tableName="calendar_integration_settings">
+      <column name="google_access_token" type="text"/>
+      <column name="google_access_token_expiration" type="bigint"/>
+    </addColumn>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/dbchangelogs/changelogmaster.xml
+++ b/src/main/resources/dbchangelogs/changelogmaster.xml
@@ -26,5 +26,6 @@
   <include relativeToChangelogFile="true" file="changelog-5.35.0-add-spring-session.xml"/>
   <include relativeToChangelogFile="true" file="changelog-6.0.0-M4-adjust-allocation-sizes.xml"/>
   <include relativeToChangelogFile="true" file="changelog-6.0.0-RC1-add-navigation-collapsed-to-user-settings.xml"/>
+  <include relativeToChangelogFile="true" file="changelog-6.2.0-google-calendar-access-token.xml"/>
 
 </databaseChangeLog>

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendarintegration/EncryptedSecretConverterTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendarintegration/EncryptedSecretConverterTest.java
@@ -1,0 +1,97 @@
+package org.synyx.urlaubsverwaltung.calendarintegration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EncryptedSecretConverterTest {
+
+    @Test
+    void ensureEncryptsAndDecrypts() {
+
+        final EncryptedSecretConverter sut = converterWithSecret("super-secret");
+
+        final String encrypted = sut.convertToDatabaseColumn("my-refresh-token");
+        assertThat(encrypted)
+            .startsWith("enc:v1:")
+            .doesNotContain("my-refresh-token");
+
+        assertThat(sut.convertToEntityAttribute(encrypted)).isEqualTo("my-refresh-token");
+    }
+
+    @Test
+    void ensureEncryptionUsesRandomSaltAndIv() {
+
+        final EncryptedSecretConverter sut = converterWithSecret("super-secret");
+
+        final String first = sut.convertToDatabaseColumn("my-refresh-token");
+        final String second = sut.convertToDatabaseColumn("my-refresh-token");
+
+        assertThat(first).isNotEqualTo(second);
+    }
+
+    @Test
+    void ensureOtherConverterInstanceWithSameSecretCanDecrypt() {
+
+        final String encrypted = converterWithSecret("super-secret").convertToDatabaseColumn("my-refresh-token");
+
+        final EncryptedSecretConverter sut = converterWithSecret("super-secret");
+        assertThat(sut.convertToEntityAttribute(encrypted)).isEqualTo("my-refresh-token");
+    }
+
+    @Test
+    void ensureNullIsPassedThrough() {
+
+        final EncryptedSecretConverter sut = converterWithSecret("super-secret");
+
+        assertThat(sut.convertToDatabaseColumn(null)).isNull();
+        assertThat(sut.convertToEntityAttribute(null)).isNull();
+    }
+
+    @Test
+    void ensureLegacyPlaintextValueIsReadAsIs() {
+
+        final EncryptedSecretConverter sut = converterWithSecret("super-secret");
+
+        assertThat(sut.convertToEntityAttribute("legacy-plaintext-token")).isEqualTo("legacy-plaintext-token");
+    }
+
+    @Test
+    void ensureValuesArePassedThroughWithoutConfiguredSecret() {
+
+        final EncryptedSecretConverter sut = converterWithSecret(null);
+
+        assertThat(sut.convertToDatabaseColumn("my-refresh-token")).isEqualTo("my-refresh-token");
+        assertThat(sut.convertToEntityAttribute("my-refresh-token")).isEqualTo("my-refresh-token");
+    }
+
+    @Test
+    void ensureEncryptedValueWithoutConfiguredSecretThrows() {
+
+        final EncryptedSecretConverter withSecret = converterWithSecret("super-secret");
+        final String encrypted = withSecret.convertToDatabaseColumn("my-refresh-token");
+
+        final EncryptedSecretConverter sut = converterWithSecret(null);
+        assertThatThrownBy(() -> sut.convertToEntityAttribute(encrypted))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("uv.calendar-integration.encryption-secret");
+    }
+
+    @Test
+    void ensureEncryptedValueWithDifferentSecretThrows() {
+
+        final EncryptedSecretConverter withSecret = converterWithSecret("super-secret");
+        final String encrypted = withSecret.convertToDatabaseColumn("my-refresh-token");
+
+        final EncryptedSecretConverter sut = converterWithSecret("other-secret");
+        assertThatThrownBy(() -> sut.convertToEntityAttribute(encrypted))
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    private static EncryptedSecretConverter converterWithSecret(String secret) {
+        final CalendarIntegrationProperties properties = new CalendarIntegrationProperties();
+        properties.setEncryptionSecret(secret);
+        return new EncryptedSecretConverter(properties);
+    }
+}

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendarintegration/GoogleCalendarClientProviderTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendarintegration/GoogleCalendarClientProviderTest.java
@@ -1,0 +1,76 @@
+package org.synyx.urlaubsverwaltung.calendarintegration;
+
+import com.google.api.services.calendar.Calendar;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class GoogleCalendarClientProviderTest {
+
+    @Mock
+    private CalendarSettingsService calendarSettingsService;
+
+    private GoogleCalendarClientProvider sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = new GoogleCalendarClientProvider(calendarSettingsService);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" "})
+    void ensureEmptyClientWithoutRefreshToken(String refreshToken) {
+
+        final GoogleCalendarSettings googleCalendarSettings = someGoogleCalendarSettings();
+        googleCalendarSettings.setRefreshToken(refreshToken);
+
+        final Optional<Calendar> maybeCalendarClient = sut.getCalendarClient(googleCalendarSettings);
+
+        assertThat(maybeCalendarClient).isEmpty();
+        verifyNoInteractions(calendarSettingsService);
+    }
+
+    @Test
+    void ensureClientWithRefreshToken() {
+
+        final GoogleCalendarSettings googleCalendarSettings = someGoogleCalendarSettings();
+        googleCalendarSettings.setRefreshToken("REFRESH_TOKEN");
+
+        final Optional<Calendar> maybeCalendarClient = sut.getCalendarClient(googleCalendarSettings);
+
+        assertThat(maybeCalendarClient).isPresent();
+    }
+
+    @Test
+    void ensureClientWithRefreshTokenAndPersistedAccessToken() {
+
+        final GoogleCalendarSettings googleCalendarSettings = someGoogleCalendarSettings();
+        googleCalendarSettings.setRefreshToken("REFRESH_TOKEN");
+        googleCalendarSettings.setAccessToken("ACCESS_TOKEN");
+        googleCalendarSettings.setAccessTokenExpirationMillis(4102444800000L);
+
+        final Optional<Calendar> maybeCalendarClient = sut.getCalendarClient(googleCalendarSettings);
+
+        assertThat(maybeCalendarClient).isPresent();
+    }
+
+    private static GoogleCalendarSettings someGoogleCalendarSettings() {
+        final GoogleCalendarSettings googleCalendarSettings = new GoogleCalendarSettings();
+        googleCalendarSettings.setCalendarId("CALENDAR_ID");
+        googleCalendarSettings.setClientId("CLIENT_ID");
+        googleCalendarSettings.setClientSecret("CLIENT_SECRET");
+        return googleCalendarSettings;
+    }
+}

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendarintegration/GoogleCalendarSettingsEncryptionIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendarintegration/GoogleCalendarSettingsEncryptionIT.java
@@ -1,0 +1,61 @@
+package org.synyx.urlaubsverwaltung.calendarintegration;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+import org.synyx.urlaubsverwaltung.SingleTenantTestContainersBase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = "uv.calendar-integration.encryption-secret=it-encryption-secret")
+@Transactional
+class GoogleCalendarSettingsEncryptionIT extends SingleTenantTestContainersBase {
+
+    @Autowired
+    private CalendarSettingsService calendarSettingsService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    void ensureSecretsAreEncryptedAtRestAndDecryptedOnRead() {
+
+        calendarSettingsService.insertDefaultCalendarSettings();
+
+        final CalendarSettings calendarSettings = calendarSettingsService.getCalendarSettings();
+        final GoogleCalendarSettings googleCalendarSettings = new GoogleCalendarSettings();
+        calendarSettings.setGoogleCalendarSettings(googleCalendarSettings);
+        googleCalendarSettings.setClientId("CLIENT_ID");
+        googleCalendarSettings.setClientSecret("CLIENT_SECRET");
+        googleCalendarSettings.setCalendarId("CALENDAR_ID");
+        googleCalendarSettings.setRefreshToken("REFRESH_TOKEN");
+        googleCalendarSettings.setAccessToken("ACCESS_TOKEN");
+        googleCalendarSettings.setAccessTokenExpirationMillis(4102444800000L);
+
+        final CalendarSettings saved = calendarSettingsService.save(calendarSettings);
+        entityManager.flush();
+        entityManager.clear();
+
+        final var row = jdbcTemplate.queryForMap(
+            "select google_client_secret, google_refresh_token, google_access_token from calendar_integration_settings where id = ?",
+            saved.getId()
+        );
+
+        assertThat((String) row.get("google_client_secret")).startsWith("enc:v1:").doesNotContain("CLIENT_SECRET");
+        assertThat((String) row.get("google_refresh_token")).startsWith("enc:v1:").doesNotContain("REFRESH_TOKEN");
+        assertThat((String) row.get("google_access_token")).startsWith("enc:v1:").doesNotContain("ACCESS_TOKEN");
+
+        final GoogleCalendarSettings persisted = calendarSettingsService.getCalendarSettings().getGoogleCalendarSettings();
+        assertThat(persisted.getClientSecret()).isEqualTo("CLIENT_SECRET");
+        assertThat(persisted.getRefreshToken()).isEqualTo("REFRESH_TOKEN");
+        assertThat(persisted.getAccessToken()).isEqualTo("ACCESS_TOKEN");
+        assertThat(persisted.getAccessTokenExpirationMillis()).isEqualTo(4102444800000L);
+    }
+}


### PR DESCRIPTION
The OAuth flow used Google's long-deprecated approval_prompt=force parameter (GoogleAuthorizationCodeFlowFactory). Google's OAuth server no longer honors it, and Google only returns a refresh_token on the first consent unless you explicitly force the consent screen — so re-authorizations came back
without one and the app stored null. The fix: the authorization URL now sends prompt=consent (in
GoogleCalendarOAuthHandshakeViewController), which is the current way to guarantee a refresh token together with access_type=offline.

What changed

Token handling (GoogleCalendarClientProvider, rewritten)
- Previously the access token was never stored — every single calendar operation did a refresh round-trip to Google first. Now the OAuth handshake persists access token + expiry alongside the refresh token, and the client reuses the stored access token.
- The Google Credential refreshes automatically as soon as the token is missing or within 60 seconds of expiring; a CredentialRefreshListener persists the new access token, its expiry, and a rotated refresh token if Google sends one.
- If no refresh token is present, the provider now returns empty with a clear warning (reconnect via settings → calendar sync) instead of building a client that fails on every call.
- The token endpoint was updated from the retired oauth2/v4/token URL to https://oauth2.googleapis.com/token.

Encryption at rest (new EncryptedSecretConverter + CalendarIntegrationProperties)
- Client secret, refresh token, and access token are now encrypted in the database with AES-256-GCM (key derived via PBKDF2, random IV per value, enc:v1: prefix).
- Enabled by setting uv.calendar-integration.encryption-secret. Without it, behavior stays plaintext (with a startup warning) so existing installations keep working. Existing plaintext values are read as-is and get encrypted transparently on the next save — but note that changing or losing the secret
makes encrypted values unreadable; users then have to redo the OAuth handshake.

Supporting changes
- GoogleCalendarSettings: new accessToken / accessTokenExpirationMillis fields (columns added via changelog-6.2.0-google-calendar-access-token.xml); access token is deliberately excluded from equals since that's used to detect config changes that invalidate tokens.
- SettingsCalendarSyncViewController: saving the settings form now carries over the access token like the refresh token, and clears all tokens together when client ID/secret/calendar ID change.

Tests: new EncryptedSecretConverterTest (round-trip, random IV, legacy plaintext passthrough, missing/wrong secret errors), GoogleCalendarClientProviderTest, and GoogleCalendarSettingsEncryptionIT — a Testcontainers test proving the raw DB columns contain enc:v1:… ciphertext while the entity reads
decrypted values.

One heads-up for the release notes: because prompt=consent was previously broken, existing installations likely have no (or a stale) refresh token — admins should run the "connect Google calendar" handshake once after upgrading, and set the new encryption property beforehand so tokens are encrypted from
  the start.

closes #5977

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
