### PR TITLE
Fix logo link to respect servlet context path when deployed at a subpath

### DIFF
--- a/src/main/resources/templates/_layout.html
+++ b/src/main/resources/templates/_layout.html
@@ -134,7 +134,7 @@
     <div class="launchpad-app-cell topbar-cell flex items-center gap-2 py-2 px-4 lg:pl-6">
       <div th:replace="~{launchpad/launchpad::launchpad}"></div>
       <a
-        href="/"
+        th:href="@{/}"
         class="hidden desktop:block font-logo text-xl font-medium mr-8 md:mr-16 text-zinc-900 dark:text-zinc-100 no-underline"
       >
         Urlaubsverwaltung


### PR DESCRIPTION
# Fix logo link to respect servlet context path when deployed at a subpath

## Description

When the application is deployed at a subpath using `server.servlet.context-path` (e.g. behind a reverse proxy serving multiple applications on the same domain), the top-left logo link in `_layout.html` always navigates to `/` regardless of the configured context path:

```html
<a
  href="/"
  class="hidden desktop:block font-logo text-xl font-medium ..."
>
  Urlaubsverwaltung
</a>
```

This is inconsistent with every other internal link in the templates, which already use Thymeleaf's `@{/...}` link expressions and correctly prepend the context path. The logo link is the only exception.

## Solution

Replace the hardcoded `href="/"` with `th:href="@{/}"`. Thymeleaf resolves `@{/}` relative to the configured servlet context path automatically - no additional configuration is needed.

```html
<a
  th:href="@{/}"
  class="hidden desktop:block font-logo text-xl font-medium ..."
>
  Urlaubsverwaltung
</a>
```

### Rendered output

| `server.servlet.context-path` | Before | After |
|---|---|---|
| _(not set, default)_ | `href="/"` | `href="/"` |
| `/urlaubsverwaltung` | `href="/"` ❌ | `href="/urlaubsverwaltung/"` ✅ |
| `/app` | `href="/"` ❌ | `href="/app/"` ✅ |

Deployments at the root path are completely unaffected.