### PR TITLE
Ignore query parameters when crawling pages in a11y test

### DIFF
--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/AccessibilityCrawlerAccessibilityIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/AccessibilityCrawlerAccessibilityIT.java
@@ -30,6 +30,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.Year;
@@ -134,7 +135,10 @@ class AccessibilityCrawlerAccessibilityIT {
                         try {
                             // Resolve relative URLs against the current BASE_URL context
                             final URI absoluteUri = URI.create(baseUrl).resolve(href).normalize();
-                            final String absoluteUrl = absoluteUri.toString();
+                            // Ignore query parameters (e.g. ?year=2025) so the same page isn't crawled
+                            // repeatedly with different parameter values
+                            final String absoluteUrl = new URI(absoluteUri.getScheme(), null, absoluteUri.getHost(),
+                                absoluteUri.getPort(), absoluteUri.getPath(), null, null).toString();
 
                             // Ensure it's internal, not visited, not already queued, and skip destructive paths like
                             // /logout as well as file downloads (/download, /export) - these don't navigate to an
@@ -148,7 +152,7 @@ class AccessibilityCrawlerAccessibilityIT {
 
                                 linksToVisit.add(absoluteUrl);
                             }
-                        } catch (IllegalArgumentException _) {
+                        } catch (IllegalArgumentException | URISyntaxException _) {
                             // Ignore unparseable/malformed URIs (e.g., mailto:, javascript:void(0))
                         }
                     }


### PR DESCRIPTION
Strips query strings (e.g. ?year=2025) from discovered links before dedup/queueing so pages that only differ by parameters aren't crawled and scanned multiple times.


<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
