### PR TITLE
fix: today frame in absence overview no longer ends before last row

### DIFF
--- a/src/main/css/bundles/absences-overview.css
+++ b/src/main/css/bundles/absences-overview.css
@@ -1,25 +1,35 @@
 @reference "../config.css";
 
-th.vacationOverview-cal-head.today {
-  --vacation-overview-rows: 0;
-  position: relative;
+.vacationOverview-table th.vacationOverview-cal-head.today,
+.vacationOverview-table td.today {
+  @apply border-l-3 border-r-3;
+  @apply border-l-(--uv-cal-today-border-color)/40;
+  @apply border-r-(--uv-cal-today-border-color)/40;
 }
-th.vacationOverview-cal-head.today::after {
-  content: "";
-  @apply border-3;
-  @apply border-(--uv-cal-today-border-color)/40;
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  /* head row height + (x * person height)  */
-  height: calc(100% + (var(--vacation-overview-rows) * 2.8125rem));
-  z-index: 1;
+
+.vacationOverview-table thead th.vacationOverview-cal-head.today {
+  @apply border-t-3;
+  @apply border-t-(--uv-cal-today-border-color)/40;
+}
+
+.vacationOverview-table tbody tr:last-child td.today {
+  @apply border-b-3;
+  @apply border-b-(--uv-cal-today-border-color)/40;
 }
 
 @variant dark {
-  th.vacationOverview-cal-head.today::after {
-    @apply border-(--uv-cal-today-border-color)/80;
+  .vacationOverview-table th.vacationOverview-cal-head.today,
+  .vacationOverview-table td.today {
+    @apply border-l-(--uv-cal-today-border-color)/80;
+    @apply border-r-(--uv-cal-today-border-color)/80;
+  }
+
+  .vacationOverview-table thead th.vacationOverview-cal-head.today {
+    @apply border-t-(--uv-cal-today-border-color)/80;
+  }
+
+  .vacationOverview-table tbody tr:last-child td.today {
+    @apply border-b-(--uv-cal-today-border-color)/80;
   }
 }
 

--- a/src/main/resources/templates/absences/absences-overview.html
+++ b/src/main/resources/templates/absences/absences-overview.html
@@ -178,7 +178,6 @@
                   scope="col"
                   class="non-sortable cursor-default vacationOverview-cal-head"
                   th:classappend="|${day.today ? 'today' : ''}${day.weekend ? ' weekend' : ''}|"
-                  th:style="${day.today ? '--vacation-overview-rows: ' + #lists.size(month.persons) : ''}"
                 >
                   <div class="p-2 leading-none text-center">
                     <span class="font-bold block" th:text="${day.dayOfMonth}"></span>
@@ -208,7 +207,10 @@
                     </div>
                   </a>
                 </th>
-                <td th:each="absence : ${person.days}">
+                <td
+                  th:each="absence, dayStat : ${person.days}"
+                  th:classappend="${month.days[dayStat.index].today} ? 'today' : ''"
+                >
                   <div
                     class="cal-day"
                     th:classappend="|${absence.type != null && absence.type.absenceFull ? 'absence-full absence-full--solid' : ''}${absence.type != null && absence.type.absenceMorning ? ' absence-morning absence-morning--solid' : ''}${absence.type != null && absence.type.absenceNoon ? ' absence-noon absence-noon--solid' : ''}${absence.type != null && absence.type.waitingAbsenceFull ? ' absence-full absence-full--outline' : ''}${absence.type != null && absence.type.waitingAbsenceMorning ? ' absence-morning absence-morning--outline' : ''}${absence.type != null && absence.type.waitingAbsenceNoon ? ' absence-noon absence-noon--outline' : ''}${absence.type != null && absence.type.temporaryAllowedAbsenceFull ? ' absence-full absence-full--outline-solid-half' : ''}${absence.type != null && absence.type.temporaryAllowedAbsenceMorning ? ' absence-morning absence-morning--outline-solid-half' : ''}${absence.type != null && absence.type.temporaryAllowedAbsenceNoon ? ' absence-noon absence-noon--outline-solid-half' : ''}${absence.type != null && absence.type.allowedCancellationRequestedAbsenceFull ? ' absence-full absence-full--outline-solid-second-half' : ''}${absence.type != null && absence.type.allowedCancellationRequestedAbsenceMorning ? ' absence-morning absence-morning--outline-solid-second-half' : ''}${absence.type != null && absence.type.allowedCancellationRequestedAbsenceNoon ? ' absence-noon absence-noon--outline-solid-second-half' : ''}${absence.type != null && absence.type.activeSickNoteFull ? ' sick-note-full absence-full--solid' : ''}${absence.type != null && absence.type.activeSickNoteMorning ? ' sick-note-morning absence-morning--solid' : ''}${absence.type != null && absence.type.activeSickNoteNoon ? ' sick-note-noon absence-noon--solid' : ''}${absence.type != null && absence.type.waitingSickNoteFull ? ' sick-note-full absence-full--outline' : ''}${absence.type != null && absence.type.waitingSickNoteMorning ? ' sick-note-morning absence-morning--outline' : ''}${absence.type != null && absence.type.waitingSickNoteNoon ? ' sick-note-noon absence-noon--outline' : ''}${absence.type != null && absence.type.publicHolidayFull ? ' public-holiday-full' : ''}${absence.type != null && absence.type.publicHolidayMorning ? ' public-holiday-morning' : ''}${absence.type != null && absence.type.publicHolidayNoon ? ' public-holiday-noon' : ''}${absence.workday ? '' : ' no-workday'}|"


### PR DESCRIPTION
The highlight around the current day's column was one absolutely positioned box whose height was computed from a fixed 2.8125rem per-row guess multiplied by the person count. Real row height is content-driven, so the guess drifts and the frame falls short of the last row (#6371).

Replaced it with direct borders on the today column's cells (thick top on the header, thick bottom on the last row, thick left/right throughout), which always matches the actual table regardless of row count or content.

closes #6371

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
