### PR TITLE
person search for screen readers

### DIFF
--- a/src/main/javascript/components/person-search/__tests__/person-search.spec.js
+++ b/src/main/javascript/components/person-search/__tests__/person-search.spec.js
@@ -12,14 +12,23 @@ describe("person-search", function () {
     vi.useRealTimers();
   });
 
-  function renderPersonSearch({ suggestionCount = 2 } = {}) {
+  function renderPersonSearch({
+    suggestionCount = 2,
+    messageNothingFound = "Nichts gefunden",
+    messageResultsOne = "1 Ergebnis",
+    messageResultsOther = "{0} Ergebnisse",
+  } = {}) {
     const suggestions = Array.from(
       { length: suggestionCount },
       (_, index) => `<li><a href="#suggestion-${index}" data-person-search-suggestion>Suggestion ${index}</a></li>`,
     ).join("");
 
     document.body.innerHTML = `
-      <uv-person-search>
+      <uv-person-search
+        data-message-nothing-found="${messageNothingFound}"
+        data-message-results-one="${messageResultsOne}"
+        data-message-results-other="${messageResultsOther}"
+      >
         <form>
           <input type="search" id="person-search-input" />
           <button id="person-search-submit" type="submit">Suchen</button>
@@ -31,6 +40,7 @@ describe("person-search", function () {
             </ul>
           </turbo-frame>
         </div>
+        <div class="sr-only" role="status" data-person-search-status></div>
       </uv-person-search>
     `;
 
@@ -47,6 +57,7 @@ describe("person-search", function () {
       submitButton: document.querySelector("#person-search-submit"),
       popover,
       frame: document.querySelector("#frame-persons-suggestions"),
+      statusRegion: document.querySelector("[data-person-search-status]"),
       suggestions: [...document.querySelectorAll("[data-person-search-suggestion]")],
     };
   }
@@ -97,12 +108,11 @@ describe("person-search", function () {
 
   describe("suggestions popover", function () {
     it("opens once the suggestions frame renders", function () {
-      const { frame, popover, input } = renderPersonSearch();
+      const { frame, popover } = renderPersonSearch();
 
       frameRender(frame);
 
       expect(popover.showPopover).toHaveBeenCalledTimes(1);
-      expect(input.getAttribute("aria-expanded")).toBe("true");
     });
 
     it("does not open for renders of a different frame", function () {
@@ -162,6 +172,59 @@ describe("person-search", function () {
       dispatchFocusout(widget);
 
       expect(popover.hidePopover).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("result count announcement", function () {
+    it("announces the 'nothing found' message when there are no suggestions", function () {
+      const { frame, statusRegion } = renderPersonSearch({
+        suggestionCount: 0,
+        messageNothingFound: "Nichts gefunden",
+      });
+
+      frameRender(frame);
+
+      expect(statusRegion.textContent).toBe("Nichts gefunden");
+    });
+
+    it("announces the singular results message for one suggestion", function () {
+      const { frame, statusRegion } = renderPersonSearch({
+        suggestionCount: 1,
+        messageResultsOne: "1 Ergebnis",
+      });
+
+      frameRender(frame);
+
+      expect(statusRegion.textContent).toBe("1 Ergebnis");
+    });
+
+    it("announces the plural results message with the count for multiple suggestions", function () {
+      const { frame, statusRegion } = renderPersonSearch({
+        suggestionCount: 3,
+        messageResultsOther: "{0} Ergebnisse",
+      });
+
+      frameRender(frame);
+
+      expect(statusRegion.textContent).toBe("3 Ergebnisse");
+    });
+
+    it("re-announces the result count on subsequent renders while the popover stays open", function () {
+      const { frame, statusRegion } = renderPersonSearch({ suggestionCount: 2 });
+
+      frameRender(frame);
+      frameRender(frame);
+
+      expect(statusRegion.textContent).toBe("{0} Ergebnisse".replace("{0}", "2"));
+    });
+
+    it("clears the announcement once the popover closes", function () {
+      const { widget, frame, statusRegion } = renderPersonSearch();
+      frameRender(frame);
+
+      dispatchFocusout(widget, document.body);
+
+      expect(statusRegion.textContent).toBe("");
     });
   });
 

--- a/src/main/javascript/components/person-search/person-search.js
+++ b/src/main/javascript/components/person-search/person-search.js
@@ -3,9 +3,12 @@ function focusSuggestion(element) {
   element.closest("li").scrollIntoView({ block: "nearest" });
 }
 
+const ANNOUNCE_DEBOUNCE_MS = 500;
+
 export class PersonSearch extends HTMLElement {
   #cleanup = () => {};
   #popoverVisible = false;
+  #announceTimer = 0;
 
   /** @type HTMLInputElement */
   get #searchInput() {
@@ -15,6 +18,11 @@ export class PersonSearch extends HTMLElement {
   /** @type HTMLButtonElement */
   get #submitButton() {
     return this.querySelector("[type=submit]");
+  }
+
+  /** @type HTMLElement */
+  get #statusRegion() {
+    return this.querySelector("[data-person-search-status]");
   }
 
   connectedCallback() {
@@ -41,8 +49,11 @@ export class PersonSearch extends HTMLElement {
     const handleFrameRender = (event) => {
       loading = false;
       this.#submitButton.classList.remove("button--loading");
-      if (!this.#popoverVisible && event.target.matches("[id=frame-persons-suggestions]")) {
-        this.#showSuggestionsPopover();
+      if (event.target.matches("[id=frame-persons-suggestions]")) {
+        if (!this.#popoverVisible) {
+          this.#showSuggestionsPopover();
+        }
+        this.#announceResultCount();
       }
     };
 
@@ -128,6 +139,7 @@ export class PersonSearch extends HTMLElement {
   }
 
   disconnectedCallback() {
+    clearTimeout(this.#announceTimer);
     this.#cleanup();
   }
 
@@ -139,7 +151,6 @@ export class PersonSearch extends HTMLElement {
     /** @type HTMLDialogElement */
     const popover = this.querySelector("[popover]");
     popover.showPopover();
-    this.#searchInput.setAttribute("aria-expanded", "true");
     this.#popoverVisible = true;
   }
 
@@ -147,8 +158,27 @@ export class PersonSearch extends HTMLElement {
     /** @type HTMLDialogElement */
     const popover = this.querySelector("[popover]");
     popover.hidePopover();
-    this.#searchInput.setAttribute("aria-expanded", "false");
     this.#popoverVisible = false;
+    clearTimeout(this.#announceTimer);
+    this.#statusRegion.textContent = "";
+  }
+
+  #announceResultCount() {
+    clearTimeout(this.#announceTimer);
+    this.#announceTimer = globalThis.setTimeout(() => {
+      const count = this.querySelectorAll("[data-person-search-suggestion]").length;
+
+      let message;
+      if (count === 0) {
+        message = this.dataset.messageNothingFound ?? "";
+      } else if (count === 1) {
+        message = this.dataset.messageResultsOne ?? "";
+      } else {
+        message = (this.dataset.messageResultsOther ?? "").replace("{0}", String(count));
+      }
+
+      this.#statusRegion.textContent = message;
+    }, ANNOUNCE_DEBOUNCE_MS);
   }
 
   #submit() {

--- a/src/main/javascript/components/person-search/person-search.js
+++ b/src/main/javascript/components/person-search/person-search.js
@@ -3,12 +3,9 @@ function focusSuggestion(element) {
   element.closest("li").scrollIntoView({ block: "nearest" });
 }
 
-const ANNOUNCE_DEBOUNCE_MS = 500;
-
 export class PersonSearch extends HTMLElement {
   #cleanup = () => {};
   #popoverVisible = false;
-  #announceTimer = 0;
 
   /** @type HTMLInputElement */
   get #searchInput() {
@@ -139,7 +136,6 @@ export class PersonSearch extends HTMLElement {
   }
 
   disconnectedCallback() {
-    clearTimeout(this.#announceTimer);
     this.#cleanup();
   }
 
@@ -159,26 +155,22 @@ export class PersonSearch extends HTMLElement {
     const popover = this.querySelector("[popover]");
     popover.hidePopover();
     this.#popoverVisible = false;
-    clearTimeout(this.#announceTimer);
     this.#statusRegion.textContent = "";
   }
 
   #announceResultCount() {
-    clearTimeout(this.#announceTimer);
-    this.#announceTimer = globalThis.setTimeout(() => {
-      const count = this.querySelectorAll("[data-person-search-suggestion]").length;
+    const count = this.querySelectorAll("[data-person-search-suggestion]").length;
 
-      let message;
-      if (count === 0) {
-        message = this.dataset.messageNothingFound ?? "";
-      } else if (count === 1) {
-        message = this.dataset.messageResultsOne ?? "";
-      } else {
-        message = (this.dataset.messageResultsOther ?? "").replace("{0}", String(count));
-      }
+    let message;
+    if (count === 0) {
+      message = this.dataset.messageNothingFound ?? "";
+    } else if (count === 1) {
+      message = this.dataset.messageResultsOne ?? "";
+    } else {
+      message = (this.dataset.messageResultsOther ?? "").replace("{0}", String(count));
+    }
 
-      this.#statusRegion.textContent = message;
-    }, ANNOUNCE_DEBOUNCE_MS);
+    this.#statusRegion.textContent = message;
   }
 
   #submit() {

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -33,7 +33,10 @@ form.button.search=Suchen
 
 person-search.input.label=Name
 person-search.input.placeholder=Suchen nach Vor- / Nachname
+person-search.input.hint=Ergebnisse mit Pfeiltasten auswählen, mit Enter öffnen
 person-search.nothing-found=Keine Personen gefunden
+person-search.results-found.one=Eine Person gefunden
+person-search.results-found.other={0} Personen gefunden
 person-search.suggestion.link.account=Konto
 
 absence.period.duration=Dies entspricht

--- a/src/main/resources/messages_de_AT.properties
+++ b/src/main/resources/messages_de_AT.properties
@@ -33,7 +33,10 @@ form.button.search=Suchen
 
 person-search.input.label=Name
 person-search.input.placeholder=Suchen nach Vor- / Nachname
+person-search.input.hint=Ergebnisse mit Pfeiltasten auswählen, mit Enter öffnen
 person-search.nothing-found=Keine Personen gefunden
+person-search.results-found.one=Eine Person gefunden
+person-search.results-found.other={0} Personen gefunden
 person-search.suggestion.link.account=Konto
 
 absence.period.duration=Dies entspricht

--- a/src/main/resources/messages_el.properties
+++ b/src/main/resources/messages_el.properties
@@ -33,7 +33,10 @@ form.button.search=Αναζήτηση
 
 person-search.input.label=Όνομα
 person-search.input.placeholder=Αναζήτηση με όνομα / επώνυμο
+person-search.input.hint=Χρησιμοποιήστε τα βελάκια για να περιηγηθείτε στα αποτελέσματα, το πλήκτρο Enter για να ανοίξετε
 person-search.nothing-found=Δεν βρέθηκαν άτομα
+person-search.results-found.one=Βρέθηκε ένα άτομο
+person-search.results-found.other=Βρέθηκαν {0} άτομα
 person-search.suggestion.link.account=Λογαριασμός
 
 absence.period.duration=Διάρκεια

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -33,7 +33,10 @@ form.button.search=Search
 
 person-search.input.label=Name
 person-search.input.placeholder=Search by first- / lastname
+person-search.input.hint=Use arrow keys to browse results, Enter to open
 person-search.nothing-found=No persons found
+person-search.results-found.one=One person found
+person-search.results-found.other={0} persons found
 person-search.suggestion.link.account=Account
 
 absence.period.duration=Duration

--- a/src/main/resources/templates/fragments/person-search.html
+++ b/src/main/resources/templates/fragments/person-search.html
@@ -72,7 +72,11 @@
                   </span>
                   <span class="flex flex-col gap-px dark:text-zinc-200">
                     <span th:text="${suggestion.name}">Nice Name</span>
-                    <span class="text-xs text-gray-400 dark:text-zinc-400" th:text="${suggestion.email}">
+                    <span
+                      class="text-xs text-gray-400 dark:text-zinc-400"
+                      aria-hidden="true"
+                      th:text="${suggestion.email}"
+                    >
                       email@example.org
                     </span>
                   </span>

--- a/src/main/resources/templates/fragments/person-search.html
+++ b/src/main/resources/templates/fragments/person-search.html
@@ -7,7 +7,13 @@
   </head>
   <body>
     <th:block th:fragment="person-search">
-      <uv-person-search th:if="${personSearchEnabled}" class="person-search desktop:max-w-lg">
+      <uv-person-search
+        th:if="${personSearchEnabled}"
+        class="person-search desktop:max-w-lg"
+        th:data-message-nothing-found="#{person-search.nothing-found}"
+        th:data-message-results-one="#{person-search.results-found.one}"
+        th:data-message-results-other="#{person-search.results-found.other}"
+      >
         <!-- use relative action (URL) since this form is used on different pages which all allow searching for users -->
         <form
           action=""
@@ -36,9 +42,10 @@
             th:placeholder="#{person-search.input.placeholder}"
             data-auto-submit="person-search-submit"
             data-auto-submit-delay="100"
-            aria-expanded="false"
+            aria-describedby="person-search-hint"
           />
           <button id="person-search-submit" type="submit" th:text="#{form.button.search}">Suchen</button>
+          <span id="person-search-hint" class="sr-only" th:text="#{person-search.input.hint}"></span>
         </form>
         <div
           popover="manual"
@@ -93,6 +100,8 @@
             </p>
           </turbo-frame>
         </div>
+        <!-- persistent live region (outside turbo-frame so morph does not replace it) announcing async result count to screen readers -->
+        <div class="sr-only" role="status" data-person-search-status></div>
       </uv-person-search>
     </th:block>
   </body>


### PR DESCRIPTION
closes #6388

Ich habe keine Ahnung, ob es das besser oder schlechter macht...

Zum zweiten Mal im Leben VoiceOver aktiviert und ausprobiert:
- Manchmal wird es announced, dass mit Pfeiltasten navigiert werden kann
- Manchmal wird es announced, dass 42 Personen gefunden wurden
- Manchmal wird nur meine Eingabe announced, sonst nichts mehr 

(Beobachtung: mein MacOS ist auf Deutsch eingestellt, Safari Anwendung habe ich auf Englisch, die Urlaubsverwaltung wird mit `lang="en-US" ausgeliefert`, und trotzdem werden manche Dinge auf Deutsch ausgesprochen von VoiceOver. Wird ein VoiceOver Bug sein?)

Wie sich andere Screenreader verhalten ... 🤷‍♂️

(Ursprung dieser Anpassung sind die Accessibility tests mit axe und das erfüllen dessen Regeln https://github.com/urlaubsverwaltung/urlaubsverwaltung/pull/6121)


<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
