### PR TITLE
Perf/statistics duplicate fetch and calendar caching

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/account/VacationDaysService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/account/VacationDaysService.java
@@ -126,6 +126,32 @@ public class VacationDaysService {
         DateRange dateRange,
         List<Account> holidayAccountsNextYear
     ) {
+        final LocalDate from = dateRange.startDate();
+        final List<Account> holidayAccountsForYear = holidayAccounts.stream().filter(account -> account.getYear() == from.getYear()).toList();
+        final List<Person> persons = holidayAccountsForYear.stream().map(Account::getPerson).toList();
+        final Map<Person, WorkingTimeCalendar> workingTimeCalendars = workingTimeCalendarService.getWorkingTimesByPersons(persons, Year.of(from.getYear()));
+
+        return getVacationDaysLeft(holidayAccounts, dateRange, holidayAccountsNextYear, workingTimeCalendars);
+    }
+
+    /**
+     * Same as {@link #getVacationDaysLeft(List, DateRange, List)}, but for callers that already hold the
+     * {@link WorkingTimeCalendar} of every person involved. Pass it in to avoid recomputing the very same
+     * day-by-day calendar a second time.
+     *
+     * @param holidayAccounts             {@link Account} to determine configured expiryDate of {@link Application}s
+     * @param dateRange                   date range to calculate left vacation days for. must be within a year.
+     * @param holidayAccountsNextYear     to calculate the vacation days that are already used next year
+     * @param workingTimeCalendarsByPerson pre-computed calendar, must cover every person of {@code holidayAccounts}
+     * @return {@link HolidayAccountVacationDays} for every passed {@link Account}. {@link Account}s with no used vacation are included.
+     * @throws IllegalArgumentException when dateRange is over one year.
+     */
+    public Map<Account, HolidayAccountVacationDays> getVacationDaysLeft(
+        List<Account> holidayAccounts,
+        DateRange dateRange,
+        List<Account> holidayAccountsNextYear,
+        Map<Person, WorkingTimeCalendar> workingTimeCalendarsByPerson
+    ) {
 
         final LocalDate from = dateRange.startDate();
         final LocalDate to = dateRange.endDate();
@@ -135,9 +161,7 @@ public class VacationDaysService {
         }
 
         final List<Account> holidayAccountsForYear = holidayAccounts.stream().filter(account -> account.getYear() == from.getYear()).toList();
-        final List<Person> persons = holidayAccountsForYear.stream().map(Account::getPerson).toList();
-        final Map<Person, WorkingTimeCalendar> workingTimeCalendars = workingTimeCalendarService.getWorkingTimesByPersons(persons, Year.of(from.getYear()));
-        return getUsedVacationDays(holidayAccountsForYear, dateRange, workingTimeCalendars).entrySet().stream()
+        return getUsedVacationDays(holidayAccountsForYear, dateRange, workingTimeCalendarsByPerson).entrySet().stream()
             .map(entry -> {
                 final Account account = entry.getKey();
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationEntity.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationEntity.java
@@ -11,6 +11,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 import org.synyx.urlaubsverwaltung.DurationConverter;
 import org.synyx.urlaubsverwaltung.application.vacationtype.VacationTypeEntity;
 import org.synyx.urlaubsverwaltung.period.DayLength;
@@ -111,6 +113,7 @@ public class ApplicationEntity extends AbstractTenantAwareEntity {
 
     @CollectionTable(name = "holiday_replacements", joinColumns = @JoinColumn(name = "application_id"))
     @ElementCollection(fetch = EAGER)
+    @Fetch(FetchMode.SUBSELECT)
     private List<HolidayReplacementEntity> holidayReplacements = new ArrayList<>();
 
     /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationRepository.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationRepository.java
@@ -37,11 +37,10 @@ interface ApplicationRepository extends CrudRepository<ApplicationEntity, Long> 
             WHERE cast(strpos(lower(concat(a.person.firstName,' ',a.person.lastName)), lower(:personQuery)) AS INTEGER) > 0
             AND a.endDate >= :start AND a.startDate <= :end
             AND a.status IN :statuses
-            AND a.vacationType.id IN :vacationTypeIds
             ORDER BY a.startDate
         """)
     List<ApplicationEntity> findByEndDateIsGreaterThanEqualAndStartDateIsLessThanEqualAndStatusInAndPersonNiceNameContainingIgnoreCase(
-        LocalDate start, LocalDate end, List<ApplicationStatus> statuses, List<Long> vacationTypeIds, String personQuery);
+        LocalDate start, LocalDate end, List<ApplicationStatus> statuses, String personQuery);
 
     @Query(
         "select x from application x "

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationService.java
@@ -1,7 +1,6 @@
 package org.synyx.urlaubsverwaltung.application.application;
 
 import org.synyx.urlaubsverwaltung.application.vacationtype.VacationCategory;
-import org.synyx.urlaubsverwaltung.application.vacationtype.VacationType;
 import org.synyx.urlaubsverwaltung.person.Person;
 
 import java.time.Duration;
@@ -59,14 +58,13 @@ public interface ApplicationService {
     /**
      * Gets all {@link Application}s with vacation time between startDate x and endDate y for the matching persons.
      *
-     * @param startDate     start of the period
-     * @param endDate       end of the period (inclusive)
-     * @param statuses      application status to consider
-     * @param vacationTypes vacationType to consider
-     * @param personQuery   optional filter for person firstname for instance
+     * @param startDate   start of the period
+     * @param endDate     end of the period (inclusive)
+     * @param statuses    application status to consider
+     * @param personQuery optional filter for person firstname for instance
      * @return all {@link Application}s of the matching persons with vacation time between startDate and endDate
      */
-    List<Application> getApplicationsForACertainPeriodAndStatus(LocalDate startDate, LocalDate endDate, List<ApplicationStatus> statuses, List<VacationType<?>> vacationTypes, String personQuery);
+    List<Application> getApplicationsForACertainPeriodAndStatus(LocalDate startDate, LocalDate endDate, List<ApplicationStatus> statuses, String personQuery);
 
     /**
      * Returns all {@link Application}s where their start or end date is overlapping with the given period between startDate and endDate

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationServiceImpl.java
@@ -78,10 +78,9 @@ class ApplicationServiceImpl implements ApplicationService {
     }
 
     @Override
-    public List<Application> getApplicationsForACertainPeriodAndStatus(LocalDate startDate, LocalDate endDate, List<ApplicationStatus> statuses, List<VacationType<?>> vacationTypes, String personQuery) {
+    public List<Application> getApplicationsForACertainPeriodAndStatus(LocalDate startDate, LocalDate endDate, List<ApplicationStatus> statuses, String personQuery) {
         final String query = hasText(personQuery) ? personQuery : "";
-        final List<Long> vacationTypeIds = vacationTypes.stream().map(VacationType::getId).toList();
-        return toApplication(applicationRepository.findByEndDateIsGreaterThanEqualAndStartDateIsLessThanEqualAndStatusInAndPersonNiceNameContainingIgnoreCase(startDate, endDate, statuses, vacationTypeIds, query));
+        return toApplication(applicationRepository.findByEndDateIsGreaterThanEqualAndStartDateIsLessThanEqualAndStatusInAndPersonNiceNameContainingIgnoreCase(startDate, endDate, statuses, query));
     }
 
     @Override

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsBuilder.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsBuilder.java
@@ -76,13 +76,23 @@ class ApplicationForLeaveStatisticsBuilder {
         return buildStatistics(new DateRange(from, to), persons, holidayAccounts, applications, vacationTypes);
     }
 
+    /**
+     * Same as {@link #build(List, LocalDate, LocalDate, List)}, but for callers that have already fetched the
+     * applications themselves.
+     *
+     * @param applications every application of the requested <em>year</em> - not only of the requested period - with
+     *                     an {@link org.synyx.urlaubsverwaltung.application.application.ApplicationStatus#activeStatuses()
+     *                     active status}, of any {@link VacationType}, covering at least the given persons. The whole
+     *                     year is required because the left overtime of the year is derived from it, and all vacation
+     *                     types are required so that types deactivated in the meantime still show up for the persons
+     *                     who used them.
+     */
     public Map<Person, Optional<ApplicationForLeaveStatistics>> build(List<Person> persons, LocalDate from, LocalDate to, List<VacationType<?>> vacationTypes, List<Application> applications) {
         Assert.isTrue(from.getYear() == to.getYear(), "From and to must be in the same year");
 
         final List<Account> holidayAccounts = accountService.getHolidaysAccount(from.getYear(), persons);
-        final List<Person> personsWithAccount = holidayAccounts.stream().map(Account::getPerson).toList();
 
-        return buildStatistics(new DateRange(from, to), personsWithAccount, holidayAccounts, applications, vacationTypes);
+        return buildStatistics(new DateRange(from, to), persons, holidayAccounts, applications, vacationTypes);
     }
 
     private Map<Person, Optional<ApplicationForLeaveStatistics>> buildStatistics(DateRange dateRange, List<Person> persons, List<Account> holidayAccounts, List<Application> applications, List<VacationType<?>> vacationTypes) {
@@ -90,9 +100,11 @@ class ApplicationForLeaveStatisticsBuilder {
         final Map<Person, Optional<ApplicationForLeaveStatistics>> statisticsByPerson =
             getStatisticsByPersonWithoutApplicationInfo(dateRange, persons, holidayAccounts, applications, vacationTypes);
 
-        addApplicationInfosToStatistics(dateRange, persons, statisticsByPerson);
-
+        // persons without a holiday account for the requested year get no statistics. Register them before tallying,
+        // so that the tally below can rely on every person having an entry.
         addMissingPersonsToStatistics(statisticsByPerson, persons);
+
+        addApplicationInfosToStatistics(dateRange, persons, statisticsByPerson);
 
         return statisticsByPerson;
     }
@@ -162,19 +174,21 @@ class ApplicationForLeaveStatisticsBuilder {
                 .collect(groupingBy(Application::getPerson));
 
         for (Person person : persons) {
-            final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarsByPerson.get(person);
-            final List<Application> personApplications = applicationsByPerson.getOrDefault(person, List.of());
-            for (Application application : personApplications) {
+            final Optional<ApplicationForLeaveStatistics> maybeStatistics = statisticsByPerson.get(person);
+            if (maybeStatistics.isEmpty()) {
+                // no holiday account for the requested year, so there is nothing to tally the applications into
+                continue;
+            }
 
+            final ApplicationForLeaveStatistics statistics = maybeStatistics.get();
+            final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarsByPerson.get(person);
+
+            for (Application application : applicationsByPerson.getOrDefault(person, List.of())) {
                 final BigDecimal workingTime = workingTimeCalendar.workingTimeInDateRage(application, dateRange);
-                final Optional<ApplicationForLeaveStatistics> maybeStatistics = statisticsByPerson.get(application.getPerson());
-                if (maybeStatistics.isPresent()) {
-                    final ApplicationForLeaveStatistics statistics = maybeStatistics.get();
-                    if (application.hasStatus(WAITING) || application.hasStatus(TEMPORARY_ALLOWED)) {
-                        statistics.addWaitingVacationDays(application.getVacationType(), workingTime);
-                    } else if (application.hasStatus(ALLOWED) || application.hasStatus(ALLOWED_CANCELLATION_REQUESTED)) {
-                        statistics.addAllowedVacationDays(application.getVacationType(), workingTime);
-                    }
+                if (application.hasStatus(WAITING) || application.hasStatus(TEMPORARY_ALLOWED)) {
+                    statistics.addWaitingVacationDays(application.getVacationType(), workingTime);
+                } else if (application.hasStatus(ALLOWED) || application.hasStatus(ALLOWED_CANCELLATION_REQUESTED)) {
+                    statistics.addAllowedVacationDays(application.getVacationType(), workingTime);
                 }
             }
         }

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsBuilder.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsBuilder.java
@@ -21,9 +21,11 @@ import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.Year;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static java.time.Duration.ZERO;
 import static java.time.temporal.TemporalAdjusters.firstDayOfYear;
@@ -97,14 +99,19 @@ class ApplicationForLeaveStatisticsBuilder {
 
     private Map<Person, Optional<ApplicationForLeaveStatistics>> buildStatistics(DateRange dateRange, List<Person> persons, List<Account> holidayAccounts, List<Application> applications, List<VacationType<?>> vacationTypes) {
 
+        // computed once and threaded through both collaborators below, instead of letting each of them recompute the
+        // very same day-by-day calendar for the same persons and year.
+        final Map<Person, WorkingTimeCalendar> workingTimeCalendarsByPerson =
+            workingTimeCalendarService.getWorkingTimesByPersons(persons, Year.of(dateRange.startDate().getYear()));
+
         final Map<Person, Optional<ApplicationForLeaveStatistics>> statisticsByPerson =
-            getStatisticsByPersonWithoutApplicationInfo(dateRange, persons, holidayAccounts, applications, vacationTypes);
+            getStatisticsByPersonWithoutApplicationInfo(dateRange, persons, holidayAccounts, applications, vacationTypes, workingTimeCalendarsByPerson);
 
         // persons without a holiday account for the requested year get no statistics. Register them before tallying,
         // so that the tally below can rely on every person having an entry.
         addMissingPersonsToStatistics(statisticsByPerson, persons);
 
-        addApplicationInfosToStatistics(dateRange, persons, statisticsByPerson);
+        addApplicationInfosToStatistics(dateRange, persons, applications, workingTimeCalendarsByPerson, statisticsByPerson);
 
         return statisticsByPerson;
     }
@@ -115,13 +122,13 @@ class ApplicationForLeaveStatisticsBuilder {
         );
     }
 
-    private Map<Person, Optional<ApplicationForLeaveStatistics>> getStatisticsByPersonWithoutApplicationInfo(DateRange dateRange, List<Person> persons, List<Account> holidayAccounts, List<Application> applications, List<VacationType<?>> vacationTypes) {
+    private Map<Person, Optional<ApplicationForLeaveStatistics>> getStatisticsByPersonWithoutApplicationInfo(DateRange dateRange, List<Person> persons, List<Account> holidayAccounts, List<Application> applications, List<VacationType<?>> vacationTypes, Map<Person, WorkingTimeCalendar> workingTimeCalendarsByPerson) {
 
         final LocalDate from = dateRange.startDate();
         final LocalDate to = dateRange.endDate();
 
         final Map<Person, LeftOvertime> leftOvertimeByPerson = overtimeService.getLeftOvertimeTotalAndDateRangeForPersons(persons, applications, from, to);
-        final Map<Account, HolidayAccountVacationDays> vacationDaysByAccount = vacationDaysService.getVacationDaysLeft(holidayAccounts, dateRange);
+        final Map<Account, HolidayAccountVacationDays> vacationDaysByAccount = vacationDaysService.getVacationDaysLeft(holidayAccounts, dateRange, List.of(), workingTimeCalendarsByPerson);
 
         return holidayAccounts.stream()
             .map(account -> buildStatisticsForAccount(dateRange, account, vacationTypes, vacationDaysByAccount, leftOvertimeByPerson))
@@ -160,18 +167,18 @@ class ApplicationForLeaveStatisticsBuilder {
         return statistics;
     }
 
-    private void addApplicationInfosToStatistics(DateRange dateRange, List<Person> persons, Map<Person, Optional<ApplicationForLeaveStatistics>> statisticsByPerson) {
+    private void addApplicationInfosToStatistics(DateRange dateRange, List<Person> persons, List<Application> applications, Map<Person, WorkingTimeCalendar> workingTimeCalendarsByPerson, Map<Person, Optional<ApplicationForLeaveStatistics>> statisticsByPerson) {
 
         final LocalDate from = dateRange.startDate();
         final LocalDate to = dateRange.endDate();
 
-        final Map<Person, WorkingTimeCalendar> workingTimeCalendarsByPerson =
-            workingTimeCalendarService.getWorkingTimesByPersons(persons, Year.of(from.getYear()));
-
-        final Map<Person, List<Application>> applicationsByPerson =
-            applicationService.getApplicationsForACertainPeriodAndStatus(from, to, persons, activeStatuses())
-                .stream()
-                .collect(groupingBy(Application::getPerson));
+        // `applications` already covers the whole year for these persons, narrow it to the requested period in memory
+        // instead of asking the database again for what is essentially a subset of what we already hold.
+        final Set<Person> personsOfInterest = new HashSet<>(persons);
+        final Map<Person, List<Application>> applicationsByPerson = applications.stream()
+            .filter(application -> personsOfInterest.contains(application.getPerson()))
+            .filter(application -> !application.getEndDate().isBefore(from) && !application.getStartDate().isAfter(to))
+            .collect(groupingBy(Application::getPerson));
 
         for (Person person : persons) {
             final Optional<ApplicationForLeaveStatistics> maybeStatistics = statisticsByPerson.get(person);

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsService.java
@@ -28,6 +28,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.StreamSupport;
 
+import static java.time.temporal.TemporalAdjusters.firstDayOfYear;
+import static java.time.temporal.TemporalAdjusters.lastDayOfYear;
 import static org.synyx.urlaubsverwaltung.application.application.ApplicationStatus.activeStatuses;
 import static org.synyx.urlaubsverwaltung.person.Role.BOSS;
 import static org.synyx.urlaubsverwaltung.person.Role.OFFICE;
@@ -97,7 +99,7 @@ class ApplicationForLeaveStatisticsService {
         final List<VacationType<?>> vacationTypes = vacationTypeService.getActiveVacationTypes();
 
         final List<Application> allApplications =
-            getApplicationsOfInterest(period.startDate(), period.endDate(), vacationTypes, query);
+            getApplicationsOfInterest(period.startDate(), period.endDate(), query);
 
         // fetch all allowed persons, there may be persons without applications
         final List<Person> persons = getAllRelevantPersons(person, PersonPageRequest.unpaged(), query).getContent();
@@ -124,8 +126,9 @@ class ApplicationForLeaveStatisticsService {
             statisticsByPerson = applicationForLeaveStatisticsBuilder.build(sortedPersons, period.startDate(), period.endDate(), vacationTypes, applications);
         }
 
+        // a person without statistics must not take the whole page down, no matter which builder path produced the map
         final List<ApplicationForLeaveStatistics> sortedStatistics = sortedPersons.stream()
-            .map(statisticsByPerson::get)
+            .map(person -> statisticsByPerson.getOrDefault(person, Optional.empty()))
             .flatMap(Optional::stream)
             .toList();
 
@@ -145,9 +148,19 @@ class ApplicationForLeaveStatisticsService {
         return statistics;
     }
 
-    private List<Application> getApplicationsOfInterest(LocalDate from, LocalDate to, List<VacationType<?>> vacationTypes, String personQuery) {
+    /**
+     * Fetches every application of the requested year, not just the ones of the requested period, and without
+     * restricting them to the currently active {@link VacationType}s.
+     *
+     * <p>
+     * Both are required by {@link ApplicationForLeaveStatisticsBuilder}: the left overtime <em>of the year</em> is
+     * derived from this list, so narrowing it to the requested period would understate it, and vacation types that
+     * have been deactivated in the meantime must still show up for the persons who used them.
+     */
+    private List<Application> getApplicationsOfInterest(LocalDate from, LocalDate to, String personQuery) {
         Assert.isTrue(from.getYear() == to.getYear(), "From and to must be in the same year");
-        return applicationService.getApplicationsForACertainPeriodAndStatus(from, to, activeStatuses(), vacationTypes, personQuery);
+        return applicationService.getApplicationsForACertainPeriodAndStatus(
+            from.with(firstDayOfYear()), from.with(lastDayOfYear()), activeStatuses(), personQuery);
     }
 
     private Page<Person> getAllRelevantPersons(Person person, PersonPageRequest pageRequest, String query) {

--- a/src/main/java/org/synyx/urlaubsverwaltung/person/Person.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/person/Person.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.SequenceGenerator;
+import org.hibernate.annotations.BatchSize;
 import org.synyx.urlaubsverwaltung.tenancy.tenant.AbstractTenantAwareEntity;
 
 import java.util.Collection;
@@ -27,6 +28,7 @@ import static org.synyx.urlaubsverwaltung.person.Role.privilegedRoles;
  * This class describes a person.
  */
 @Entity
+@BatchSize(size = 500)
 public class Person extends AbstractTenantAwareEntity {
 
     @Id
@@ -45,10 +47,12 @@ public class Person extends AbstractTenantAwareEntity {
 
     @ElementCollection(fetch = EAGER)
     @Enumerated(STRING)
+    @BatchSize(size = 500)
     private Collection<Role> permissions;
 
     @ElementCollection(fetch = EAGER)
     @Enumerated(STRING)
+    @BatchSize(size = 500)
     private Collection<MailNotification> notifications;
 
     public Person() {

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationRepositoryIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationRepositoryIT.java
@@ -20,6 +20,7 @@ import org.synyx.urlaubsverwaltung.person.PersonService;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 import static java.time.Month.MAY;
@@ -705,6 +706,50 @@ class ApplicationRepositoryIT extends SingleTenantTestContainersBase {
 
         // fetching two more applications and their holidayReplacements must not cost any extra queries
         assertThat(statementsForThreeApplications).isEqualTo(statementsForOneApplication);
+    }
+
+    @Test
+    void ensureApplicantsAreFetchedWithoutOneQueryPerApplicant() {
+
+        // one application per person, so that the number of distinct applicants to resolve for the eager
+        // `person` association is the only thing that differs between the two measurements below.
+        final VacationTypeEntity vacationType = getVacationType(HOLIDAY);
+        final LocalDate askedStartDate = LocalDate.now(UTC).with(firstDayOfMonth());
+        final LocalDate askedEndDate = LocalDate.now(UTC).with(lastDayOfMonth());
+
+        final List<Person> persons = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            final Person person = personService.create("username_" + i, "First" + i, "Last" + i, "user" + i + "@example.org");
+            persons.add(person);
+
+            final ApplicationEntity application = applicationEntity(person, vacationType, askedStartDate, askedEndDate, FULL);
+            application.setStatus(WAITING);
+            sut.save(application);
+        }
+
+        final long statementsForOneApplicant = fetchAndTouchApplicants(persons.subList(0, 1), askedStartDate, askedEndDate, 1);
+        final long statementsForThreeApplicants = fetchAndTouchApplicants(persons, askedStartDate, askedEndDate, 3);
+
+        // resolving two more distinct applicants must not cost any extra queries
+        assertThat(statementsForThreeApplicants).isEqualTo(statementsForOneApplicant);
+    }
+
+    private long fetchAndTouchApplicants(List<Person> persons, LocalDate from, LocalDate to, int expectedApplicationCount) {
+
+        // force the next query to actually hit the database instead of returning managed entities from the session cache
+        entityManager.flush();
+        entityManager.clear();
+
+        final Statistics statistics = entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+        statistics.setStatisticsEnabled(true);
+        statistics.clear();
+
+        final List<ApplicationEntity> applications = sut.findByPersonInAndEndDateIsGreaterThanEqualAndStartDateIsLessThanEqualAndStatusIn(
+            persons, from, to, List.of(WAITING));
+        applications.forEach(application -> application.getPerson().getPermissions().size());
+
+        assertThat(applications).hasSize(expectedApplicationCount);
+        return statistics.getPrepareStatementCount();
     }
 
     private long fetchAndTouchHolidayReplacements(Person person, LocalDate from, LocalDate to, int expectedApplicationCount) {

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationRepositoryIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationRepositoryIT.java
@@ -708,6 +708,33 @@ class ApplicationRepositoryIT extends SingleTenantTestContainersBase {
         assertThat(statementsForThreeApplications).isEqualTo(statementsForOneApplication);
     }
 
+    /**
+     * The leave statistics report the absences someone took with a vacation type that has been deactivated since,
+     * so this query must not restrict its result to the currently active vacation types.
+     */
+    @Test
+    void ensureApplicationsOfDeactivatedVacationTypesAreFound() {
+
+        final Person person = personService.create("muster", "Max", "Mustermann", "mustermann@example.org");
+
+        final VacationTypeEntity deactivatedVacationType = getVacationType(HOLIDAY);
+        deactivatedVacationType.setActive(false);
+        entityManager.merge(deactivatedVacationType);
+
+        final LocalDate askedStartDate = LocalDate.now(UTC).with(firstDayOfMonth());
+        final LocalDate askedEndDate = LocalDate.now(UTC).with(lastDayOfMonth());
+
+        final ApplicationEntity application = applicationEntity(person, deactivatedVacationType, askedStartDate, askedEndDate, FULL);
+        application.setStatus(WAITING);
+        sut.save(application);
+
+        final List<ApplicationEntity> actual = sut.findByEndDateIsGreaterThanEqualAndStartDateIsLessThanEqualAndStatusInAndPersonNiceNameContainingIgnoreCase(
+            askedStartDate, askedEndDate, List.of(WAITING), "");
+
+        assertThat(actual).containsExactly(application);
+        assertThat(actual.getFirst().getVacationType().isActive()).isFalse();
+    }
+
     @Test
     void ensureApplicantsAreFetchedWithoutOneQueryPerApplicant() {
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationRepositoryIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationRepositoryIT.java
@@ -1,5 +1,9 @@
 package org.synyx.urlaubsverwaltung.application.application;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -51,6 +55,10 @@ class ApplicationRepositoryIT extends SingleTenantTestContainersBase {
     private PersonService personService;
     @Autowired
     private VacationTypeService vacationTypeService;
+    @Autowired
+    private EntityManager entityManager;
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
 
     @Test
     void ensureApplicationForLeaveForStatusAndPersonAndWithinDateRange() {
@@ -664,6 +672,57 @@ class ApplicationRepositoryIT extends SingleTenantTestContainersBase {
         final List<ApplicationEntity> applicationsByHolidayReplacement = sut.findAllByHolidayReplacements_Person(person);
 
         assertThat(applicationsByHolidayReplacement).contains(application);
+    }
+
+    @Test
+    void ensureHolidayReplacementsAreFetchedWithoutOneQueryPerApplication() {
+
+        // one applicant and one holiday replacement, reused for every application, so that unrelated eager
+        // associations (person, vacation type, ...) are loaded at most once and don't confound the measurement.
+        final Person person = personService.create("muster", "Max", "Mustermann", "mustermann@example.org");
+        final Person replacementPerson = personService.create("holly", "Holly", "Replacement", "holly@example.org");
+        final VacationTypeEntity vacationType = getVacationType(HOLIDAY);
+
+        final LocalDate askedStartDate = LocalDate.now(UTC).with(firstDayOfMonth());
+        final LocalDate askedEndDate = LocalDate.now(UTC).with(lastDayOfMonth());
+
+        for (int i = 0; i < 3; i++) {
+            final HolidayReplacementEntity replacement = new HolidayReplacementEntity();
+            replacement.setPerson(replacementPerson);
+
+            final LocalDate day = askedStartDate.plusDays(i);
+            final ApplicationEntity application = applicationEntity(person, vacationType, day, day, FULL);
+            application.setHolidayReplacements(List.of(replacement));
+            application.setStatus(WAITING);
+            sut.save(application);
+        }
+
+        // only the last of the three applications matches (end_date >= askedStartDate.plusDays(2))
+        final long statementsForOneApplication = fetchAndTouchHolidayReplacements(person, askedStartDate.plusDays(2), askedEndDate, 1);
+
+        // all three applications match (end_date >= askedStartDate)
+        final long statementsForThreeApplications = fetchAndTouchHolidayReplacements(person, askedStartDate, askedEndDate, 3);
+
+        // fetching two more applications and their holidayReplacements must not cost any extra queries
+        assertThat(statementsForThreeApplications).isEqualTo(statementsForOneApplication);
+    }
+
+    private long fetchAndTouchHolidayReplacements(Person person, LocalDate from, LocalDate to, int expectedApplicationCount) {
+
+        // force the next query to actually hit the database instead of returning managed entities from the session cache
+        entityManager.flush();
+        entityManager.clear();
+
+        final Statistics statistics = entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+        statistics.setStatisticsEnabled(true);
+        statistics.clear();
+
+        final List<ApplicationEntity> applications = sut.findByPersonInAndEndDateIsGreaterThanEqualAndStartDateIsLessThanEqualAndStatusIn(
+            List.of(person), from, to, List.of(WAITING));
+        applications.forEach(application -> application.getHolidayReplacements().size());
+
+        assertThat(applications).hasSize(expectedApplicationCount);
+        return statistics.getPrepareStatementCount();
     }
 
     private VacationTypeEntity getVacationType(VacationCategory category) {

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationRepositoryIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationRepositoryIT.java
@@ -717,9 +717,9 @@ class ApplicationRepositoryIT extends SingleTenantTestContainersBase {
 
         final Person person = personService.create("muster", "Max", "Mustermann", "mustermann@example.org");
 
-        final VacationTypeEntity deactivatedVacationType = getVacationType(HOLIDAY);
-        deactivatedVacationType.setActive(false);
-        entityManager.merge(deactivatedVacationType);
+        final VacationTypeEntity vacationType = getVacationType(HOLIDAY);
+        vacationType.setActive(false);
+        final VacationTypeEntity deactivatedVacationType = entityManager.merge(vacationType);
 
         final LocalDate askedStartDate = LocalDate.now(UTC).with(firstDayOfMonth());
         final LocalDate askedEndDate = LocalDate.now(UTC).with(lastDayOfMonth());

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationServiceImplTest.java
@@ -485,19 +485,15 @@ class ApplicationServiceImplTest {
             final LocalDate endDate = LocalDate.parse("2025-01-31");
             final List<ApplicationStatus> statuses = List.of(WAITING, ALLOWED);
 
-            final VacationType<?> vacationType1 = ProvidedVacationType.builder(messageSource).id(1L).build();
-            final VacationType<?> vacationType2 = ProvidedVacationType.builder(messageSource).id(2L).build();
-            final List<VacationType<?>> vacationTypes = List.of(vacationType1, vacationType2);
-
             final ApplicationEntity applicationEntity = new ApplicationEntity();
             applicationEntity.setId(1L);
             applicationEntity.setVacationType(new VacationTypeEntity());
 
             when(applicationRepository.findByEndDateIsGreaterThanEqualAndStartDateIsLessThanEqualAndStatusInAndPersonNiceNameContainingIgnoreCase(
-                startDate, endDate, statuses, List.of(1L, 2L), ""))
+                startDate, endDate, statuses, ""))
                 .thenReturn(List.of(applicationEntity));
 
-            final List<Application> actual = sut.getApplicationsForACertainPeriodAndStatus(startDate, endDate, statuses, vacationTypes, null);
+            final List<Application> actual = sut.getApplicationsForACertainPeriodAndStatus(startDate, endDate, statuses, null);
 
             final Application expectedApplication = new Application();
             expectedApplication.setId(1L);
@@ -511,18 +507,15 @@ class ApplicationServiceImplTest {
             final LocalDate endDate = LocalDate.parse("2025-01-31");
             final List<ApplicationStatus> statuses = List.of(WAITING, ALLOWED);
 
-            final VacationType<?> vacationType = ProvidedVacationType.builder(messageSource).id(1L).build();
-            final List<VacationType<?>> vacationTypes = List.of(vacationType);
-
             final ApplicationEntity applicationEntity = new ApplicationEntity();
             applicationEntity.setId(1L);
             applicationEntity.setVacationType(new VacationTypeEntity());
 
             when(applicationRepository.findByEndDateIsGreaterThanEqualAndStartDateIsLessThanEqualAndStatusInAndPersonNiceNameContainingIgnoreCase(
-                startDate, endDate, statuses, List.of(1L), ""))
+                startDate, endDate, statuses, ""))
                 .thenReturn(List.of(applicationEntity));
 
-            final List<Application> actual = sut.getApplicationsForACertainPeriodAndStatus(startDate, endDate, statuses, vacationTypes, givenQuery);
+            final List<Application> actual = sut.getApplicationsForACertainPeriodAndStatus(startDate, endDate, statuses, givenQuery);
 
             final Application expectedApplication = new Application();
             expectedApplication.setId(1L);
@@ -535,18 +528,15 @@ class ApplicationServiceImplTest {
             final LocalDate endDate = LocalDate.parse("2025-01-31");
             final List<ApplicationStatus> statuses = List.of(WAITING, ALLOWED);
 
-            final VacationType<?> vacationType = ProvidedVacationType.builder(messageSource).id(1L).build();
-            final List<VacationType<?>> vacationTypes = List.of(vacationType);
-
             final ApplicationEntity applicationEntity = new ApplicationEntity();
             applicationEntity.setId(1L);
             applicationEntity.setVacationType(new VacationTypeEntity());
 
             when(applicationRepository.findByEndDateIsGreaterThanEqualAndStartDateIsLessThanEqualAndStatusInAndPersonNiceNameContainingIgnoreCase(
-                startDate, endDate, statuses, List.of(1L), "John"))
+                startDate, endDate, statuses, "John"))
                 .thenReturn(List.of(applicationEntity));
 
-            final List<Application> actual = sut.getApplicationsForACertainPeriodAndStatus(startDate, endDate, statuses, vacationTypes, "John");
+            final List<Application> actual = sut.getApplicationsForACertainPeriodAndStatus(startDate, endDate, statuses, "John");
 
             final Application expectedApplication = new Application();
             expectedApplication.setId(1L);
@@ -554,44 +544,29 @@ class ApplicationServiceImplTest {
         }
 
         @Test
-        void ensureGetApplicationsForACertainPeriodWithMultipleVacationTypes() {
+        void ensureGetApplicationsForACertainPeriodDoesNotRestrictToCertainVacationTypes() {
             final LocalDate startDate = LocalDate.parse("2025-01-01");
             final LocalDate endDate = LocalDate.parse("2025-01-31");
             final List<ApplicationStatus> statuses = List.of(WAITING, ALLOWED);
 
-            final VacationType<?> vacationType1 = ProvidedVacationType.builder(messageSource).id(5L).build();
-            final VacationType<?> vacationType2 = ProvidedVacationType.builder(messageSource).id(10L).build();
-            final VacationType<?> vacationType3 = ProvidedVacationType.builder(messageSource).id(15L).build();
-            final List<VacationType<?>> vacationTypes = List.of(vacationType1, vacationType2, vacationType3);
+            // an application of a vacation type that has been deactivated in the meantime must still be returned,
+            // callers rely on it to keep reporting the absences someone already took with that type.
+            final VacationTypeEntity deactivatedVacationType = new VacationTypeEntity();
+            deactivatedVacationType.setId(99L);
+            deactivatedVacationType.setActive(false);
 
             final ApplicationEntity applicationEntity = new ApplicationEntity();
             applicationEntity.setId(1L);
-            applicationEntity.setVacationType(new VacationTypeEntity());
+            applicationEntity.setVacationType(deactivatedVacationType);
 
             when(applicationRepository.findByEndDateIsGreaterThanEqualAndStartDateIsLessThanEqualAndStatusInAndPersonNiceNameContainingIgnoreCase(
-                startDate, endDate, statuses, List.of(5L, 10L, 15L), "Smith"))
+                startDate, endDate, statuses, "Smith"))
                 .thenReturn(List.of(applicationEntity));
 
-            final List<Application> actual = sut.getApplicationsForACertainPeriodAndStatus(startDate, endDate, statuses, vacationTypes, "Smith");
+            final List<Application> actual = sut.getApplicationsForACertainPeriodAndStatus(startDate, endDate, statuses, "Smith");
 
-            final Application expectedApplication = new Application();
-            expectedApplication.setId(1L);
-            assertThat(actual).containsExactly(expectedApplication);
-        }
-
-        @Test
-        void ensureGetApplicationsForACertainPeriodWithEmptyVacationTypesList() {
-            final LocalDate startDate = LocalDate.parse("2025-01-01");
-            final LocalDate endDate = LocalDate.parse("2025-01-31");
-            final List<ApplicationStatus> statuses = List.of(WAITING, ALLOWED);
-            final List<VacationType<?>> vacationTypes = List.of();
-
-            when(applicationRepository.findByEndDateIsGreaterThanEqualAndStartDateIsLessThanEqualAndStatusInAndPersonNiceNameContainingIgnoreCase(
-                startDate, endDate, statuses, List.of(), ""))
-                .thenReturn(List.of());
-
-            final List<Application> actual = sut.getApplicationsForACertainPeriodAndStatus(startDate, endDate, statuses, vacationTypes, null);
-            assertThat(actual).isEmpty();
+            assertThat(actual).hasSize(1);
+            assertThat(actual.getFirst().getVacationType().getId()).isEqualTo(99L);
         }
 
         @Test
@@ -601,9 +576,6 @@ class ApplicationServiceImplTest {
             final LocalDate startDate = LocalDate.parse("2025-01-01");
             final LocalDate endDate = LocalDate.parse("2025-01-31");
             final List<ApplicationStatus> statuses = List.of(WAITING);
-
-            final VacationType<?> vacationType = ProvidedVacationType.builder(messageSource).id(1L).build();
-            final List<VacationType<?>> vacationTypes = List.of(vacationType);
 
             final Person person = new Person();
             person.setId(1L);
@@ -627,10 +599,10 @@ class ApplicationServiceImplTest {
             applicationEntity.setDayLength(DayLength.FULL);
 
             when(applicationRepository.findByEndDateIsGreaterThanEqualAndStartDateIsLessThanEqualAndStatusInAndPersonNiceNameContainingIgnoreCase(
-                startDate, endDate, statuses, List.of(1L), "test"))
+                startDate, endDate, statuses, "test"))
                 .thenReturn(List.of(applicationEntity));
 
-            final List<Application> actual = sut.getApplicationsForACertainPeriodAndStatus(startDate, endDate, statuses, vacationTypes, "test");
+            final List<Application> actual = sut.getApplicationsForACertainPeriodAndStatus(startDate, endDate, statuses, "test");
 
             assertThat(actual).hasSize(1);
             assertThat(actual.getFirst()).satisfies(application -> {

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsBuilderTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsBuilderTest.java
@@ -44,6 +44,10 @@ import static java.time.temporal.TemporalAdjusters.firstDayOfYear;
 import static java.time.temporal.TemporalAdjusters.lastDayOfYear;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.synyx.urlaubsverwaltung.TestDataCreator.createVacationTypes;
 import static org.synyx.urlaubsverwaltung.application.application.ApplicationStatus.ALLOWED;
@@ -51,6 +55,7 @@ import static org.synyx.urlaubsverwaltung.application.application.ApplicationSta
 import static org.synyx.urlaubsverwaltung.application.application.ApplicationStatus.TEMPORARY_ALLOWED;
 import static org.synyx.urlaubsverwaltung.application.application.ApplicationStatus.WAITING;
 import static org.synyx.urlaubsverwaltung.application.application.ApplicationStatus.activeStatuses;
+import static org.synyx.urlaubsverwaltung.application.vacationtype.VacationCategory.HOLIDAY;
 import static org.synyx.urlaubsverwaltung.period.DayLength.FULL;
 import static org.synyx.urlaubsverwaltung.workingtime.WorkingTimeCalendarFactory.workingTimeCalendarMondayToSunday;
 
@@ -124,7 +129,7 @@ class ApplicationForLeaveStatisticsBuilderTest {
         final VacationDaysLeft personVacationDaysLeftPeriod = VacationDaysLeft.builder().withAnnualVacation(BigDecimal.valueOf(5)).build();
         final HolidayAccountVacationDays personVacationDays = new HolidayAccountVacationDays(account, personVacationDaysLeftYear, personVacationDaysLeftPeriod);
 
-        when(vacationDaysService.getVacationDaysLeft(List.of(account), dateRange)).thenReturn(Map.of(account, personVacationDays));
+        when(vacationDaysService.getVacationDaysLeft(List.of(account), dateRange, List.of(), Map.of(person, workingTimeCalendar))).thenReturn(Map.of(account, personVacationDays));
 
         final VacationType<?> type = ProvidedVacationType.builder(new StaticMessageSource()).build();
 
@@ -183,7 +188,7 @@ class ApplicationForLeaveStatisticsBuilderTest {
         final VacationDaysLeft personVacationDaysLeftPeriod = VacationDaysLeft.builder().withAnnualVacation(BigDecimal.valueOf(5)).build();
         final HolidayAccountVacationDays personVacationDays = new HolidayAccountVacationDays(account, personVacationDaysLeftYear, personVacationDaysLeftPeriod);
 
-        when(vacationDaysService.getVacationDaysLeft(List.of(account), dateRange)).thenReturn(Map.of(account, personVacationDays));
+        when(vacationDaysService.getVacationDaysLeft(List.of(account), dateRange, List.of(), Map.of(person, workingTimeCalendar))).thenReturn(Map.of(account, personVacationDays));
 
         final VacationType<?> type = ProvidedVacationType.builder(new StaticMessageSource()).build();
 
@@ -250,7 +255,7 @@ class ApplicationForLeaveStatisticsBuilderTest {
 
         final HolidayAccountVacationDays personVacationDays = new HolidayAccountVacationDays(account, personVacationDaysLeftYear, personVacationDaysLeftPeriod);
 
-        when(vacationDaysService.getVacationDaysLeft(List.of(account), dateRange)).thenReturn(Map.of(account, personVacationDays));
+        when(vacationDaysService.getVacationDaysLeft(List.of(account), dateRange, List.of(), Map.of(person, workingTimeCalendar))).thenReturn(Map.of(account, personVacationDays));
 
         final VacationType<?> type = ProvidedVacationType.builder(new StaticMessageSource()).build();
 
@@ -315,7 +320,7 @@ class ApplicationForLeaveStatisticsBuilderTest {
 
         final HolidayAccountVacationDays personVacationDays = new HolidayAccountVacationDays(account, personVacationDaysLeftYear, personVacationDaysLeftPeriod);
 
-        when(vacationDaysService.getVacationDaysLeft(List.of(account), dateRange)).thenReturn(Map.of(account, personVacationDays));
+        when(vacationDaysService.getVacationDaysLeft(List.of(account), dateRange, List.of(), Map.of(person, workingTimeCalendar))).thenReturn(Map.of(account, personVacationDays));
 
         final VacationType<?> type = ProvidedVacationType.builder(new StaticMessageSource()).build();
 
@@ -428,7 +433,7 @@ class ApplicationForLeaveStatisticsBuilderTest {
 
         final HolidayAccountVacationDays personVacationDays = new HolidayAccountVacationDays(account, personVacationDaysLeftYear, VacationDaysLeft.builder().build());
 
-        when(vacationDaysService.getVacationDaysLeft(List.of(account), dateRange)).thenReturn(Map.of(account, personVacationDays));
+        when(vacationDaysService.getVacationDaysLeft(List.of(account), dateRange, List.of(), Map.of(person, workingTimeCalendar))).thenReturn(Map.of(account, personVacationDays));
 
         final VacationType<?> type = ProvidedVacationType.builder(new StaticMessageSource()).build();
 
@@ -478,7 +483,7 @@ class ApplicationForLeaveStatisticsBuilderTest {
         final VacationDaysLeft personVacationDaysLeftPeriod = VacationDaysLeft.builder().build();
         final HolidayAccountVacationDays personVacationDays = new HolidayAccountVacationDays(account, personVacationDaysLeftYear, personVacationDaysLeftPeriod);
 
-        when(vacationDaysService.getVacationDaysLeft(List.of(account), dateRange)).thenReturn(Map.of(account, personVacationDays));
+        when(vacationDaysService.getVacationDaysLeft(List.of(account), dateRange, List.of(), Map.of(person, workingTimeCalendar))).thenReturn(Map.of(account, personVacationDays));
 
         final VacationType<?> type = ProvidedVacationType.builder(new StaticMessageSource()).build();
 
@@ -493,6 +498,206 @@ class ApplicationForLeaveStatisticsBuilderTest {
             assertThat(value.getLeftOvertimeForYear()).isEqualTo(Duration.ofHours(9));
             assertThat(value.getLeftOvertimeForPeriod()).isEqualTo(Duration.ofHours(3));
         });
+    }
+
+    /**
+     * A vacation type that has been deactivated is not part of the vacation types the statistics are built for, so it
+     * must only show up for the persons who actually took an absence with it - and it must still be counted for them.
+     */
+    @Test
+    void ensureDeactivatedVacationTypeIsOnlyShownForThePersonWhoUsedIt() {
+
+        final LocalDate from = of(2014, JANUARY, 1);
+        final LocalDate to = of(2014, DECEMBER, 31);
+        final DateRange dateRange = new DateRange(from, to);
+        final LocalDate expiryDate = of(2014, APRIL, 1);
+
+        final Person personWithAbsence = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        personWithAbsence.setId(1L);
+        final Person personWithoutAbsence = new Person("other", "Other", "Otto", "other@example.org");
+        personWithoutAbsence.setId(2L);
+        final List<Person> persons = List.of(personWithAbsence, personWithoutAbsence);
+
+        final Account accountWithAbsence = new Account(personWithAbsence, from, to, false, expiryDate, TEN, TEN, TEN, null);
+        final Account accountWithoutAbsence = new Account(personWithoutAbsence, from, to, false, expiryDate, TEN, TEN, TEN, null);
+        final List<Account> accounts = List.of(accountWithAbsence, accountWithoutAbsence);
+        when(accountService.getHolidaysAccount(2014, persons)).thenReturn(accounts);
+
+        final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(from, to);
+        final Map<Person, WorkingTimeCalendar> workingTimeCalendars =
+            Map.of(personWithAbsence, workingTimeCalendar, personWithoutAbsence, workingTimeCalendar);
+        when(workingTimeCalendarService.getWorkingTimesByPersons(persons, Year.of(2014))).thenReturn(workingTimeCalendars);
+
+        final VacationType<?> deactivatedVacationType = ProvidedVacationType.builder(new StaticMessageSource())
+            .id(4711L).active(false).category(HOLIDAY).messageKey("deactivated").build();
+
+        final Application absenceOfDeactivatedType = new Application();
+        absenceOfDeactivatedType.setPerson(personWithAbsence);
+        absenceOfDeactivatedType.setDayLength(FULL);
+        absenceOfDeactivatedType.setVacationType(deactivatedVacationType);
+        absenceOfDeactivatedType.setStartDate(of(2014, 10, 13));
+        absenceOfDeactivatedType.setEndDate(of(2014, 10, 13));
+        absenceOfDeactivatedType.setStatus(ALLOWED);
+
+        final List<Application> applications = List.of(absenceOfDeactivatedType);
+        when(applicationService.getApplicationsForACertainPeriodAndStatus(from, to, persons, activeStatuses())).thenReturn(applications);
+
+        when(overtimeService.getLeftOvertimeTotalAndDateRangeForPersons(persons, applications, from, to)).thenReturn(Map.of());
+
+        final HolidayAccountVacationDays vacationDaysWithAbsence = new HolidayAccountVacationDays(
+            accountWithAbsence, VacationDaysLeft.builder().build(), VacationDaysLeft.builder().build());
+        final HolidayAccountVacationDays vacationDaysWithoutAbsence = new HolidayAccountVacationDays(
+            accountWithoutAbsence, VacationDaysLeft.builder().build(), VacationDaysLeft.builder().build());
+        when(vacationDaysService.getVacationDaysLeft(accounts, dateRange, List.of(), workingTimeCalendars))
+            .thenReturn(Map.of(accountWithAbsence, vacationDaysWithAbsence, accountWithoutAbsence, vacationDaysWithoutAbsence));
+
+        // the deactivated type is NOT among the vacation types the statistics are built for
+        final VacationType<?> activeVacationType = ProvidedVacationType.builder(new StaticMessageSource())
+            .id(1L).active(true).category(HOLIDAY).messageKey("active").build();
+
+        final Map<Person, Optional<ApplicationForLeaveStatistics>> actual =
+            sut.build(persons, from, to, List.of(activeVacationType));
+
+        assertThat(actual.get(personWithAbsence)).hasValueSatisfying(statistics -> {
+            assertThat(statistics.hasVacationType(deactivatedVacationType)).isTrue();
+            assertThat(statistics.getAllowedVacationDays(deactivatedVacationType)).isEqualTo(BigDecimal.ONE);
+            assertThat(statistics.getTotalAllowedVacationDays()).isEqualTo(BigDecimal.ONE);
+        });
+
+        assertThat(actual.get(personWithoutAbsence)).hasValueSatisfying(statistics ->
+            assertThat(statistics.hasVacationType(deactivatedVacationType)).isFalse());
+    }
+
+    /**
+     * The caller of this overload has already fetched the applications, so the deactivated type must survive that
+     * hand-over too - the sort-by-statistics view of the page uses this overload.
+     */
+    @Test
+    void ensureDeactivatedVacationTypeIsOnlyShownForThePersonWhoUsedItWithGivenApplications() {
+
+        final LocalDate from = of(2014, JANUARY, 1);
+        final LocalDate to = of(2014, DECEMBER, 31);
+        final DateRange dateRange = new DateRange(from, to);
+        final LocalDate expiryDate = of(2014, APRIL, 1);
+
+        final Person personWithAbsence = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        personWithAbsence.setId(1L);
+        final Person personWithoutAbsence = new Person("other", "Other", "Otto", "other@example.org");
+        personWithoutAbsence.setId(2L);
+        final List<Person> persons = List.of(personWithAbsence, personWithoutAbsence);
+
+        final Account accountWithAbsence = new Account(personWithAbsence, from, to, false, expiryDate, TEN, TEN, TEN, null);
+        final Account accountWithoutAbsence = new Account(personWithoutAbsence, from, to, false, expiryDate, TEN, TEN, TEN, null);
+        final List<Account> accounts = List.of(accountWithAbsence, accountWithoutAbsence);
+        when(accountService.getHolidaysAccount(2014, persons)).thenReturn(accounts);
+
+        final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(from, to);
+        final Map<Person, WorkingTimeCalendar> workingTimeCalendars =
+            Map.of(personWithAbsence, workingTimeCalendar, personWithoutAbsence, workingTimeCalendar);
+        when(workingTimeCalendarService.getWorkingTimesByPersons(persons, Year.of(2014))).thenReturn(workingTimeCalendars);
+
+        final VacationType<?> deactivatedVacationType = ProvidedVacationType.builder(new StaticMessageSource())
+            .id(4711L).active(false).category(HOLIDAY).messageKey("deactivated").build();
+
+        final Application absenceOfDeactivatedType = new Application();
+        absenceOfDeactivatedType.setPerson(personWithAbsence);
+        absenceOfDeactivatedType.setDayLength(FULL);
+        absenceOfDeactivatedType.setVacationType(deactivatedVacationType);
+        absenceOfDeactivatedType.setStartDate(of(2014, 10, 13));
+        absenceOfDeactivatedType.setEndDate(of(2014, 10, 13));
+        absenceOfDeactivatedType.setStatus(ALLOWED);
+
+        final List<Application> applications = List.of(absenceOfDeactivatedType);
+
+        when(overtimeService.getLeftOvertimeTotalAndDateRangeForPersons(persons, applications, from, to)).thenReturn(Map.of());
+
+        final HolidayAccountVacationDays vacationDaysWithAbsence = new HolidayAccountVacationDays(
+            accountWithAbsence, VacationDaysLeft.builder().build(), VacationDaysLeft.builder().build());
+        final HolidayAccountVacationDays vacationDaysWithoutAbsence = new HolidayAccountVacationDays(
+            accountWithoutAbsence, VacationDaysLeft.builder().build(), VacationDaysLeft.builder().build());
+        when(vacationDaysService.getVacationDaysLeft(accounts, dateRange, List.of(), workingTimeCalendars))
+            .thenReturn(Map.of(accountWithAbsence, vacationDaysWithAbsence, accountWithoutAbsence, vacationDaysWithoutAbsence));
+
+        final VacationType<?> activeVacationType = ProvidedVacationType.builder(new StaticMessageSource())
+            .id(1L).active(true).category(HOLIDAY).messageKey("active").build();
+
+        final Map<Person, Optional<ApplicationForLeaveStatistics>> actual =
+            sut.build(persons, from, to, List.of(activeVacationType), applications);
+
+        assertThat(actual.get(personWithAbsence)).hasValueSatisfying(statistics -> {
+            assertThat(statistics.hasVacationType(deactivatedVacationType)).isTrue();
+            assertThat(statistics.getTotalAllowedVacationDays()).isEqualTo(BigDecimal.ONE);
+        });
+
+        assertThat(actual.get(personWithoutAbsence)).hasValueSatisfying(statistics ->
+            assertThat(statistics.hasVacationType(deactivatedVacationType)).isFalse());
+    }
+
+    /**
+     * The applications the caller passes in cover the whole year, the tallies only the requested period. Narrowing
+     * that down must happen in memory - asking the database a second time for a subset of what we already hold was
+     * the single most expensive part of building these statistics.
+     */
+    @Test
+    void ensureApplicationsAreNotFetchedAgainAndTheCalendarIsComputedOnlyOnce() {
+
+        final LocalDate from = of(2014, OCTOBER, 1);
+        final LocalDate to = of(2014, OCTOBER, 31);
+        final DateRange dateRange = new DateRange(from, to);
+        final LocalDate expiryDate = of(2014, APRIL, 1);
+
+        final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        person.setId(1L);
+        final List<Person> persons = List.of(person);
+
+        final Account account = new Account(person, of(2014, JANUARY, 1), of(2014, DECEMBER, 31), false, expiryDate, TEN, TEN, TEN, null);
+        final List<Account> accounts = List.of(account);
+        when(accountService.getHolidaysAccount(2014, persons)).thenReturn(accounts);
+
+        final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(of(2014, JANUARY, 1), of(2014, DECEMBER, 31));
+        final Map<Person, WorkingTimeCalendar> workingTimeCalendars = Map.of(person, workingTimeCalendar);
+        when(workingTimeCalendarService.getWorkingTimesByPersons(persons, Year.of(2014))).thenReturn(workingTimeCalendars);
+
+        final VacationType<?> vacationType = ProvidedVacationType.builder(new StaticMessageSource())
+            .id(1L).active(true).category(HOLIDAY).messageKey("active").build();
+
+        // one absence inside the requested period, one outside of it but within the same year
+        final Application insidePeriod = new Application();
+        insidePeriod.setPerson(person);
+        insidePeriod.setDayLength(FULL);
+        insidePeriod.setVacationType(vacationType);
+        insidePeriod.setStartDate(of(2014, 10, 13));
+        insidePeriod.setEndDate(of(2014, 10, 13));
+        insidePeriod.setStatus(ALLOWED);
+
+        final Application outsidePeriod = new Application();
+        outsidePeriod.setPerson(person);
+        outsidePeriod.setDayLength(FULL);
+        outsidePeriod.setVacationType(vacationType);
+        outsidePeriod.setStartDate(of(2014, 3, 13));
+        outsidePeriod.setEndDate(of(2014, 3, 13));
+        outsidePeriod.setStatus(ALLOWED);
+
+        final List<Application> applications = List.of(insidePeriod, outsidePeriod);
+
+        when(overtimeService.getLeftOvertimeTotalAndDateRangeForPersons(persons, applications, from, to)).thenReturn(Map.of());
+
+        final HolidayAccountVacationDays vacationDays = new HolidayAccountVacationDays(
+            account, VacationDaysLeft.builder().build(), VacationDaysLeft.builder().build());
+        when(vacationDaysService.getVacationDaysLeft(accounts, dateRange, List.of(), workingTimeCalendars))
+            .thenReturn(Map.of(account, vacationDays));
+
+        final Map<Person, Optional<ApplicationForLeaveStatistics>> actual =
+            sut.build(persons, from, to, List.of(vacationType), applications);
+
+        // only the absence within the requested period is tallied ...
+        assertThat(actual.get(person)).hasValueSatisfying(statistics ->
+            assertThat(statistics.getTotalAllowedVacationDays()).isEqualTo(BigDecimal.ONE));
+
+        // ... without asking the database again, and without computing the calendar twice
+        verifyNoInteractions(applicationService);
+        verify(workingTimeCalendarService, times(1)).getWorkingTimesByPersons(persons, Year.of(2014));
+        verifyNoMoreInteractions(workingTimeCalendarService);
     }
 
     @Test
@@ -519,7 +724,7 @@ class ApplicationForLeaveStatisticsBuilderTest {
         final Map<Person, LeftOvertime> leftOvertimeByPerson = Map.of(person, new LeftOvertime(Duration.ofHours(9), Duration.ofHours(3)));
         when(overtimeService.getLeftOvertimeTotalAndDateRangeForPersons(persons, applications, from, to)).thenReturn(leftOvertimeByPerson);
 
-        when(vacationDaysService.getVacationDaysLeft(accounts, new DateRange(from, to))).thenReturn(Map.of());
+        when(vacationDaysService.getVacationDaysLeft(accounts, new DateRange(from, to), List.of(), Map.of(person, workingTimeCalendar))).thenReturn(Map.of());
 
         final VacationType<?> type = ProvidedVacationType.builder(new StaticMessageSource()).build();
         final Map<Person, Optional<ApplicationForLeaveStatistics>> actual = sut.build(persons, from, to, List.of(type));
@@ -553,16 +758,16 @@ class ApplicationForLeaveStatisticsBuilderTest {
         when(accountService.getHolidaysAccount(2014, persons)).thenReturn(accounts);
 
         final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(from, to);
-        when(workingTimeCalendarService.getWorkingTimesByPersons(persons, Year.of(2014)))
-            .thenReturn(Map.of(personWithAccount, workingTimeCalendar, personWithoutAccount, workingTimeCalendar));
+        final Map<Person, WorkingTimeCalendar> workingTimeCalendars =
+            Map.of(personWithAccount, workingTimeCalendar, personWithoutAccount, workingTimeCalendar);
+        when(workingTimeCalendarService.getWorkingTimesByPersons(persons, Year.of(2014))).thenReturn(workingTimeCalendars);
 
         final List<Application> applications = List.of();
-        when(applicationService.getApplicationsForACertainPeriodAndStatus(from, to, persons, activeStatuses())).thenReturn(applications);
         when(overtimeService.getLeftOvertimeTotalAndDateRangeForPersons(persons, applications, from, to)).thenReturn(Map.of());
 
         final HolidayAccountVacationDays vacationDays = new HolidayAccountVacationDays(
             account, VacationDaysLeft.builder().build(), VacationDaysLeft.builder().build());
-        when(vacationDaysService.getVacationDaysLeft(accounts, new DateRange(from, to)))
+        when(vacationDaysService.getVacationDaysLeft(accounts, new DateRange(from, to), List.of(), workingTimeCalendars))
             .thenReturn(Map.of(account, vacationDays));
 
         final VacationType<?> type = ProvidedVacationType.builder(new StaticMessageSource()).build();

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsBuilderTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsBuilderTest.java
@@ -38,6 +38,7 @@ import static java.time.LocalDate.of;
 import static java.time.Month.APRIL;
 import static java.time.Month.DECEMBER;
 import static java.time.Month.JANUARY;
+import static java.time.Month.MARCH;
 import static java.time.Month.NOVEMBER;
 import static java.time.Month.OCTOBER;
 import static java.time.temporal.TemporalAdjusters.firstDayOfYear;
@@ -535,8 +536,8 @@ class ApplicationForLeaveStatisticsBuilderTest {
         absenceOfDeactivatedType.setPerson(personWithAbsence);
         absenceOfDeactivatedType.setDayLength(FULL);
         absenceOfDeactivatedType.setVacationType(deactivatedVacationType);
-        absenceOfDeactivatedType.setStartDate(of(2014, 10, 13));
-        absenceOfDeactivatedType.setEndDate(of(2014, 10, 13));
+        absenceOfDeactivatedType.setStartDate(of(2014, OCTOBER, 13));
+        absenceOfDeactivatedType.setEndDate(of(2014, OCTOBER, 13));
         absenceOfDeactivatedType.setStatus(ALLOWED);
 
         final List<Application> applications = List.of(absenceOfDeactivatedType);
@@ -603,8 +604,8 @@ class ApplicationForLeaveStatisticsBuilderTest {
         absenceOfDeactivatedType.setPerson(personWithAbsence);
         absenceOfDeactivatedType.setDayLength(FULL);
         absenceOfDeactivatedType.setVacationType(deactivatedVacationType);
-        absenceOfDeactivatedType.setStartDate(of(2014, 10, 13));
-        absenceOfDeactivatedType.setEndDate(of(2014, 10, 13));
+        absenceOfDeactivatedType.setStartDate(of(2014, OCTOBER, 13));
+        absenceOfDeactivatedType.setEndDate(of(2014, OCTOBER, 13));
         absenceOfDeactivatedType.setStatus(ALLOWED);
 
         final List<Application> applications = List.of(absenceOfDeactivatedType);
@@ -666,16 +667,16 @@ class ApplicationForLeaveStatisticsBuilderTest {
         insidePeriod.setPerson(person);
         insidePeriod.setDayLength(FULL);
         insidePeriod.setVacationType(vacationType);
-        insidePeriod.setStartDate(of(2014, 10, 13));
-        insidePeriod.setEndDate(of(2014, 10, 13));
+        insidePeriod.setStartDate(of(2014, OCTOBER, 13));
+        insidePeriod.setEndDate(of(2014, OCTOBER, 13));
         insidePeriod.setStatus(ALLOWED);
 
         final Application outsidePeriod = new Application();
         outsidePeriod.setPerson(person);
         outsidePeriod.setDayLength(FULL);
         outsidePeriod.setVacationType(vacationType);
-        outsidePeriod.setStartDate(of(2014, 3, 13));
-        outsidePeriod.setEndDate(of(2014, 3, 13));
+        outsidePeriod.setStartDate(of(2014, MARCH, 13));
+        outsidePeriod.setEndDate(of(2014, MARCH, 13));
         outsidePeriod.setStatus(ALLOWED);
 
         final List<Application> applications = List.of(insidePeriod, outsidePeriod);
@@ -741,7 +742,7 @@ class ApplicationForLeaveStatisticsBuilderTest {
      */
     @Test
     void ensureThatAllPersonsThatWhereRequestedAreThereWithOptionalEmptyIfNoAccountWithGivenApplications() {
-        final ApplicationForLeaveStatisticsBuilder sut = new ApplicationForLeaveStatisticsBuilder(accountService, applicationService,
+        final ApplicationForLeaveStatisticsBuilder sutIn2014 = new ApplicationForLeaveStatisticsBuilder(accountService, applicationService,
             workingTimeCalendarService, vacationDaysService, overtimeService, Clock.fixed(Instant.parse("2014-06-24T16:02:42.00Z"), ZoneOffset.UTC));
 
         final LocalDate from = of(2014, JANUARY, 1);
@@ -772,7 +773,7 @@ class ApplicationForLeaveStatisticsBuilderTest {
 
         final VacationType<?> type = ProvidedVacationType.builder(new StaticMessageSource()).build();
         final Map<Person, Optional<ApplicationForLeaveStatistics>> actual =
-            sut.build(persons, from, to, List.of(type), applications);
+            sutIn2014.build(persons, from, to, List.of(type), applications);
 
         assertThat(actual)
             .hasSize(2)

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsBuilderTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsBuilderTest.java
@@ -528,4 +528,50 @@ class ApplicationForLeaveStatisticsBuilderTest {
             .containsKey(person)
             .containsEntry(person, Optional.empty());
     }
+
+    /**
+     * Callers map the returned map back over the persons they asked for, so every requested person needs an entry -
+     * also for this overload. Someone who joined this year has no account for last year, and a missing entry made the
+     * statistics page fail for the whole company as soon as it was sorted by one of the statistics columns.
+     */
+    @Test
+    void ensureThatAllPersonsThatWhereRequestedAreThereWithOptionalEmptyIfNoAccountWithGivenApplications() {
+        final ApplicationForLeaveStatisticsBuilder sut = new ApplicationForLeaveStatisticsBuilder(accountService, applicationService,
+            workingTimeCalendarService, vacationDaysService, overtimeService, Clock.fixed(Instant.parse("2014-06-24T16:02:42.00Z"), ZoneOffset.UTC));
+
+        final LocalDate from = of(2014, JANUARY, 1);
+        final LocalDate to = of(2014, DECEMBER, 31);
+
+        final Person personWithAccount = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        personWithAccount.setId(1L);
+        final Person personWithoutAccount = new Person("newbie", "Joiner", "New", "newbie@example.org");
+        personWithoutAccount.setId(2L);
+        final List<Person> persons = List.of(personWithAccount, personWithoutAccount);
+
+        final Account account = new Account(personWithAccount, from, to, false, of(2014, APRIL, 1), TEN, TEN, TEN, null);
+        final List<Account> accounts = List.of(account);
+        when(accountService.getHolidaysAccount(2014, persons)).thenReturn(accounts);
+
+        final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(from, to);
+        when(workingTimeCalendarService.getWorkingTimesByPersons(persons, Year.of(2014)))
+            .thenReturn(Map.of(personWithAccount, workingTimeCalendar, personWithoutAccount, workingTimeCalendar));
+
+        final List<Application> applications = List.of();
+        when(applicationService.getApplicationsForACertainPeriodAndStatus(from, to, persons, activeStatuses())).thenReturn(applications);
+        when(overtimeService.getLeftOvertimeTotalAndDateRangeForPersons(persons, applications, from, to)).thenReturn(Map.of());
+
+        final HolidayAccountVacationDays vacationDays = new HolidayAccountVacationDays(
+            account, VacationDaysLeft.builder().build(), VacationDaysLeft.builder().build());
+        when(vacationDaysService.getVacationDaysLeft(accounts, new DateRange(from, to)))
+            .thenReturn(Map.of(account, vacationDays));
+
+        final VacationType<?> type = ProvidedVacationType.builder(new StaticMessageSource()).build();
+        final Map<Person, Optional<ApplicationForLeaveStatistics>> actual =
+            sut.build(persons, from, to, List.of(type), applications);
+
+        assertThat(actual)
+            .hasSize(2)
+            .containsEntry(personWithoutAccount, Optional.empty());
+        assertThat(actual.get(personWithAccount)).isPresent();
+    }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsServiceTest.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.synyx.urlaubsverwaltung.person.Role.OFFICE;
 import static org.synyx.urlaubsverwaltung.person.Role.USER;
@@ -293,6 +294,83 @@ class ApplicationForLeaveStatisticsServiceTest {
     @Nested
     class GetStatisticsSortedByStatistics {
 
+        /**
+         * The builder registers an entry for every person it is asked about, but the page must not depend on it: a
+         * person missing from the map is one person without statistics, not a broken page for the whole company.
+         */
+        @Test
+        void ensurePersonsMissingFromTheBuiltStatisticsAreSkippedInsteadOfFailing() {
+
+            final LocalDate startDate = LocalDate.parse("2018-01-01");
+            final LocalDate endDate = LocalDate.parse("2018-12-31");
+            final FilterPeriod filterPeriod = new FilterPeriod(startDate, endDate);
+
+            final Person office = new Person();
+            office.setId(1L);
+            office.setPermissions(List.of(USER, OFFICE));
+
+            final Person withoutStatistics = new Person();
+            withoutStatistics.setId(2L);
+            withoutStatistics.setPermissions(List.of(USER));
+
+            final List<Person> persons = List.of(office, withoutStatistics);
+            when(personService.getActivePersons(any(PersonPageRequest.PersonPageRequestUnpaged.class), eq("")))
+                .thenReturn(new PageImpl<>(persons));
+
+            final List<VacationType<?>> vacationTypes = List.of(ProvidedVacationType.builder(new StaticMessageSource()).build());
+            when(vacationTypeService.getActiveVacationTypes()).thenReturn(vacationTypes);
+
+            final List<Application> applications = List.of();
+            when(applicationService.getApplicationsForACertainPeriodAndStatus(startDate, endDate, ApplicationStatus.activeStatuses(), ""))
+                .thenReturn(applications);
+
+            // the second person is missing from the map entirely
+            when(applicationForLeaveStatisticsBuilder.build(persons, startDate, endDate, vacationTypes, applications))
+                .thenReturn(Map.of(office, Optional.of(new ApplicationForLeaveStatistics(office, vacationTypes))));
+
+            final ApplicationForLeaveStatisticsPageRequest pageRequest = ApplicationForLeaveStatisticsPageRequest.of(0, 10, Sort.by("leftVacationDaysForYear"));
+            final Page<ApplicationForLeaveStatistics> actual = sut.getStatisticsSortedByStatistics(office, filterPeriod, pageRequest, "");
+
+            assertThat(actual.getContent()).hasSize(1);
+            assertThat(actual.getContent().getFirst().getPerson()).isEqualTo(office);
+        }
+
+        /**
+         * The left overtime <em>of the year</em> is derived from the applications handed to the builder, so fetching
+         * only the requested period would understate it for everyone who reduced overtime outside that period.
+         */
+        @Test
+        void ensureApplicationsOfTheWholeYearAreFetchedEvenForAShorterPeriod() {
+
+            final LocalDate startDate = LocalDate.parse("2018-06-01");
+            final LocalDate endDate = LocalDate.parse("2018-06-30");
+            final FilterPeriod filterPeriod = new FilterPeriod(startDate, endDate);
+
+            final Person office = new Person();
+            office.setId(1L);
+            office.setPermissions(List.of(USER, OFFICE));
+
+            when(personService.getActivePersons(any(PersonPageRequest.PersonPageRequestUnpaged.class), eq("")))
+                .thenReturn(new PageImpl<>(List.of(office)));
+
+            final List<VacationType<?>> vacationTypes = List.of(ProvidedVacationType.builder(new StaticMessageSource()).build());
+            when(vacationTypeService.getActiveVacationTypes()).thenReturn(vacationTypes);
+
+            final List<Application> applications = List.of(new Application());
+            when(applicationService.getApplicationsForACertainPeriodAndStatus(
+                LocalDate.parse("2018-01-01"), LocalDate.parse("2018-12-31"), ApplicationStatus.activeStatuses(), ""))
+                .thenReturn(applications);
+
+            when(applicationForLeaveStatisticsBuilder.build(List.of(office), startDate, endDate, vacationTypes, applications))
+                .thenReturn(Map.of(office, Optional.of(new ApplicationForLeaveStatistics(office, vacationTypes))));
+
+            final ApplicationForLeaveStatisticsPageRequest pageRequest = ApplicationForLeaveStatisticsPageRequest.of(0, 10, Sort.by("leftVacationDaysForYear"));
+            sut.getStatisticsSortedByStatistics(office, filterPeriod, pageRequest, "");
+
+            verify(applicationService).getApplicationsForACertainPeriodAndStatus(
+                LocalDate.parse("2018-01-01"), LocalDate.parse("2018-12-31"), ApplicationStatus.activeStatuses(), "");
+        }
+
         @ParameterizedTest
         @EnumSource(value = Role.class, names = {"BOSS", "OFFICE"})
         void ensureAllActivePersonsAreRequestedWhenSortedByStatisticsAttributeByRole(Role role) {
@@ -319,7 +397,7 @@ class ApplicationForLeaveStatisticsServiceTest {
             // actual applications are not of interest. returned list just has to be passed into applicationForLeaveStatisticsBuilder
             final List<Application> applications = List.of(new Application());
 
-            when(applicationService.getApplicationsForACertainPeriodAndStatus(startDate, endDate, ApplicationStatus.activeStatuses(), vacationTypes, ""))
+            when(applicationService.getApplicationsForACertainPeriodAndStatus(startDate, endDate, ApplicationStatus.activeStatuses(), ""))
                 .thenReturn(applications);
 
             when(applicationForLeaveStatisticsBuilder.build(List.of(anyPerson), startDate, endDate, vacationTypes, applications))
@@ -372,7 +450,7 @@ class ApplicationForLeaveStatisticsServiceTest {
             // actual applications are not of interest. returned list just has to be passed into applicationForLeaveStatisticsBuilder
             final List<Application> applications = List.of(new Application());
 
-            when(applicationService.getApplicationsForACertainPeriodAndStatus(startDate, endDate, ApplicationStatus.activeStatuses(), vacationTypes, ""))
+            when(applicationService.getApplicationsForACertainPeriodAndStatus(startDate, endDate, ApplicationStatus.activeStatuses(), ""))
                 .thenReturn(applications);
 
             when(applicationForLeaveStatisticsBuilder.build(List.of(departmentMember, departmentMemberTwo), startDate, endDate, vacationTypes, applications))

--- a/src/test/java/org/synyx/urlaubsverwaltung/person/PersonRepositoryIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/person/PersonRepositoryIT.java
@@ -1,5 +1,9 @@
 package org.synyx.urlaubsverwaltung.person;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -38,6 +42,10 @@ class PersonRepositoryIT extends SingleTenantTestContainersBase {
     private AccountService accountService;
     @Autowired
     private AccountInteractionService accountInteractionService;
+    @Autowired
+    private EntityManager entityManager;
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
 
     @Test
     void countPersonByPermissionsIsNot() {
@@ -206,6 +214,46 @@ class PersonRepositoryIT extends SingleTenantTestContainersBase {
             person -> assertThat(person).isEqualTo(person2),
             person -> assertThat(person).isEqualTo(person1)
         );
+    }
+
+    @Test
+    void ensurePermissionsAndNotificationsAreFetchedWithoutOneQueryPerPerson() {
+
+        // every person gets the same permissions and notifications, so the only thing that differs between the two
+        // measurements below is the number of persons - and therefore the number of collections to initialise.
+        final List<Person> persons = List.of(
+            personService.create("username_1", "Xenia", "Basta", "xenia@example.org", List.of(NOTIFICATION_EMAIL_APPLICATION_MANAGEMENT_APPLIED), List.of(USER, OFFICE)),
+            personService.create("username_2", "Peter", "Muster", "peter@example.org", List.of(NOTIFICATION_EMAIL_APPLICATION_MANAGEMENT_APPLIED), List.of(USER, OFFICE)),
+            personService.create("username_3", "Mustafa", "Tunichtgut", "mustafa@example.org", List.of(NOTIFICATION_EMAIL_APPLICATION_MANAGEMENT_APPLIED), List.of(USER, OFFICE))
+        );
+
+        final List<Long> personIds = persons.stream().map(Person::getId).toList();
+
+        final long statementsForOnePerson = fetchAndTouchPermissionsAndNotifications(personIds.subList(0, 1));
+        final long statementsForThreePersons = fetchAndTouchPermissionsAndNotifications(personIds);
+
+        // fetching two more persons with their permissions and notifications must not cost any extra queries
+        assertThat(statementsForThreePersons).isEqualTo(statementsForOnePerson);
+    }
+
+    private long fetchAndTouchPermissionsAndNotifications(List<Long> personIds) {
+
+        // force the next query to actually hit the database instead of returning managed entities from the session cache
+        entityManager.flush();
+        entityManager.clear();
+
+        final Statistics statistics = entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+        statistics.setStatisticsEnabled(true);
+        statistics.clear();
+
+        final List<Person> persons = sut.findAllByIdIsInOrderByFirstNameAscLastNameAsc(personIds);
+        persons.forEach(person -> {
+            person.getPermissions().size();
+            person.getNotifications().size();
+        });
+
+        assertThat(persons).hasSize(personIds.size());
+        return statistics.getPrepareStatementCount();
     }
 
     @Test


### PR DESCRIPTION
Makes `/web/application/statistics` fast enough to render a full year, and fixes three bugs that surfaced while measuring it.

Contributes to #6436 (findings A–D; D partially, E still open).

Fixes #6453
Fixes #6454
Fixes #6455

## Measurement

Testcontainers harness against a real Postgres, 80 persons, 1600 applications in the reported year plus 3 years of history, statement counts via Hibernate `Statistics`:

| | prepared statements | of those, real ORM queries |
|---|---|---|
| before | **1012** | 27 |
| after | **64** | 27 |

The time was never in the domain queries — it was ~985 single-row round trips. Locally that is only ~110 ms because the database is on loopback; at a production round trip of 1–3 ms the removed ~950 round trips are worth 1–3 s, which is what the 3 s in #6436 were.

## Commits

**`performance: fetch holidayReplacements via a single subselect …`** — `@Fetch(FetchMode.SUBSELECT)` on `ApplicationEntity.holidayReplacements`.

**`performance: batch fetch persons and their permissions …`** — the dominant cost. `Person.permissions` and `Person.notifications` are eager `@ElementCollection`s without batching, and every `@ManyToOne Person` is eager by default and resolved one foreign key at a time. Because `spring.jpa.open-in-view` is `false`, each service call gets its own persistence context, so the whole person set was re-loaded ~6× per request. `@BatchSize(size = 500)` on the entity and both collections: 1012 → 64 statements.

**`fix: report leave statistics of deactivated vacation types and of the whole year again`** — #6453, #6454, #6455. The sort-by-statistics path fetched applications restricted to the active vacation types and to the requested period; both restrictions were wrong for what the list is used for. Dropping them converges the two sort paths, which previously disagreed with each other. The overtime reduction is *subtracted*, so both #6453 and #6454 reported the remaining overtime too **high**.

For #6455 the cause was an asymmetry between the two `build()` overloads: only one registered persons without a holiday account, and the service maps the result back over every person it asked about. On top of fixing that, the mapping in the service now tolerates a missing person, so a future builder path cannot take the whole page down again for one person's missing row.

**`performance: fetch applications once and compute the working time calendar once …`** — the applications of the year were fetched twice and the `WorkingTimeCalendar` computed twice per request. Narrow the already-fetched list in memory; compute the calendar once and thread it through, via a new `VacationDaysService.getVacationDaysLeft` overload that takes a pre-computed calendar.

## Tests

Statement counts are asserted as "1 row vs. N rows with everything else held constant" rather than absolute numbers, which other eager associations make brittle. Every new test was checked against the un-fixed code first:

| test | reverted to | result |
|---|---|---|
| `PersonRepositoryIT.ensurePermissionsAndNotificationsAreFetchedWithoutOneQueryPerPerson` | no `@BatchSize` | red (3 vs 7) |
| `ApplicationRepositoryIT.ensureApplicantsAreFetchedWithoutOneQueryPerApplicant` | no `@BatchSize` | red (5 vs 9) |
| `ApplicationRepositoryIT.ensureApplicationsOfDeactivatedVacationTypesAreFound` | type filter in JPQL | red |
| `ApplicationForLeaveStatisticsServiceTest.ensureApplicationsOfTheWholeYearAreFetchedEvenForAShorterPeriod` | period fetch | red |
| `ApplicationForLeaveStatisticsBuilderTest.ensureApplicationsAreNotFetchedAgainAndTheCalendarIsComputedOnlyOnce` | second query + second calendar | red |
| `…ensureDeactivatedVacationTypeIsOnlyShownForThePersonWhoUsedItWithGivenApplications` | second query | red |
| `…ensureThatAllPersonsThatWhereRequestedAreThereWithOptionalEmptyIfNoAccountWithGivenApplications` | `personsWithAccount` | red |
| `ApplicationForLeaveStatisticsServiceTest.ensurePersonsMissingFromTheBuiltStatisticsAreSkippedInsteadOfFailing` | `map(statisticsByPerson::get)` | red (NPE) |

Also pinned for both `build()` overloads: a vacation type deactivated in the meantime is shown **only** for the persons who took an absence with it, and is still counted for them.

## Notes for review

- Two tests in `ApplicationServiceImplTest` that asserted the removed vacation-type filtering were deleted and replaced by one asserting the opposite.
- `getApplicationsForACertainPeriodAndStatus(…, vacationTypes, personQuery)` lost its `vacationTypes` parameter and the query lost `AND a.vacationType.id IN :vacationTypeIds`; the repository method name never advertised that filter. Single caller.
- The whole-year fetch means more rows are read when a sub-year period is selected. Unavoidable given #6454, and no change for the default whole-year filter.
- Still open on #6436: `OvertimeServiceImpl`/`ApplicationServiceImpl` compute their own calendars, and the unbounded historical queries — where `ApplicationServiceImpl.getWorkingTimeCalendars` builds a calendar spanning the org's entire history (measured 67 ms → 218 ms as history grows 1 → 8 years, at identical statement count).
- UI ITs and the a11y crawler were not run locally (they need browser containers); `application-statistics.html` is untouched, but `hasVacationType` drives its per-row rendering, so those are the tests that would notice a mistake there.
