### PR TITLE
calendar: show both public holidays on one day

### DIFF
--- a/src/main/javascript/components/calendar/__tests__/calendar.spec.js
+++ b/src/main/javascript/components/calendar/__tests__/calendar.spec.js
@@ -440,6 +440,51 @@ describe("calendar", () => {
     expect($('[data-datepicker-date="2020-12-09"][class="datepicker-day datepicker-day-past"] > svg')).toBeTruthy();
   });
 
+  test("ensure description of all public holidays on the same day is shown", async () => {
+    // today is 2024-06-15 (so may 2024 is within the rendered months)
+    mockDate(1_718_452_800_000);
+
+    fetchMock.route(
+      "/persons/42/absences?from=2024-01-01&to=2024-12-31&absence-types=vacation%2Csick_note%2Cno_workday",
+      {
+        absences: [],
+      },
+    );
+
+    // croatia has two public holidays on 2024-05-30 (statehood day and corpus christi)
+    fetchMock.route(`/persons/42/public-holidays?from=2024-01-01&to=2024-12-31`, {
+      publicHolidays: [
+        {
+          date: "2024-05-30",
+          description: "Statehood Day",
+          dayLength: "1",
+          absencePeriodName: "FULL",
+        },
+        {
+          date: "2024-05-30",
+          description: "Corpus Christi",
+          dayLength: "1",
+          absencePeriodName: "FULL",
+        },
+      ],
+    });
+
+    await calendarTestSetup();
+
+    const holidayService = createHolidayService({ personId: 42 });
+    // fetch personal holiday data and cache the (mocked) response
+    // the response is used when the calendar renders
+    await holidayService.fetchAbsences(2024);
+    await holidayService.fetchPublicHolidays(2024);
+
+    renderCalendar(holidayService);
+
+    const $ = document.querySelector.bind(document);
+    const day = $('[data-datepicker-date="2024-05-30"]');
+    expect(day).toBeTruthy();
+    expect(day.getAttribute("title")).toBe("Statehood Day, Corpus Christi");
+  });
+
   function mockEmptyYear(personId, year) {
     fetchMock.route(
       `/persons/${personId}/absences?from=${year}-01-01&to=${year}-12-31&absence-types=vacation%2Csick_note%2Cno_workday`,

--- a/src/main/javascript/components/calendar/holiday-service.js
+++ b/src/main/javascript/components/calendar/holiday-service.js
@@ -230,17 +230,11 @@ export const HolidayService = (function () {
     },
 
     getDescription: function (date) {
-      const year = getYear(date);
-      const formattedDate = format(date, "yyyy-MM-dd");
-
-      if (_CACHE["publicHoliday"] && _CACHE["publicHoliday"][year]) {
-        const publicHoliday = _CACHE["publicHoliday"][year].find((holiday) => holiday.date === formattedDate);
-        if (publicHoliday) {
-          return publicHoliday.description;
-        }
-      }
-
-      return "";
+      // there can be more than one public holiday on the same day (e.g. a fixed and a movable one
+      // falling on the same date in a special year), so join the descriptions of all of them.
+      return getPublicHolidaysForDate(date)
+        .map((publicHoliday) => publicHoliday.description)
+        .join(", ");
     },
 
     getAbsenceId: function (date) {

--- a/src/test/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidaysServiceImplTest.java
@@ -29,6 +29,7 @@ import static java.time.Month.JANUARY;
 import static java.time.Month.MAY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
+import static org.synyx.urlaubsverwaltung.workingtime.FederalState.CROATIA;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.GERMANY_BADEN_WUERTTEMBERG;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.GERMANY_BAYERN_MUENCHEN;
 import static org.synyx.urlaubsverwaltung.workingtime.FederalState.GERMANY_BERLIN;
@@ -44,7 +45,10 @@ class PublicHolidaysServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        sut = new PublicHolidaysServiceImpl(settingsService, Map.of("de", getHolidayManager()));
+        sut = new PublicHolidaysServiceImpl(settingsService, Map.of(
+            "de", getHolidayManager(HolidayCalendar.GERMANY),
+            "hr", getHolidayManager(HolidayCalendar.CROATIA)
+        ));
     }
 
     @Test
@@ -184,6 +188,20 @@ class PublicHolidaysServiceImplTest {
     }
 
     @Test
+    void ensureGetPublicHolidaysReturnsBothPublicHolidaysWhenTwoAreOnTheSameDay() {
+
+        // in croatia there are two public holidays on 2024-05-30 (statehood day and corpus christi)
+        final List<PublicHoliday> publicHolidays = sut.getPublicHolidays(of(2024, MAY, 30), of(2024, MAY, 30), CROATIA);
+
+        assertThat(publicHolidays)
+            .hasSize(2)
+            .allSatisfy(publicHoliday -> assertThat(publicHoliday.date()).isEqualTo(of(2024, MAY, 30)))
+            .extracting(PublicHoliday::description)
+            .doesNotHaveDuplicates()
+            .doesNotContainNull();
+    }
+
+    @Test
     void ensureGetPublicHolidaysReturnsWhenPersonHasNoPublicHolidaysDefined() {
 
         when(settingsService.getSettings()).thenReturn(new Settings());
@@ -196,7 +214,7 @@ class PublicHolidaysServiceImplTest {
             new PublicHoliday(LocalDate.of(2023, DECEMBER, 31), null, null));
     }
 
-    private HolidayManager getHolidayManager() {
-        return HolidayManager.getInstance(ManagerParameters.create(HolidayCalendar.GERMANY));
+    private HolidayManager getHolidayManager(HolidayCalendar holidayCalendar) {
+        return HolidayManager.getInstance(ManagerParameters.create(holidayCalendar));
     }
 }


### PR DESCRIPTION
closes #4174

This can be tested on the 30th may in 2024 for public holidays in Croatia 

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
