### PR TITLE
Add swipe gesture support to the mobile overview calendar

### DIFF
--- a/src/main/javascript/components/calendar/__tests__/__snapshots__/calendar.spec.js.snap
+++ b/src/main/javascript/components/calendar/__tests__/__snapshots__/calendar.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`calendar > ensure correct rendering when clicking .datepicker-next  > click 1`] = `
 <body
-  class="mousedown"
+  class=""
 >
   <div
     class="unselectable"
@@ -9244,7 +9244,7 @@ exports[`calendar > ensure correct rendering when clicking .datepicker-next  > c
 
 exports[`calendar > ensure correct rendering when clicking .datepicker-prev  > click 1`] = `
 <body
-  class="mousedown"
+  class=""
 >
   <div
     class="unselectable"

--- a/src/main/javascript/components/calendar/__tests__/calendar.spec.js
+++ b/src/main/javascript/components/calendar/__tests__/calendar.spec.js
@@ -123,6 +123,42 @@ describe("calendar", () => {
     expect(holidayService.navigateToApplicationForLeave).toHaveBeenCalledWith("1337");
   });
 
+  it("dragging from one day to another on desktop marks and books the whole range in between", async () => {
+    // today is 2017-12-01
+    mockDate(1_512_130_448_379);
+
+    fetchMock.route(
+      "/persons/42/absences?from=2017-01-01&to=2017-12-31&absence-types=vacation%2Csick_note%2Cno_workday",
+      {
+        absences: [],
+      },
+    );
+
+    await calendarTestSetup();
+
+    const holidayService = createHolidayService({ personId: 42 });
+    holidayService.bookHoliday = vi.fn();
+    await holidayService.fetchAbsences(2017);
+
+    renderCalendar(holidayService);
+
+    const dayFrom = document.querySelector(`.datepicker-day[data-datepicker-date="2017-12-11"]`);
+    const dayTo = document.querySelector(`.datepicker-day[data-datepicker-date="2017-12-15"]`);
+    const dayBetween = document.querySelector(`.datepicker-day[data-datepicker-date="2017-12-13"]`);
+
+    dayFrom.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0 }));
+    dayTo.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+
+    // days between drag-start and the currently hovered day are marked while the button is still held
+    expect(dayBetween.classList.contains("datepicker-day-selected")).toBe(true);
+    expect(holidayService.bookHoliday).not.toHaveBeenCalled();
+
+    document.body.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    dayTo.click();
+
+    expect(holidayService.bookHoliday).toHaveBeenCalledWith(parseISO("2017-12-11"), parseISO("2017-12-15"));
+  });
+
   describe.each([[`.datepicker-prev`], [`.datepicker-next`]])(
     "ensure correct rendering when clicking %s ",
     (buttonSelector) => {
@@ -483,6 +519,255 @@ describe("calendar", () => {
     const day = $('[data-datepicker-date="2024-05-30"]');
     expect(day).toBeTruthy();
     expect(day.getAttribute("title")).toBe("Statehood Day, Corpus Christi");
+  });
+
+  describe("swipe gestures", () => {
+    const expectedInitialCaptions = [
+      "August 2017",
+      "September 2017",
+      "October 2017",
+      "November 2017",
+      "December 2017",
+      "January 2018",
+      "February 2018",
+      "March 2018",
+      "April 2018",
+      "May 2018",
+    ];
+
+    function touchEvent(type, x, y) {
+      const event = new Event(type, { bubbles: true, cancelable: true });
+      event.touches = [{ clientX: x, clientY: y }];
+      return event;
+    }
+
+    function swipe(container, { startX, endX, startY = 100, endY = 100 }) {
+      container.dispatchEvent(touchEvent("touchstart", startX, startY));
+      container.dispatchEvent(touchEvent("touchmove", endX, endY));
+      container.dispatchEvent(touchEvent("touchend", endX, endY));
+    }
+
+    function flush() {
+      return new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    function monthCaptions() {
+      return [...document.querySelectorAll(".calendar-month-caption")].map((element) => element.textContent);
+    }
+
+    // resolves the swipe animation started by `swipe`, mirroring the browser
+    // firing `transitionend` once the CSS slide animation finishes
+    function settleSwipeAnimation() {
+      const currentMonthElement = document.querySelectorAll(".calendar-month-container")[4];
+      currentMonthElement.dispatchEvent(new Event("transitionend", { bubbles: true }));
+      return flush();
+    }
+
+    async function setUpMobileCalendar() {
+      // pretend to be on a touch-sized viewport so swipe handling is active
+      globalThis.matchMedia = vi.fn().mockReturnValue({ matches: true, addEventListener: vi.fn() });
+
+      // today is 2017-12-01
+      mockDate(1_512_130_448_379);
+
+      fetchMock.route(
+        "/persons/42/absences?from=2017-01-01&to=2017-12-31&absence-types=vacation%2Csick_note%2Cno_workday",
+        {
+          absences: [],
+        },
+      );
+      fetchMock.route(`/persons/42/public-holidays?from=2017-01-01&to=2017-12-31`, { publicHolidays: [] });
+      mockEmptyYear(42, 2018);
+
+      await calendarTestSetup();
+
+      renderCalendar(createHolidayService({ webPrefix: "", apiPrefix: "", personId: 42 }));
+
+      return document.querySelector(".calendar-container");
+    }
+
+    it("swiping left past the commit threshold navigates to the next month, like the next button", async () => {
+      const container = await setUpMobileCalendar();
+      expect(monthCaptions()).toEqual(expectedInitialCaptions);
+
+      swipe(container, { startX: 200, endX: 100 });
+      await settleSwipeAnimation();
+
+      expect(monthCaptions()).toEqual([
+        "September 2017",
+        "October 2017",
+        "November 2017",
+        "December 2017",
+        "January 2018",
+        "February 2018",
+        "March 2018",
+        "April 2018",
+        "May 2018",
+        "June 2018",
+      ]);
+    });
+
+    it("swiping right past the commit threshold navigates to the previous month, like the previous button", async () => {
+      const container = await setUpMobileCalendar();
+
+      swipe(container, { startX: 100, endX: 200 });
+      await settleSwipeAnimation();
+
+      expect(monthCaptions()).toEqual([
+        "July 2017",
+        "August 2017",
+        "September 2017",
+        "October 2017",
+        "November 2017",
+        "December 2017",
+        "January 2018",
+        "February 2018",
+        "March 2018",
+        "April 2018",
+      ]);
+    });
+
+    it("does not navigate when the swipe distance stays under the commit threshold", async () => {
+      const container = await setUpMobileCalendar();
+
+      swipe(container, { startX: 200, endX: 180 });
+      await settleSwipeAnimation();
+
+      expect(monthCaptions()).toEqual(expectedInitialCaptions);
+    });
+
+    it("ignores a predominantly vertical touch move so page scrolling keeps working", async () => {
+      const container = await setUpMobileCalendar();
+
+      const preventDefaultSpy = vi.fn();
+      container.dispatchEvent(touchEvent("touchstart", 200, 100));
+      const moveEvent = touchEvent("touchmove", 205, 180);
+      moveEvent.preventDefault = preventDefaultSpy;
+      container.dispatchEvent(moveEvent);
+      container.dispatchEvent(touchEvent("touchend", 205, 180));
+
+      expect(preventDefaultSpy).not.toHaveBeenCalled();
+      expect(monthCaptions()).toEqual(expectedInitialCaptions);
+    });
+
+    it("does not react to touch gestures outside the mobile single-month view", async () => {
+      globalThis.matchMedia = vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn() });
+
+      mockDate(1_512_130_448_379);
+      await calendarTestSetup();
+      renderCalendar(createHolidayService({ personId: 42 }));
+
+      const container = document.querySelector(".calendar-container");
+      swipe(container, { startX: 200, endX: 50 });
+
+      expect(document.querySelectorAll(".calendar-month-container.calendar-month-swipe-active").length).toBe(0);
+      expect(monthCaptions()).toEqual(expectedInitialCaptions);
+    });
+  });
+
+  describe("mobile day range selection (tap to mark)", () => {
+    async function setUpMobileCalendarNoAbsences() {
+      // pretend to be on a touch-sized viewport so tap-to-mark handling is active
+      globalThis.matchMedia = vi.fn().mockReturnValue({ matches: true, addEventListener: vi.fn() });
+
+      // today is 2017-12-01
+      mockDate(1_512_130_448_379);
+
+      await calendarTestSetup();
+
+      const holidayService = createHolidayService({ personId: 42 });
+      holidayService.bookHoliday = vi.fn();
+
+      renderCalendar(holidayService);
+
+      return holidayService;
+    }
+
+    function day(date) {
+      return document.querySelector(`.datepicker-day[data-datepicker-date="${date}"]`);
+    }
+
+    function isMarked(date) {
+      return day(date).classList.contains("datepicker-day-selected");
+    }
+
+    it("marks a day on first tap without booking, marks the range on a second tap, and books on a third tap inside the range", async () => {
+      const holidayService = await setUpMobileCalendarNoAbsences();
+
+      day("2017-12-11").click();
+      expect(holidayService.bookHoliday).not.toHaveBeenCalled();
+      expect(isMarked("2017-12-11")).toBe(true);
+      expect(isMarked("2017-12-15")).toBe(false);
+
+      day("2017-12-15").click();
+      expect(holidayService.bookHoliday).not.toHaveBeenCalled();
+      expect(isMarked("2017-12-11")).toBe(true);
+      expect(isMarked("2017-12-13")).toBe(true);
+      expect(isMarked("2017-12-15")).toBe(true);
+
+      day("2017-12-13").click();
+      expect(holidayService.bookHoliday).toHaveBeenCalledWith(parseISO("2017-12-11"), parseISO("2017-12-15"));
+      expect(isMarked("2017-12-11")).toBe(false);
+      expect(isMarked("2017-12-15")).toBe(false);
+    });
+
+    it("confirms a single-day booking when the already-marked day is tapped again", async () => {
+      const holidayService = await setUpMobileCalendarNoAbsences();
+
+      day("2017-12-11").click();
+      day("2017-12-11").click();
+
+      expect(holidayService.bookHoliday).toHaveBeenCalledWith(parseISO("2017-12-11"), parseISO("2017-12-11"));
+    });
+
+    it("extends the marked range relative to the original anchor when tapping outside it", async () => {
+      const holidayService = await setUpMobileCalendarNoAbsences();
+
+      day("2017-12-11").click(); // anchor
+      day("2017-12-15").click(); // marks range 11-15
+      day("2017-12-20").click(); // outside 11-15, re-anchored to 11-20
+
+      expect(holidayService.bookHoliday).not.toHaveBeenCalled();
+      expect(isMarked("2017-12-13")).toBe(true);
+      expect(isMarked("2017-12-18")).toBe(true);
+
+      day("2017-12-18").click();
+      expect(holidayService.bookHoliday).toHaveBeenCalledWith(parseISO("2017-12-11"), parseISO("2017-12-20"));
+    });
+
+    it("still navigates directly to an existing absence on tap, without engaging range marking", async () => {
+      globalThis.matchMedia = vi.fn().mockReturnValue({ matches: true, addEventListener: vi.fn() });
+      mockDate(1_512_130_448_379);
+
+      fetchMock.route(
+        "/persons/42/absences?from=2017-01-01&to=2017-12-31&absence-types=vacation%2Csick_note%2Cno_workday",
+        {
+          absences: [
+            {
+              date: "2017-12-15",
+              absenceType: "VACATION",
+              id: 1337,
+              absent: "FULL",
+              absentNumeric: 1,
+              status: "ALLOWED",
+              typeId: 1,
+            },
+          ],
+        },
+      );
+
+      await calendarTestSetup();
+
+      const holidayService = createHolidayService({ personId: 42 });
+      holidayService.navigateToApplicationForLeave = vi.fn();
+      await holidayService.fetchAbsences(2017);
+
+      renderCalendar(holidayService);
+
+      day("2017-12-15").click();
+
+      expect(holidayService.navigateToApplicationForLeave).toHaveBeenCalledWith("1337");
+    });
   });
 
   function mockEmptyYear(personId, year) {

--- a/src/main/javascript/components/calendar/__tests__/calendar.spec.js
+++ b/src/main/javascript/components/calendar/__tests__/calendar.spec.js
@@ -650,6 +650,23 @@ describe("calendar", () => {
       expect(monthCaptions()).toEqual(expectedInitialCaptions);
     });
 
+    it("ignores a swipe to the right started mid-animation while a swipe to the left is still settling", async () => {
+      const container = await setUpMobileCalendar();
+
+      // swipe left, past the commit threshold, but don't let its transitionend fire yet
+      swipe(container, { startX: 200, endX: 100 });
+
+      // fire a swipe to the right immediately, before the left swipe's slide
+      // animation (and its cleanup) has finished
+      swipe(container, { startX: 100, endX: 200 });
+
+      expect(
+        document.querySelectorAll(".calendar-month-container.calendar-month-swipe-active").length,
+      ).toBeLessThanOrEqual(2);
+
+      await settleSwipeAnimation();
+    });
+
     it("does not react to touch gestures outside the mobile single-month view", async () => {
       globalThis.matchMedia = vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn() });
 

--- a/src/main/javascript/components/calendar/calendar.css
+++ b/src/main/javascript/components/calendar/calendar.css
@@ -111,6 +111,21 @@
   display: block;
 }
 
+/* SWIPE GESTURE (mobile single-month view) */
+
+/* current & target month while a horizontal swipe is in progress, positioned
+   so both can be transform-translated in lockstep with the finger */
+.calendar-month-container.calendar-month-swipe-active {
+  display: block !important;
+  left: 0 !important;
+  z-index: 1;
+}
+
+/* only applied once the touch ends, so mid-drag movement follows the finger 1:1 */
+.calendar-month-container.calendar-month-swipe-transition {
+  transition: transform 0.3s ease-in-out;
+}
+
 @variant sm {
   .calendar-month-container:nth-child(5) {
     --width: 80vw;

--- a/src/main/javascript/components/calendar/calendar.js
+++ b/src/main/javascript/components/calendar/calendar.js
@@ -564,7 +564,10 @@ const Controller = (function () {
   // slide the current and the target month into view and then delegate to
   // the existing button handlers to do the actual data fetch + DOM swap.
   let swipeGesture;
-  let swipeNavigationPending = false;
+  // true from the moment a swipe commits or snaps back (touchend) until its slide
+  // transition (and, if committed, the resulting month navigation) has fully finished;
+  // blocks a new gesture from starting on elements that are still mid-transition
+  let swipeSettling = false;
 
   function getCurrentMonthElement() {
     return view.getRootElement().querySelectorAll(`.${CSS.month}`)[currentMonthIndex];
@@ -613,7 +616,7 @@ const Controller = (function () {
 
   const swipeHandlers = {
     touchstart: function (event) {
-      if (!mobileScreenQuery.matches || swipeGesture || swipeNavigationPending || event.touches.length !== 1) {
+      if (!mobileScreenQuery.matches || swipeGesture || swipeSettling || event.touches.length !== 1) {
         return;
       }
 
@@ -671,6 +674,8 @@ const Controller = (function () {
 
       const commit = Math.abs(deltaX) >= swipeCommitThreshold;
 
+      swipeSettling = true;
+
       currentElement.classList.add(CSS.swipeTransition);
       targetElement.classList.add(CSS.swipeTransition);
 
@@ -690,11 +695,12 @@ const Controller = (function () {
           clearSwipeStyles(targetElement);
 
           if (commit) {
-            swipeNavigationPending = true;
             const navigate = direction === "next" ? datepickerHandlers.clickNext : datepickerHandlers.clickPrevious;
             Promise.resolve(navigate()).finally(function () {
-              swipeNavigationPending = false;
+              swipeSettling = false;
             });
+          } else {
+            swipeSettling = false;
           }
         },
         { once: true },

--- a/src/main/javascript/components/calendar/calendar.js
+++ b/src/main/javascript/components/calendar/calendar.js
@@ -56,8 +56,20 @@ const CSS = {
   next: "datepicker-next",
   previous: "datepicker-prev",
   month: "calendar-month-container",
+  container: "calendar-container",
   mousedown: "mousedown",
+  swipeActive: "calendar-month-swipe-active",
+  swipeTransition: "calendar-month-swipe-transition",
 };
+
+// how many pixels a touch must move (in the dominant axis) before we decide
+// the gesture is a horizontal swipe rather than vertical page scrolling
+const swipeAxisLockThreshold = 10;
+// how many pixels a horizontal swipe must cover before it commits to a month change
+const swipeCommitThreshold = 50;
+// mirrors ".calendar-month-container:nth-child(5)" in calendar.css, the slot
+// CSS always uses to display the "current" month on mobile
+const currentMonthIndex = 4;
 
 const DATA = {
   date: "datepickerDate",
@@ -390,9 +402,76 @@ const Controller = (function () {
   let view;
   let holidayService;
 
+  const mobileScreenQuery = globalThis.matchMedia("(max-width: 640px)");
+
+  function navigateToAbsenceDetails(isSelectable, absenceType, absenceId) {
+    if (isSelectable !== "true" || absenceId === "-1") {
+      return false;
+    }
+
+    if (absenceType === "VACATION") {
+      holidayService.navigateToApplicationForLeave(absenceId);
+      return true;
+    }
+
+    if (absenceType === "SICK_NOTE") {
+      holidayService.navigateToSickNote(absenceId);
+      return true;
+    }
+
+    return false;
+  }
+
+  // no mousedown-drag range selection on mobile (it would fight the swipe-to-change-month
+  // gesture), so a range is built from separate taps instead: tap a day to mark it, tap
+  // another day to mark the range between them, tap anywhere inside the marked range
+  // again to confirm and book it
+  function handleMobileDayClick(dateThis, isSelectable) {
+    if (isSelectable !== "true") {
+      return;
+    }
+
+    const start = selectionFrom();
+    const end = selectionTo();
+    const hasPendingSelection = isValidDate(start) && isValidDate(end);
+
+    if (hasPendingSelection && isWithinInterval(dateThis, { start, end })) {
+      holidayService.bookHoliday(start, end);
+      clearSelection();
+    } else if (hasPendingSelection) {
+      const anchor = new Date(view.getRootElement().dataset[DATA.selected]);
+      const isThisBefore = isBefore(dateThis, anchor);
+      selectionFrom(isThisBefore ? dateThis : anchor);
+      selectionTo(isThisBefore ? anchor : dateThis);
+    } else {
+      view.getRootElement().dataset[DATA.selected] = dateThis;
+      selectionFrom(dateThis);
+      selectionTo(dateThis);
+    }
+  }
+
+  function handleDesktopDayClick(dateThis, isSelectable) {
+    const dateFrom = selectionFrom();
+    const dateTo = selectionTo();
+
+    if (
+      isSelectable === "true" &&
+      isValidDate(dateFrom) &&
+      isValidDate(dateTo) &&
+      isWithinInterval(dateThis, {
+        start: dateFrom,
+        end: dateTo,
+      })
+    ) {
+      holidayService.bookHoliday(dateFrom, dateTo);
+    }
+  }
+
   const datepickerHandlers = {
     mousedown: function (event) {
-      if (event.button !== mouseButtons.left) {
+      if (event.button !== mouseButtons.left || mobileScreenQuery.matches) {
+        // on mobile, range selection is driven entirely by taps in the click handler below,
+        // so that a mousedown-drag never competes with the swipe-to-change-month gesture
         return;
       }
 
@@ -429,30 +508,22 @@ const Controller = (function () {
     },
 
     click: function () {
-      const dateFrom = selectionFrom();
-      const dateTo = selectionTo();
-
       const dateThis = getDateFromElement(this);
 
       const isSelectable = this.dataset.datepickerSelectable;
       const absenceId = this.dataset.datepickerAbsenceId;
       const absenceType = this.dataset.datepickerAbsenceType;
 
-      if (isSelectable === "true" && absenceType === "VACATION" && absenceId !== "-1") {
-        holidayService.navigateToApplicationForLeave(absenceId);
-      } else if (isSelectable === "true" && absenceType === "SICK_NOTE" && absenceId !== "-1") {
-        holidayService.navigateToSickNote(absenceId);
-      } else if (
-        isSelectable === "true" &&
-        isValidDate(dateFrom) &&
-        isValidDate(dateTo) &&
-        isWithinInterval(dateThis, {
-          start: dateFrom,
-          end: dateTo,
-        })
-      ) {
-        holidayService.bookHoliday(dateFrom, dateTo);
+      if (navigateToAbsenceDetails(isSelectable, absenceType, absenceId)) {
+        return;
       }
+
+      if (mobileScreenQuery.matches) {
+        handleMobileDayClick(dateThis, isSelectable);
+        return;
+      }
+
+      handleDesktopDayClick(dateThis, isSelectable);
     },
 
     clickNext: function () {
@@ -465,7 +536,7 @@ const Controller = (function () {
       // to load data for the new (invisible) prev month
       const date = addMonths(new Date(y, m, 1), 1);
 
-      Promise.all([
+      return Promise.all([
         holidayService.fetchPublicHolidays(getYear(date)),
         holidayService.fetchAbsences(getYear(date)),
       ]).then(view.displayNext);
@@ -481,10 +552,163 @@ const Controller = (function () {
       // to load data for the new (invisible) prev month
       const date = subMonths(new Date(y, m, 1), 1);
 
-      Promise.all([
+      return Promise.all([
         holidayService.fetchPublicHolidays(getYear(date)),
         holidayService.fetchAbsences(getYear(date)),
       ]).then(view.displayPrevious);
+    },
+  };
+
+  // touch swipe support for the single-month mobile view. Adjacent months
+  // are already rendered (just hidden via CSS), so a swipe only has to
+  // slide the current and the target month into view and then delegate to
+  // the existing button handlers to do the actual data fetch + DOM swap.
+  let swipeGesture;
+  let swipeNavigationPending = false;
+
+  function getCurrentMonthElement() {
+    return view.getRootElement().querySelectorAll(`.${CSS.month}`)[currentMonthIndex];
+  }
+
+  function clearSwipeStyles(element) {
+    if (!element) {
+      return;
+    }
+    element.classList.remove(CSS.swipeActive, CSS.swipeTransition);
+    element.style.removeProperty("transform");
+  }
+
+  // decides whether the touch is a horizontal swipe or vertical scroll, exactly once per
+  // gesture, and (if horizontal) locks in the target month element to slide alongside
+  function lockSwipeAxis(deltaX, deltaY) {
+    if (Math.abs(deltaX) < swipeAxisLockThreshold && Math.abs(deltaY) < swipeAxisLockThreshold) {
+      return;
+    }
+
+    swipeGesture.axis = Math.abs(deltaX) > Math.abs(deltaY) ? "horizontal" : "vertical";
+
+    if (swipeGesture.axis !== "horizontal") {
+      return;
+    }
+
+    swipeGesture.direction = deltaX < 0 ? "next" : "previous";
+    swipeGesture.targetElement =
+      swipeGesture.direction === "next"
+        ? swipeGesture.currentElement.nextElementSibling
+        : swipeGesture.currentElement.previousElementSibling;
+
+    if (swipeGesture.targetElement) {
+      swipeGesture.currentElement.classList.add(CSS.swipeActive);
+      swipeGesture.targetElement.classList.add(CSS.swipeActive);
+    }
+  }
+
+  function applySwipeTransform(deltaX) {
+    swipeGesture.deltaX = deltaX;
+    const targetOffset = swipeGesture.direction === "next" ? "100%" : "-100%";
+
+    swipeGesture.currentElement.style.transform = `translateX(${deltaX}px)`;
+    swipeGesture.targetElement.style.transform = `translateX(calc(${targetOffset} + ${deltaX}px))`;
+  }
+
+  const swipeHandlers = {
+    touchstart: function (event) {
+      if (!mobileScreenQuery.matches || swipeGesture || swipeNavigationPending || event.touches.length !== 1) {
+        return;
+      }
+
+      const currentElement = getCurrentMonthElement();
+      if (!currentElement) {
+        return;
+      }
+
+      swipeGesture = {
+        startX: event.touches[0].clientX,
+        startY: event.touches[0].clientY,
+        deltaX: 0,
+        axis: undefined,
+        direction: undefined,
+        currentElement,
+        targetElement: undefined,
+      };
+    },
+
+    touchmove: function (event) {
+      if (!swipeGesture) {
+        return;
+      }
+
+      const touch = event.touches[0];
+      const deltaX = touch.clientX - swipeGesture.startX;
+      const deltaY = touch.clientY - swipeGesture.startY;
+
+      if (!swipeGesture.axis) {
+        lockSwipeAxis(deltaX, deltaY);
+      }
+
+      if (swipeGesture.axis !== "horizontal" || !swipeGesture.targetElement) {
+        // vertical scroll (or no adjacent month to slide in): let the page scroll as usual
+        return;
+      }
+
+      // we're committed to a horizontal swipe now, don't let the page scroll along
+      event.preventDefault();
+
+      applySwipeTransform(deltaX);
+    },
+
+    touchend: function () {
+      if (!swipeGesture) {
+        return;
+      }
+
+      const { axis, targetElement, currentElement, direction, deltaX } = swipeGesture;
+      swipeGesture = undefined;
+
+      if (axis !== "horizontal" || !targetElement) {
+        return;
+      }
+
+      const commit = Math.abs(deltaX) >= swipeCommitThreshold;
+
+      currentElement.classList.add(CSS.swipeTransition);
+      targetElement.classList.add(CSS.swipeTransition);
+
+      if (commit) {
+        const outOffset = direction === "next" ? "-100%" : "100%";
+        currentElement.style.transform = `translateX(${outOffset})`;
+        targetElement.style.transform = "translateX(0)";
+      } else {
+        currentElement.style.transform = "translateX(0)";
+        targetElement.style.transform = "";
+      }
+
+      currentElement.addEventListener(
+        "transitionend",
+        function () {
+          clearSwipeStyles(currentElement);
+          clearSwipeStyles(targetElement);
+
+          if (commit) {
+            swipeNavigationPending = true;
+            const navigate = direction === "next" ? datepickerHandlers.clickNext : datepickerHandlers.clickPrevious;
+            Promise.resolve(navigate()).finally(function () {
+              swipeNavigationPending = false;
+            });
+          }
+        },
+        { once: true },
+      );
+    },
+
+    touchcancel: function () {
+      if (!swipeGesture) {
+        return;
+      }
+
+      clearSwipeStyles(swipeGesture.currentElement);
+      clearSwipeStyles(swipeGesture.targetElement);
+      swipeGesture = undefined;
     },
   };
 
@@ -584,18 +808,23 @@ const Controller = (function () {
         document.body.classList.remove(CSS.mousedown);
       });
 
-      const smScreenQuery = globalThis.matchMedia("(max-width: 640px)");
-      if (smScreenQuery.matches) {
+      if (mobileScreenQuery.matches) {
         for (const button of view.getRootElement().querySelectorAll("button")) {
           button.classList.add("button");
         }
       }
 
-      smScreenQuery.addEventListener("change", function () {
+      mobileScreenQuery.addEventListener("change", function () {
         for (const button of view.getRootElement().querySelectorAll("button")) {
           button.classList.toggle("button");
         }
       });
+
+      const calendarContainer = view.getRootElement().querySelector(`.${CSS.container}`);
+      calendarContainer.addEventListener("touchstart", swipeHandlers.touchstart, { passive: true });
+      calendarContainer.addEventListener("touchmove", swipeHandlers.touchmove, { passive: false });
+      calendarContainer.addEventListener("touchend", swipeHandlers.touchend);
+      calendarContainer.addEventListener("touchcancel", swipeHandlers.touchcancel);
     },
   };
 


### PR DESCRIPTION
  Adds swipe gesture support to the personal overview calendar on mobile, as requested in #1815.                                  
                                                                                                                                  
  - **Swipe left/right** on the calendar now navigates to the next/previous month, with the current and target month sliding in   
  sync with the touch (falls back to a snap-back animation if the swipe doesn't clear a commit threshold). The existing prev/next 
  buttons are unchanged and still work everywhere.                                                                                
  - Swiping is scoped to the mobile single-month view only — desktop is untouched, buttons-only navigation stays as-is, and touch 
  handlers no-op entirely outside that viewport.                                                                                  
  - A mousedown-drag for day-range selection would otherwise fight the swipe gesture on touch, so **mobile day selection now uses 
  tap-based marking** instead of drag: tap a day to mark it, tap another day to mark the range between them, tap anywhere inside  
  the marked range again to confirm and open the application form. Tapping an existing absence still opens it directly, same as   
  before.                                                                                                                         
  - **Desktop is functionally unchanged**: click-and-hold-drag across days still marks and books the range in between, and a plain
  click still books a single day immediately.                                                                                     
                                                                                                                                  
  ## Test plan                                                                                                                    
  - [x] `calendar.spec.js`: added coverage for swipe navigation (commit threshold, snap-back, vertical-scroll passthrough, desktop
  no-op), mobile tap-to-mark-range selection, and an explicit desktop drag-to-select regression test                              
  - [x] Full JS test suite passes (`npx vitest run`)                                                                              
  - [x] `npx eslint` / `npx prettier --check` clean 

Closes #1815

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
