### PR TITLE
fix: wait for datepicker hydration in SickNoteExtensionPage

### DIFF
--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/SickNoteUIIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/SickNoteUIIT.java
@@ -1,7 +1,6 @@
 package org.synyx.urlaubsverwaltung.ui;
 
 import com.microsoft.playwright.Page;
-import com.microsoft.playwright.options.LoadState;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -206,10 +205,7 @@ class SickNoteUIIT {
         final SickNoteDetailPage sickNoteDetailPage = new SickNoteDetailPage(page, messageSource, GERMAN);
 
         navigationPage.quickAdd.clickCreateNewSickNote();
-
-        // waiting for fetched assets (we may have to wait a little more for datepicker instantiation?)
-        page.waitForLoadState(LoadState.DOMCONTENTLOADED);
-        page.waitForCondition(sickNoteExtensionPage::isVisible);
+        sickNoteExtensionPage.waitForVisible();
 
         sickNoteExtensionPage.setCustomNextEndDate(nextEndDate);
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/pages/SickNoteExtensionPage.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/pages/SickNoteExtensionPage.java
@@ -12,6 +12,10 @@ import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertTha
 
 public class SickNoteExtensionPage {
 
+    // the `duet-date-picker` prefix matches only the hydrated datepicker, not the plain `input[date]` the server renders.
+    private static final String DUET_CUSTOM_NEXT_END_DATE_SELECTOR =
+        "duet-date-picker [data-test-id=sicknote-custom-next-end-date-input]";
+
     private final Page page;
     private final MessageSource messageSource;
     private final Locale locale;
@@ -30,10 +34,17 @@ public class SickNoteExtensionPage {
         return page.title().equals(messageSource.getMessage("sicknote.extend.header.title", null, locale));
     }
 
+    /**
+     * Waits for the page and its datepicker to be ready to interact with.
+     */
+    public void waitForVisible() {
+        page.waitForCondition(this::isVisible);
+        page.waitForSelector(DUET_CUSTOM_NEXT_END_DATE_SELECTOR);
+    }
+
     public void setCustomNextEndDate(LocalDate nextEndDate) {
         final String nextEndDateValue = DATE_FORMATTER.format(nextEndDate);
-        // this only works for initialised datepicker (fails with native date input element)
-        page.locator("[data-test-id=sicknote-custom-next-end-date-input]").fill(nextEndDateValue);
+        page.locator(DUET_CUSTOM_NEXT_END_DATE_SELECTOR).fill(nextEndDateValue);
     }
 
     public void showsExtensionPreview(LocalDate startDate, LocalDate nextEndDate) {


### PR DESCRIPTION
Follow-up to the same hydration race fixed for SickNoteFormPage and ApplicationFormPage: the server renders a plain `input[date]` which `createDatepicker` replaces with a `duet-date-picker`, so filling the input before that replacement loses the typed value.

setCustomNextEndDate now targets the hydrated picker, which turns the existing "only works for initialised datepicker" comment into something the selector actually enforces instead of merely documenting.

The new waitForVisible() replaces a DOMCONTENTLOADED wait that came with the comment "we may have to wait a little more for datepicker instantiation?" - waiting for the hydrated datepicker is strictly stronger and removes the guess.

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
