### PR TITLE
fix: wait for JavaScript readiness in UI test page objects

### DIFF
--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/pages/ApplicationFormPage.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/pages/ApplicationFormPage.java
@@ -12,9 +12,12 @@ import static java.time.format.DateTimeFormatter.ofPattern;
 
 public class ApplicationFormPage {
 
-    private static final String FROM_INPUT_SELECTOR = "#from";
-    private static final String TO_INPUT_SELECTOR = "#to";
+    private static final String DUET_FROM_INPUT_SELECTOR = "duet-date-picker #from";
+    private static final String DUET_TO_INPUT_SELECTOR = "duet-date-picker #to";
     private static final String SUBMIT_SELECTOR = "button#apply-application";
+    private static final String HOLIDAY_REPLACEMENT_SELECT_SELECTOR = "[data-test-id=holiday-replacement-select]";
+    private static final String HOLIDAY_REPLACEMENT_SELECT_READY_SELECTOR =
+        HOLIDAY_REPLACEMENT_SELECT_SELECTOR + "[aria-controls=added-replacements-list-element]";
     private static final String VACATION_TYPE_SELECT_SELECTOR = "[data-test-id=vacation-type-select]";
     private static final String DAY_LENGTH_FULL_SELECTOR = "[data-test-id=day-length-full]";
     private static final String DAY_LENGTH_MORNING_SELECTOR = "[data-test-id=day-length-morning]";
@@ -28,21 +31,22 @@ public class ApplicationFormPage {
 
     public void waitForVisible() {
         page.waitForSelector(VACATION_TYPE_SELECT_SELECTOR);
-        page.waitForSelector(FROM_INPUT_SELECTOR);
+        page.waitForSelector(DUET_FROM_INPUT_SELECTOR);
+        page.waitForSelector(DUET_TO_INPUT_SELECTOR);
     }
 
     public void assertDatesAreSelected(LocalDate startDate, LocalDate endDate) {
         final String startDateString = ofPattern("d.M.yyyy").format(startDate);
         final String endDateString = ofPattern("d.M.yyyy").format(endDate);
 
-        assertThat(page.locator(FROM_INPUT_SELECTOR)).hasValue(startDateString);
-        assertThat(page.locator(TO_INPUT_SELECTOR)).hasValue(endDateString);
+        assertThat(page.locator(DUET_FROM_INPUT_SELECTOR)).hasValue(startDateString);
+        assertThat(page.locator(DUET_TO_INPUT_SELECTOR)).hasValue(endDateString);
 
     }
 
     public void from(LocalDate date) {
         final String dateString = ofPattern("d.M.yyyy").format(date);
-        page.locator(FROM_INPUT_SELECTOR).fill(dateString);
+        page.locator(DUET_FROM_INPUT_SELECTOR).fill(dateString);
     }
 
     public Locator vacationTypeSelect() {
@@ -59,13 +63,15 @@ public class ApplicationFormPage {
     }
 
     /**
-     * selected the given person in the  replacement select box.
-     * Note that this does not submit the form! Maybe there is JavaScript loaded which does it, though.
+     * Selects the given person in the replacement select box, which makes JavaScript add the person to the list of
+     * replacements. Note that this does not submit the form!
      *
      * @param person person that should be selected
      */
     public void selectReplacement(Person person) {
-        final Locator element = page.locator("[data-test-id=holiday-replacement-select]");
+        // wait for JavaScript to be ready, otherwise the selection happens without a `change` listener and is lost.
+        page.waitForSelector(HOLIDAY_REPLACEMENT_SELECT_READY_SELECTOR);
+        final Locator element = page.locator(HOLIDAY_REPLACEMENT_SELECT_SELECTOR);
         element.selectOption(String.valueOf(person.getId()));
     }
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/pages/SickNoteFormPage.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/pages/SickNoteFormPage.java
@@ -13,10 +13,10 @@ public class SickNoteFormPage {
     private static final String PERSON_SELECTOR = "[data-test-id=person-select]";
     private static final String SICKNOTE_TYPE_SELECTOR = "[data-test-id=sicknote-type-select]";
     private static final String DAY_TYPE_FULL_SELECTOR = "[data-test-id=day-type-full]";
-    private static final String FROM_SELECTOR = "[data-test-id=sicknote-from-date]";
-    private static final String TO_SELECTOR = "[data-test-id=sicknote-to-date]";
-    private static final String AUB_FROM_SELECTOR = "[data-test-id=sicknote-aub-from]";
-    private static final String AUB_TO_SELECTOR = "[data-test-id=sicknote-aub-to]";
+    private static final String DUET_FROM_SELECTOR = "duet-date-picker [data-test-id=sicknote-from-date]";
+    private static final String DUET_TO_SELECTOR = "duet-date-picker [data-test-id=sicknote-to-date]";
+    private static final String DUET_AUB_FROM_SELECTOR = "duet-date-picker [data-test-id=sicknote-aub-from]";
+    private static final String DUET_AUB_TO_SELECTOR = "duet-date-picker [data-test-id=sicknote-aub-to]";
     private static final String SUBMIT_SELECTOR = "[data-test-id=sicknote-submit-button]";
 
     private final Page page;
@@ -37,16 +37,18 @@ public class SickNoteFormPage {
     }
 
     public void waitForVisible() {
-        page.waitForSelector(FROM_SELECTOR);
-        page.waitForSelector(TO_SELECTOR);
+        page.waitForSelector(DUET_FROM_SELECTOR);
+        page.waitForSelector(DUET_TO_SELECTOR);
+        page.waitForSelector(DUET_AUB_FROM_SELECTOR);
+        page.waitForSelector(DUET_AUB_TO_SELECTOR);
     }
 
     public void startDate(LocalDate startDate) {
-        setDate(startDate, FROM_SELECTOR);
+        setDate(startDate, DUET_FROM_SELECTOR);
     }
 
     public void toDate(LocalDate toDate) {
-        setDate(toDate, TO_SELECTOR);
+        setDate(toDate, DUET_TO_SELECTOR);
     }
 
     public void selectTypeChildSickNote() {
@@ -54,7 +56,7 @@ public class SickNoteFormPage {
     }
 
     public void aubStartDate(LocalDate aubStartDate) {
-        setDate(aubStartDate, AUB_FROM_SELECTOR);
+        setDate(aubStartDate, DUET_AUB_FROM_SELECTOR);
     }
 
     /**
@@ -74,12 +76,12 @@ public class SickNoteFormPage {
 
     public void showsToDate(LocalDate fromDate) {
         final String expectedDateString = ofPattern("d.M.yyyy").format(fromDate);
-        assertThat(page.locator(TO_SELECTOR)).hasValue(expectedDateString);
+        assertThat(page.locator(DUET_TO_SELECTOR)).hasValue(expectedDateString);
     }
 
     public void showsAubToDate(LocalDate fromDate) {
         final String expectedDateString = ofPattern("d.M.yyyy").format(fromDate);
-        assertThat(page.locator(AUB_TO_SELECTOR)).hasValue(expectedDateString);
+        assertThat(page.locator(DUET_AUB_TO_SELECTOR)).hasValue(expectedDateString);
     }
 
     /**


### PR DESCRIPTION
ApplicationForLeaveUIIT and SickNoteUIIT flake on slow CI runners because the page objects interact with the form before its JavaScript ran, which silently discards the interaction.

Two mechanisms, one cause:

- The server renders a plain `input[date]` which `createDatepicker` replaces with a `duet-date-picker`, seeding the new picker from the server rendered `data-iso-value` instead of the live value. A date typed before that replacement is lost. Scoping the selectors below `duet-date-picker` makes them match only the hydrated picker's inner input, as OvertimePage already does.

- Adding a holiday replacement is handled by a `change` listener attached by JavaScript. Selecting an option before that listener exists does nothing, so waitForReplacementAtPosition times out. `initApplicationReplacementSelect` sets `aria-controls` in the same function that attaches the listener, so the attribute marks the select as ready.

Both failure modes were confirmed from the trace screenshots of run 30875404433: the sick note form showed an empty "from" date with a required field error while "to" held its value, and the application form showed a selected replacement that was never added to the list.

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
