### PR TITLE
Fixed and verified on an iPhone viewport in WebKit (the iOS browser e…

### DIFF
--- a/src/main/css/components/popover.css
+++ b/src/main/css/components/popover.css
@@ -289,6 +289,21 @@
     }
   }
 
+  /* duet-date-picker renders its mobile dialog with `position: fixed` sliding in from the viewport bottom.
+   * transform and backdrop-filter (even identity values like `translate(0, 0)`) turn the popover into the
+   * containing block of fixed positioned descendants — the dialog would be placed at the popover
+   * instead of covering the viewport. */
+  .popover:has(duet-date-picker),
+  .popover-menu:has(duet-date-picker) {
+    transform: none;
+    backdrop-filter: none;
+
+    @variant dark {
+      /* solid background because the translucent one relies on backdrop-blur */
+      background-color: var(--color-zinc-900);
+    }
+  }
+
   .popover-menu.popover-menu-person-group {
     ul {
       display: grid;


### PR DESCRIPTION
…ngine) and Chromium.

Reason: The date range selector (e.g. on the statistics page and for sick days) is contained within a native popover element. The .popover class permanently sets `transform: translateX(...) translateY(...)` for the fade-in animation — even when idle, as an identity transform. However, a transform
turns an element into a containing block for position: fixed descendants. As a result, Duet’s mobile dialogue (below 576px: position: fixed; inset: 0, bottom sheet covering the entire viewport) was positioned relative to the small popover rather than the viewport — and appeared at the top of the page. In the case of “Request holiday” the date picker is not contained within a popover, which is why it worked there.

Translated with DeepL.com (free version)

closes #5748

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
