### PR TITLE
fix: prevent duplicated non-working-day icon in datepicker

### DIFF
--- a/src/main/javascript/components/datepicker/__tests__/create-datepicker.spec.js
+++ b/src/main/javascript/components/datepicker/__tests__/create-datepicker.spec.js
@@ -1058,6 +1058,44 @@ describe("create-datepicker", () => {
         expect(element.classList).toContain("datepicker-day");
         expect(element.closest("button").querySelector("svg")).toBeTruthy();
       });
+
+      test("no-workday icon is rendered only once when the initial value's month differs from the current one", async () => {
+        // opening the datepicker for a value whose month is not the current one makes duet-date-picker
+        // navigate its visible month right away. this fires the toggle click handler and the month/year
+        // heading mutation observer for the very same "open" interaction (see create-datepicker.js).
+        fetchMock.route(`my-url-prefix/persons/42/public-holidays?from=2020-11-30&to=2021-01-03`, {
+          publicHolidays: [],
+        });
+
+        fetchMock.route(
+          `my-url-prefix/persons/42/absences?from=2020-11-30&to=2021-01-03&absence-types=vacation,sick_note,no_workday`,
+          {
+            absences: [
+              {
+                date: "2020-12-24",
+                absent: "FULL",
+                absenceType: "NO_WORKDAY",
+              },
+            ],
+          },
+        );
+
+        document.body.innerHTML = `
+          <input value="24.12.2020" data-iso-value="2020-12-24" />
+        `;
+
+        const urlPrefix = "my-url-prefix";
+        const getPersonId = () => 42;
+
+        await createDatepicker("input", { urlPrefix, getPersonId });
+
+        document.querySelector("button.duet-date__toggle").click();
+        await new Promise((resolve) => setTimeout(resolve, 20));
+
+        const element = getDatepickerDayElement("24. Dezember");
+        expect(element.querySelectorAll("[data-uv-icon]")).toHaveLength(1);
+        expect(element.querySelectorAll("svg")).toHaveLength(1);
+      });
     });
   });
 

--- a/src/main/javascript/components/datepicker/create-datepicker.js
+++ b/src/main/javascript/components/datepicker/create-datepicker.js
@@ -171,6 +171,11 @@ function hydrateDatepicker(duetDateElement, options) {
           icon.classList.add("w-3", "h-3", "inline-block");
         }
 
+        // toggle click and heading mutation observer can both trigger `showAbsences` for the same
+        // "open datepicker" interaction, so the removal at the top of `showAbsences` alone is not
+        // enough to prevent two icons ending up appended for the same day.
+        dayElement.querySelector("[data-uv-icon]")?.remove();
+
         icon.dataset.uvIcon = "";
         dayElement.append(icon);
       }


### PR DESCRIPTION
Opening the datepicker for a date whose month differs from the current one makes duet-date-picker navigate its visible month right away. That fires the toggle click handler and the month/year heading mutation observer for the same "open" interaction, so two concurrent calls to showAbsences() each end up appending their own icon for the same day.

Fixes #6358

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
