### PR TITLE
Speed up UI/a11y IT tests: opt-in slowMo, batch anchor href reads

### DIFF
--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/AccessibilityCrawlerAccessibilityIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/AccessibilityCrawlerAccessibilityIT.java
@@ -4,7 +4,6 @@ import com.deque.html.axecore.playwright.AxeBuilder;
 import com.deque.html.axecore.results.AxeResults;
 import com.deque.html.axecore.results.CheckedNode;
 import com.deque.html.axecore.results.Rule;
-import com.microsoft.playwright.ElementHandle;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.WaitUntilState;
 import org.junit.jupiter.api.Test;
@@ -127,10 +126,10 @@ class AccessibilityCrawlerAccessibilityIT {
                 page.navigate(currentUrl, new Page.NavigateOptions().setWaitUntil(WaitUntilState.NETWORKIDLE));
 
                 // 2. Discover new internal links on this page
-                final List<ElementHandle> anchors = page.querySelectorAll("a[href]");
-                for (ElementHandle anchor : anchors) {
-                    final String href = anchor.getAttribute("href");
-
+                @SuppressWarnings("unchecked")
+                final List<String> hrefs = (List<String>) page.evalOnSelectorAll("a[href]",
+                    "els => els.map(el => el.getAttribute('href'))");
+                for (String href : hrefs) {
                     if (href != null && !href.trim().isEmpty()) {
                         try {
                             // Resolve relative URLs against the current BASE_URL context

--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/extension/UiIntegrationTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/extension/UiIntegrationTest.java
@@ -73,12 +73,13 @@ public @interface UiIntegrationTest {
 
             // webkit | firefox | chromium (playwright-default)
             final String browser = System.getProperty("browser", "chromium");
+            // set e.g. -Dplaywright.slowmo=200 to slow down test steps and follow them with your own eyes.
+            final double slowMo = Double.parseDouble(System.getProperty("playwright.slowmo", "0"));
 
             return new Options()
                 .setBrowserName(browser)
                 .setConnectOptions(new BrowserType.ConnectOptions()
-                    // increase to make test steps slower and be able to follow it with your own eyes.
-                    .setSlowMo(200)
+                    .setSlowMo(slowMo)
                 )
                 .setContextOptions(new Browser.NewContextOptions()
                     .setRecordVideoDir(Path.of("target/ui-test", browser))


### PR DESCRIPTION
slowMo(200) was hardcoded for every Playwright IPC call in all UiIntegrationTest-based tests, meant only for watching a run live. Gate it behind -Dplaywright.slowmo, defaulting to 0 for normal runs.

AccessibilityCrawlerAccessibilityIT also fetched each anchor's href via a separate handle + getAttribute round-trip; collect them in one evalOnSelectorAll call instead, cutting per-page round-trips.

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
