### PR TITLE
fix: correct AUB_TO_SELECTOR copy-paste bug in SickNoteFormPage

### DIFF
--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/pages/SickNoteFormPage.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/pages/SickNoteFormPage.java
@@ -16,7 +16,7 @@ public class SickNoteFormPage {
     private static final String FROM_SELECTOR = "[data-test-id=sicknote-from-date]";
     private static final String TO_SELECTOR = "[data-test-id=sicknote-to-date]";
     private static final String AUB_FROM_SELECTOR = "[data-test-id=sicknote-aub-from]";
-    private static final String AUB_TO_SELECTOR = "[data-test-id=sicknote-aub-from]";
+    private static final String AUB_TO_SELECTOR = "[data-test-id=sicknote-aub-to]";
     private static final String SUBMIT_SELECTOR = "[data-test-id=sicknote-submit-button]";
 
     private final Page page;


### PR DESCRIPTION
AUB_TO_SELECTOR pointed at the same element as AUB_FROM_SELECTOR, so showsAubToDate() silently re-checked the "from" field instead of waiting for the "to" field. That masked a real race: the "AU to" date is only auto-filled by client-side JS once the datepicker's duetChange event fires, which can lose to form submission, especially on webkit. With the correct selector, showsAubToDate()'s assertion polls until the JS copy has actually landed, removing the race.

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
