### PR TITLE
refactor: use java.time.Month constants instead of int literals

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/extension/backup/backup/BackupDataCollectionService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/extension/backup/backup/BackupDataCollectionService.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.lang.invoke.MethodHandles.lookup;
+import static java.time.Month.DECEMBER;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -73,7 +74,7 @@ class BackupDataCollectionService {
     }
 
     private static LocalDate getLastDayOfNextYear() {
-        return LocalDate.of(LocalDate.now().plusYears(1).getYear(), 12, 31);
+        return LocalDate.of(LocalDate.now().plusYears(1).getYear(), DECEMBER, 31);
     }
 
     public UrlaubsverwaltungBackupDTO collectData() {

--- a/src/test/java/org/synyx/urlaubsverwaltung/absence/DateRangeTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/absence/DateRangeTest.java
@@ -10,6 +10,9 @@ import java.time.LocalDate;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static java.time.Month.AUGUST;
+import static java.time.Month.JULY;
+import static java.time.Month.OCTOBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -174,19 +177,19 @@ class DateRangeTest {
 
     @Test
     void dateRangeDurationReturnsCorrectValueIfNotEmpty() {
-        final Duration duration = new DateRange(LocalDate.of(2022, 10, 10), LocalDate.of(2022, 10, 20)).duration();
+        final Duration duration = new DateRange(LocalDate.of(2022, OCTOBER, 10), LocalDate.of(2022, OCTOBER, 20)).duration();
         assertThat(duration).isEqualTo(Duration.ofDays(11));
     }
 
     @Test
     void ensureThatDateRangeIsCorrectOverMoreThanOneMonth() {
-        final Duration duration = new DateRange(LocalDate.of(2021, 7, 12), LocalDate.of(2021, 8, 13)).duration();
+        final Duration duration = new DateRange(LocalDate.of(2021, JULY, 12), LocalDate.of(2021, AUGUST, 13)).duration();
         assertThat(duration).isEqualTo(Duration.ofDays(33));
     }
 
     @Test
     void dateRangeDurationReturnsOneOnSameDay() {
-        final LocalDate date = LocalDate.of(2022, 10, 10);
+        final LocalDate date = LocalDate.of(2022, OCTOBER, 10);
         final Duration duration = new DateRange(date, date).duration();
         assertThat(duration).isEqualTo(Duration.ofDays(1));
     }

--- a/src/test/java/org/synyx/urlaubsverwaltung/absence/OvertimeAbsenceApiControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/absence/OvertimeAbsenceApiControllerTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static java.time.Month.JANUARY;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -55,7 +56,7 @@ class OvertimeAbsenceApiControllerTest {
     @Test
     void threeHoursForty() throws Exception {
 
-        final LocalDate date = LocalDate.of(2016, 1, 1);
+        final LocalDate date = LocalDate.of(2016, JANUARY, 1);
         final Duration duration = Duration.ofHours(3).plusMinutes(40);
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
@@ -94,8 +95,8 @@ class OvertimeAbsenceApiControllerTest {
 
     @Test
     void multipleDays() throws Exception {
-        final LocalDate startDate = LocalDate.of(2016, 1, 1);
-        final LocalDate endDate = LocalDate.of(2016, 1, 2);
+        final LocalDate startDate = LocalDate.of(2016, JANUARY, 1);
+        final LocalDate endDate = LocalDate.of(2016, JANUARY, 2);
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         person.setId(2L);
@@ -137,8 +138,8 @@ class OvertimeAbsenceApiControllerTest {
 
     @Test
     void multipleDaysWithDaysWithoutWorkingDaysAndHalfDays() throws Exception {
-        final LocalDate startDate = LocalDate.of(2016, 1, 1);
-        final LocalDate endDate = LocalDate.of(2016, 1, 3);
+        final LocalDate startDate = LocalDate.of(2016, JANUARY, 1);
+        final LocalDate endDate = LocalDate.of(2016, JANUARY, 3);
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         person.setId(2L);
@@ -156,9 +157,9 @@ class OvertimeAbsenceApiControllerTest {
         when(workingTimeCalendarService.getWorkingTimesByPersons(Set.of(person), new DateRange(startDate, endDate)))
             .thenReturn(Map.of(
                 person, new WorkingTimeCalendar(Map.of(
-                    LocalDate.of(2016, 1, 1), fullWorkday(),
-                    LocalDate.of(2016, 1, 2), halfWorkdayMorning(),
-                    LocalDate.of(2016, 1, 3), noWorkday()
+                    LocalDate.of(2016, JANUARY, 1), fullWorkday(),
+                    LocalDate.of(2016, JANUARY, 2), halfWorkdayMorning(),
+                    LocalDate.of(2016, JANUARY, 3), noWorkday()
                 ))
             ));
 
@@ -230,7 +231,7 @@ class OvertimeAbsenceApiControllerTest {
     @Test
     void ensureToSetDurationToZeroIfNotKnown() throws Exception {
 
-        final LocalDate date = LocalDate.of(2016, 1, 1);
+        final LocalDate date = LocalDate.of(2016, JANUARY, 1);
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         person.setId(2L);

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/AccountFormTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/AccountFormTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AccountFormTest {
@@ -13,8 +15,8 @@ class AccountFormTest {
     void ensureHasDefaultValuesForHolidaysAccountPeriod() {
         final AccountForm accountForm = new AccountForm(2014);
         assertThat(accountForm.getHolidaysAccountYear()).isEqualTo(2014);
-        assertThat(accountForm.getHolidaysAccountValidFrom()).isEqualTo(LocalDate.of(2014, 1, 1));
-        assertThat(accountForm.getHolidaysAccountValidTo()).isEqualTo(LocalDate.of(2014, 12, 31));
+        assertThat(accountForm.getHolidaysAccountValidFrom()).isEqualTo(LocalDate.of(2014, JANUARY, 1));
+        assertThat(accountForm.getHolidaysAccountValidTo()).isEqualTo(LocalDate.of(2014, DECEMBER, 31));
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/AccountFormValidatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/AccountFormValidatorTest.java
@@ -16,9 +16,13 @@ import org.synyx.urlaubsverwaltung.settings.SettingsService;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.Month;
 import java.util.stream.Stream;
 
+import static java.time.Month.APRIL;
+import static java.time.Month.FEBRUARY;
+import static java.time.Month.JANUARY;
+import static java.time.Month.MARCH;
+import static java.time.Month.MAY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -336,8 +340,8 @@ class AccountFormValidatorTest {
     @Test
     void ensureInvalidPeriodForToDateAfterFromDate() {
         final AccountForm form = new AccountForm(2021);
-        form.setHolidaysAccountValidFrom(LocalDate.of(2021, Month.MARCH, 1));
-        form.setHolidaysAccountValidTo(LocalDate.of(2021, Month.JANUARY, 1));
+        form.setHolidaysAccountValidFrom(LocalDate.of(2021, MARCH, 1));
+        form.setHolidaysAccountValidTo(LocalDate.of(2021, JANUARY, 1));
 
         sut.validatePeriod(form, errors);
         verify(errors).rejectValue("holidaysAccountValidTo", "person.form.annualVacation.error.holidaysAccountValidTo.invalidRangeReversed");
@@ -347,8 +351,8 @@ class AccountFormValidatorTest {
     @Test
     void ensureInvalidPeriodForToDateEqualsFromDate() {
         final AccountForm form = new AccountForm(2021);
-        form.setHolidaysAccountValidFrom(LocalDate.of(2021, Month.MARCH, 1));
-        form.setHolidaysAccountValidTo(LocalDate.of(2021, Month.MARCH, 1));
+        form.setHolidaysAccountValidFrom(LocalDate.of(2021, MARCH, 1));
+        form.setHolidaysAccountValidTo(LocalDate.of(2021, MARCH, 1));
 
         sut.validatePeriod(form, errors);
         verify(errors).rejectValue("holidaysAccountValidTo", "person.form.annualVacation.error.holidaysAccountValidTo.invalidRange");
@@ -358,8 +362,8 @@ class AccountFormValidatorTest {
     @Test
     void ensureInvalidPeriodForFromDateWrongYear() {
         final AccountForm form = new AccountForm(2021);
-        form.setHolidaysAccountValidFrom(LocalDate.of(2022, Month.MARCH, 1));
-        form.setHolidaysAccountValidTo(LocalDate.of(2021, Month.MARCH, 1));
+        form.setHolidaysAccountValidFrom(LocalDate.of(2022, MARCH, 1));
+        form.setHolidaysAccountValidTo(LocalDate.of(2021, MARCH, 1));
 
         sut.validatePeriod(form, errors);
         verify(errors).rejectValue("holidaysAccountValidFrom", "person.form.annualVacation.error.holidaysAccountValidFrom.invalidYear", new Object[]{"2021"}, "");
@@ -368,8 +372,8 @@ class AccountFormValidatorTest {
     @Test
     void ensureInvalidPeriodForToDateWringYear() {
         final AccountForm form = new AccountForm(2021);
-        form.setHolidaysAccountValidFrom(LocalDate.of(2021, Month.MARCH, 1));
-        form.setHolidaysAccountValidTo(LocalDate.of(2020, Month.MARCH, 1));
+        form.setHolidaysAccountValidFrom(LocalDate.of(2021, MARCH, 1));
+        form.setHolidaysAccountValidTo(LocalDate.of(2020, MARCH, 1));
 
         sut.validatePeriod(form, errors);
         verify(errors).rejectValue("holidaysAccountValidTo", "person.form.annualVacation.error.holidaysAccountValidTo.invalidYear", new Object[]{"2021"}, "");
@@ -378,8 +382,8 @@ class AccountFormValidatorTest {
     @Test
     void ensureValidPeriodHasNoValidationError() {
         final AccountForm form = new AccountForm(2013);
-        form.setHolidaysAccountValidFrom(LocalDate.of(2013, 5, 1));
-        form.setHolidaysAccountValidTo(LocalDate.of(2013, 5, 5));
+        form.setHolidaysAccountValidFrom(LocalDate.of(2013, MAY, 1));
+        form.setHolidaysAccountValidTo(LocalDate.of(2013, MAY, 5));
 
         sut.validatePeriod(form, errors);
         verifyNoInteractions(errors);
@@ -403,7 +407,7 @@ class AccountFormValidatorTest {
     @Test
     void ensureHolidaysAccountExpiryDateCanBeNull() {
 
-        mockExpiryDateGlobal(LocalDate.of(2013, 2, 1));
+        mockExpiryDateGlobal(LocalDate.of(2013, FEBRUARY, 1));
 
         final AccountForm form = new AccountForm(2013);
         form.setDoRemainingVacationDaysExpireLocally(true);
@@ -416,10 +420,10 @@ class AccountFormValidatorTest {
     @Test
     void ensureInvalidExpiryDateWrongYear() {
 
-        mockExpiryDateGlobal(LocalDate.of(2021, 4, 1));
+        mockExpiryDateGlobal(LocalDate.of(2021, APRIL, 1));
 
         final AccountForm form = new AccountForm(2021);
-        form.setExpiryDateLocally(LocalDate.of(2022, Month.MARCH, 1));
+        form.setExpiryDateLocally(LocalDate.of(2022, MARCH, 1));
 
         sut.validateExpiryDateLocally(form, errors, this::getSettings);
         verify(errors).rejectValue("expiryDateLocally", "person.form.annualVacation.error.expiryDateLocally.invalidYear", new Object[]{"2021"}, "");
@@ -428,11 +432,11 @@ class AccountFormValidatorTest {
     @Test
     void ensureExpiryDateHasNoValidationError() {
 
-        mockExpiryDateGlobal(LocalDate.of(2013, 4, 1));
+        mockExpiryDateGlobal(LocalDate.of(2013, APRIL, 1));
 
         final AccountForm form = new AccountForm(2013);
         form.setDoRemainingVacationDaysExpireLocally(true);
-        form.setExpiryDateLocally(LocalDate.of(2013, 5, 1));
+        form.setExpiryDateLocally(LocalDate.of(2013, MAY, 1));
 
         sut.validateExpiryDateLocally(form, errors, this::getSettings);
         verifyNoInteractions(errors);

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/AccountInteractionServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/AccountInteractionServiceImplTest.java
@@ -157,7 +157,7 @@ class AccountInteractionServiceImplTest {
         final LocalDate validTo = LocalDate.of(2022, DECEMBER, 31);
 
         final Account account = new Account();
-        account.setExpiryDateLocally(LocalDate.of(2022, 4, 1));
+        account.setExpiryDateLocally(LocalDate.of(2022, APRIL, 1));
 
         when(accountService.save(any(Account.class))).then(returnsFirstArg());
 
@@ -270,8 +270,8 @@ class AccountInteractionServiceImplTest {
         assertThat(createdHolidaysAccount.getAnnualVacationDays()).isEqualTo(referenceHolidaysAccount.getAnnualVacationDays());
         assertThat(createdHolidaysAccount.getRemainingVacationDays()).isEqualTo(leftDays);
         assertThat(createdHolidaysAccount.getRemainingVacationDaysNotExpiring()).isEqualTo(ZERO);
-        assertThat(createdHolidaysAccount.getValidFrom()).isEqualTo(LocalDate.of(nextYear, 1, 1));
-        assertThat(createdHolidaysAccount.getValidTo()).isEqualTo(LocalDate.of(nextYear, 12, 31));
+        assertThat(createdHolidaysAccount.getValidFrom()).isEqualTo(LocalDate.of(nextYear, JANUARY, 1));
+        assertThat(createdHolidaysAccount.getValidTo()).isEqualTo(LocalDate.of(nextYear, DECEMBER, 31));
         assertThat(createdHolidaysAccount.getExpiryDateLocally()).isNull();
         assertThat(createdHolidaysAccount.isDoRemainingVacationDaysExpireLocally()).isNull();
         assertThat(createdHolidaysAccount.doRemainingVacationDaysExpire()).isFalse();
@@ -297,8 +297,8 @@ class AccountInteractionServiceImplTest {
             BigDecimal.valueOf(8), BigDecimal.valueOf(4), "comment");
 
         final LocalDate expiryDateOld = LocalDate.of(year, APRIL, 1);
-        final Account nextYearAccount = new Account(person, LocalDate.of(nextYear, 1, 1), LocalDate.of(
-            nextYear, 10, 31), true, expiryDateOld, BigDecimal.valueOf(28), ZERO, ZERO, "comment");
+        final Account nextYearAccount = new Account(person, LocalDate.of(nextYear, JANUARY, 1), LocalDate.of(
+            nextYear, OCTOBER, 31), true, expiryDateOld, BigDecimal.valueOf(28), ZERO, ZERO, "comment");
 
         when(accountService.getHolidaysAccount(nextYear, person)).thenReturn(Optional.of(nextYearAccount));
         when(vacationDaysService.getTotalLeftVacationDays(referenceAccount)).thenReturn(leftDays);

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/AccountServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/AccountServiceImplTest.java
@@ -18,6 +18,8 @@ import java.util.Optional;
 
 import static java.math.BigDecimal.ZERO;
 import static java.time.Month.APRIL;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
 import static java.time.Month.JUNE;
 import static java.time.temporal.TemporalAdjusters.lastDayOfYear;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -119,7 +121,7 @@ class AccountServiceImplTest {
 
         final int year = 2012;
         final LocalDate from = Year.of(year).atDay(1);
-        final LocalDate to = LocalDate.of(year, 1, 1).with(lastDayOfYear());
+        final LocalDate to = LocalDate.of(year, JANUARY, 1).with(lastDayOfYear());
         final LocalDate expiryDate = LocalDate.of(year, APRIL, 1);
 
         final AccountEntity accountEntity1 = new AccountEntity(person, from, to, null, expiryDate,
@@ -289,8 +291,8 @@ class AccountServiceImplTest {
     void ensureSave() {
 
         final Account account = new Account();
-        account.setValidFrom(LocalDate.of(2022, 1, 1));
-        account.setValidTo(LocalDate.of(2022, 12, 31));
+        account.setValidFrom(LocalDate.of(2022, JANUARY, 1));
+        account.setValidTo(LocalDate.of(2022, DECEMBER, 31));
         account.setExpiryDateLocally(LocalDate.of(2022, JUNE, 1));
         account.setDoRemainingVacationDaysExpireLocally(true);
         account.setDoRemainingVacationDaysExpireGlobally(false);
@@ -313,8 +315,8 @@ class AccountServiceImplTest {
         assertThat(captor.getValue()).satisfies(entity -> {
             assertThat(entity.getYear()).isEqualTo(2022);
             assertThat(entity.getExpiryDate()).isEqualTo(LocalDate.of(2022, JUNE, 1));
-            assertThat(entity.getValidFrom()).isEqualTo(LocalDate.of(2022, 1, 1));
-            assertThat(entity.getValidTo()).isEqualTo(LocalDate.of(2022, 12, 31));
+            assertThat(entity.getValidFrom()).isEqualTo(LocalDate.of(2022, JANUARY, 1));
+            assertThat(entity.getValidTo()).isEqualTo(LocalDate.of(2022, DECEMBER, 31));
             assertThat(entity.getAnnualVacationDays()).isEqualTo(BigDecimal.valueOf(30));
             assertThat(entity.getActualVacationDays()).isEqualTo(BigDecimal.valueOf(20));
             assertThat(entity.getRemainingVacationDays()).isEqualTo(BigDecimal.valueOf(10));
@@ -324,8 +326,8 @@ class AccountServiceImplTest {
 
         assertThat(actual.getYear()).isEqualTo(2022);
         assertThat(actual.getExpiryDate()).isEqualTo(LocalDate.of(2022, JUNE, 1));
-        assertThat(actual.getValidFrom()).isEqualTo(LocalDate.of(2022, 1, 1));
-        assertThat(actual.getValidTo()).isEqualTo(LocalDate.of(2022, 12, 31));
+        assertThat(actual.getValidFrom()).isEqualTo(LocalDate.of(2022, JANUARY, 1));
+        assertThat(actual.getValidTo()).isEqualTo(LocalDate.of(2022, DECEMBER, 31));
         assertThat(actual.getAnnualVacationDays()).isEqualTo(BigDecimal.valueOf(30));
         assertThat(actual.getActualVacationDays()).isEqualTo(BigDecimal.valueOf(20));
         assertThat(actual.getRemainingVacationDays()).isEqualTo(BigDecimal.valueOf(10));
@@ -337,8 +339,8 @@ class AccountServiceImplTest {
     void ensureToCalculateGlobalExpiryDateAfterSaveOnMapping() {
 
         final Account account = new Account();
-        account.setValidFrom(LocalDate.of(2022, 1, 1));
-        account.setValidTo(LocalDate.of(2022, 12, 31));
+        account.setValidFrom(LocalDate.of(2022, JANUARY, 1));
+        account.setValidTo(LocalDate.of(2022, DECEMBER, 31));
         account.setExpiryDateLocally(null);
         account.setDoRemainingVacationDaysExpireLocally(true);
         account.setDoRemainingVacationDaysExpireGlobally(false);

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/AccountSettingsTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/AccountSettingsTest.java
@@ -3,9 +3,10 @@ package org.synyx.urlaubsverwaltung.account;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
-import java.time.Month;
 import java.time.Year;
 
+import static java.time.Month.APRIL;
+import static java.time.Month.FEBRUARY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AccountSettingsTest {
@@ -16,7 +17,7 @@ class AccountSettingsTest {
         final AccountSettings settings = new AccountSettings();
         assertThat(settings.getMaximumAnnualVacationDays()).isEqualTo(40);
         assertThat(settings.getExpiryDateDayOfMonth()).isEqualTo(1);
-        assertThat(settings.getExpiryDateMonth()).isEqualTo(Month.APRIL);
+        assertThat(settings.getExpiryDateMonth()).isEqualTo(APRIL);
     }
 
     @Test
@@ -24,12 +25,12 @@ class AccountSettingsTest {
 
         final AccountSettings sut = new AccountSettings();
         sut.setExpiryDateDayOfMonth(31);
-        sut.setExpiryDateMonth(Month.FEBRUARY);
+        sut.setExpiryDateMonth(FEBRUARY);
 
         // 2024 is a leap year
-        assertThat(sut.getExpiryDateForYear(Year.of(2023))).isEqualTo(LocalDate.of(2023, 2, 28));
-        assertThat(sut.getExpiryDateForYear(Year.of(2024))).isEqualTo(LocalDate.of(2024, 2, 29));
-        assertThat(sut.getExpiryDateForYear(Year.of(2025))).isEqualTo(LocalDate.of(2025, 2, 28));
-        assertThat(sut.getExpiryDateForYear(Year.of(2026))).isEqualTo(LocalDate.of(2026, 2, 28));
+        assertThat(sut.getExpiryDateForYear(Year.of(2023))).isEqualTo(LocalDate.of(2023, FEBRUARY, 28));
+        assertThat(sut.getExpiryDateForYear(Year.of(2024))).isEqualTo(LocalDate.of(2024, FEBRUARY, 29));
+        assertThat(sut.getExpiryDateForYear(Year.of(2025))).isEqualTo(LocalDate.of(2025, FEBRUARY, 28));
+        assertThat(sut.getExpiryDateForYear(Year.of(2026))).isEqualTo(LocalDate.of(2026, FEBRUARY, 28));
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/VacationDaysReminderServiceIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/VacationDaysReminderServiceIT.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import static com.icegreen.greenmail.util.ServerSetupTest.SMTP_IMAP;
 import static java.math.BigDecimal.TEN;
 import static java.math.BigDecimal.ZERO;
+import static java.time.Month.APRIL;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.when;
@@ -63,14 +64,14 @@ class VacationDaysReminderServiceIT extends SingleTenantTestContainersBase {
 
         final Account account = new Account();
         account.setPerson(person);
-        account.setExpiryDateLocally(LocalDate.of(2022, 4, 1));
+        account.setExpiryDateLocally(LocalDate.of(2022, APRIL, 1));
         account.setDoRemainingVacationDaysExpireLocally(true);
         when(accountService.getHolidaysAccount(2022, List.of(person))).thenReturn(List.of(account));
         when(vacationDaysService.getTotalLeftVacationDays(account)).thenReturn(TEN);
 
         final Account accountNextYear = new Account();
         accountNextYear.setPerson(person);
-        accountNextYear.setExpiryDateLocally(LocalDate.of(2023, 4, 10));
+        accountNextYear.setExpiryDateLocally(LocalDate.of(2023, APRIL, 10));
         accountNextYear.setDoRemainingVacationDaysExpireLocally(true);
         when(accountService.getHolidaysAccount(2023, person)).thenReturn(Optional.of(accountNextYear));
 
@@ -108,7 +109,7 @@ class VacationDaysReminderServiceIT extends SingleTenantTestContainersBase {
 
         final Account account = new Account();
         account.setPerson(person);
-        account.setExpiryDateLocally(LocalDate.of(2022, 4, 1));
+        account.setExpiryDateLocally(LocalDate.of(2022, APRIL, 1));
         account.setDoRemainingVacationDaysExpireLocally(true);
         when(accountService.getHolidaysAccount(2022, List.of(person))).thenReturn(List.of(account));
         when(vacationDaysService.getTotalLeftVacationDays(account)).thenReturn(TEN);
@@ -149,13 +150,13 @@ class VacationDaysReminderServiceIT extends SingleTenantTestContainersBase {
 
         final Account account2022 = new Account();
         account2022.setPerson(person);
-        account2022.setExpiryDateLocally(LocalDate.of(2022, 4, 1));
+        account2022.setExpiryDateLocally(LocalDate.of(2022, APRIL, 1));
         account2022.setDoRemainingVacationDaysExpireLocally(true);
         when(accountService.getHolidaysAccount(2022, List.of(person))).thenReturn(List.of(account2022));
 
         final Account account2023 = new Account();
         account2023.setPerson(person);
-        account2023.setExpiryDateLocally(LocalDate.of(2023, 4, 1));
+        account2023.setExpiryDateLocally(LocalDate.of(2023, APRIL, 1));
         account2023.setDoRemainingVacationDaysExpireLocally(true);
         when(accountService.getHolidaysAccount(2023, List.of(person))).thenReturn(List.of(account2023));
 
@@ -203,13 +204,13 @@ class VacationDaysReminderServiceIT extends SingleTenantTestContainersBase {
 
         final Account account = new Account();
         account.setPerson(person);
-        account.setExpiryDateLocally(LocalDate.of(2022, 4, 1));
+        account.setExpiryDateLocally(LocalDate.of(2022, APRIL, 1));
         account.setDoRemainingVacationDaysExpireLocally(true);
         when(accountService.getHolidaysAccount(2022, List.of(person))).thenReturn(List.of(account));
 
         final Account account2023 = new Account();
         account2023.setPerson(person);
-        account2023.setExpiryDateLocally(LocalDate.of(2023, 4, 1));
+        account2023.setExpiryDateLocally(LocalDate.of(2023, APRIL, 1));
         account2023.setDoRemainingVacationDaysExpireLocally(true);
         when(accountService.getHolidaysAccount(2023, List.of(person))).thenReturn(List.of(account2023));
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/VacationDaysReminderServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/VacationDaysReminderServiceTest.java
@@ -23,6 +23,8 @@ import java.util.Optional;
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.TEN;
 import static java.math.BigDecimal.ZERO;
+import static java.time.Month.APRIL;
+import static java.time.Month.MARCH;
 import static java.util.Locale.GERMAN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
@@ -54,7 +56,7 @@ class VacationDaysReminderServiceTest {
         when(personService.getActivePersons()).thenReturn(List.of(person));
 
         final Account account = new Account();
-        account.setExpiryDateLocally(LocalDate.of(2022, 4, 1));
+        account.setExpiryDateLocally(LocalDate.of(2022, APRIL, 1));
         when(accountService.getHolidaysAccount(2022, List.of(person))).thenReturn(List.of(account));
         when(vacationDaysService.getTotalLeftVacationDays(account)).thenReturn(ZERO);
 
@@ -115,7 +117,7 @@ class VacationDaysReminderServiceTest {
         final Account account = new Account();
         account.setPerson(person);
         account.setDoRemainingVacationDaysExpireGlobally(true);
-        account.setExpiryDateLocally(LocalDate.of(2022, 4, 1));
+        account.setExpiryDateLocally(LocalDate.of(2022, APRIL, 1));
         when(accountService.getHolidaysAccount(2022, List.of(person))).thenReturn(List.of(account));
         when(vacationDaysService.getTotalLeftVacationDays(account)).thenReturn(TEN);
 
@@ -131,7 +133,7 @@ class VacationDaysReminderServiceTest {
             entry("recipientNiceName", "Marlene Muster"),
             entry("personId", 42L),
             entry("vacationDaysLeft", TEN),
-            entry("expiryDateNextYear", LocalDate.of(2023, 4, 1))
+            entry("expiryDateNextYear", LocalDate.of(2023, APRIL, 1))
         );
     }
 
@@ -146,12 +148,12 @@ class VacationDaysReminderServiceTest {
 
         final Account account2022 = new Account();
         account2022.setDoRemainingVacationDaysExpireLocally(true);
-        account2022.setExpiryDateLocally(LocalDate.of(2022, 4, 1));
+        account2022.setExpiryDateLocally(LocalDate.of(2022, APRIL, 1));
         when(accountService.getHolidaysAccount(2022, List.of(person))).thenReturn(List.of(account2022));
 
         final Account account2023 = new Account();
         account2023.setDoRemainingVacationDaysExpireLocally(true);
-        account2023.setExpiryDateLocally(LocalDate.of(2023, 4, 1));
+        account2023.setExpiryDateLocally(LocalDate.of(2023, APRIL, 1));
         when(accountService.getHolidaysAccount(2023, List.of(person))).thenReturn(List.of(account2023));
 
         final Year year = Year.of(2022);
@@ -181,13 +183,13 @@ class VacationDaysReminderServiceTest {
         final Account account2022 = new Account();
         account2022.setPerson(person);
         account2022.setDoRemainingVacationDaysExpireLocally(true);
-        account2022.setExpiryDateLocally(LocalDate.of(2022, 4, 1));
+        account2022.setExpiryDateLocally(LocalDate.of(2022, APRIL, 1));
         when(accountService.getHolidaysAccount(2022, List.of(person))).thenReturn(List.of(account2022));
 
         final Account account2023 = new Account();
         account2023.setPerson(person);
         account2023.setDoRemainingVacationDaysExpireLocally(true);
-        account2023.setExpiryDateLocally(LocalDate.of(2023, 4, 1));
+        account2023.setExpiryDateLocally(LocalDate.of(2023, APRIL, 1));
         when(accountService.getHolidaysAccount(2023, List.of(person))).thenReturn(List.of(account2023));
 
         final VacationDaysLeft vacationDaysLeft = VacationDaysLeft.builder()
@@ -213,8 +215,8 @@ class VacationDaysReminderServiceTest {
                 entry("recipientNiceName", "Marlene Muster"),
                 entry("personId", 42L),
                 entry("remainingVacationDays", TEN),
-                entry("dayBeforeExpiryDate", LocalDate.of(2022, 3, 31)),
-                entry("expiryDate", LocalDate.of(2022, 4, 1))
+                entry("dayBeforeExpiryDate", LocalDate.of(2022, MARCH, 31)),
+                entry("expiryDate", LocalDate.of(2022, APRIL, 1))
             );
     }
 
@@ -229,7 +231,7 @@ class VacationDaysReminderServiceTest {
 
         final Account account2022 = new Account();
         account2022.setPerson(person);
-        account2022.setExpiryDateLocally(LocalDate.of(2022, 4, 1));
+        account2022.setExpiryDateLocally(LocalDate.of(2022, APRIL, 1));
         when(accountService.getHolidaysAccount(2022, List.of(person))).thenReturn(List.of(account2022));
 
         sut.notifyForExpiredRemainingVacationDays();
@@ -247,8 +249,8 @@ class VacationDaysReminderServiceTest {
 
         final Account account2022 = new Account();
         account2022.setPerson(person);
-        account2022.setExpiryDateLocally(LocalDate.of(2022, 4, 2));
-        account2022.setExpiryNotificationSentDate(LocalDate.of(2022, 4, 1));
+        account2022.setExpiryDateLocally(LocalDate.of(2022, APRIL, 2));
+        account2022.setExpiryNotificationSentDate(LocalDate.of(2022, APRIL, 1));
         when(accountService.getHolidaysAccount(2022, List.of(person))).thenReturn(List.of(account2022));
 
         sut.notifyForExpiredRemainingVacationDays();
@@ -267,12 +269,12 @@ class VacationDaysReminderServiceTest {
 
         final Account account2022 = new Account();
         account2022.setDoRemainingVacationDaysExpireLocally(true);
-        account2022.setExpiryDateLocally(LocalDate.of(2022, 4, 1));
+        account2022.setExpiryDateLocally(LocalDate.of(2022, APRIL, 1));
         when(accountService.getHolidaysAccount(2022, List.of(person))).thenReturn(List.of(account2022));
 
         final Account account2023 = new Account();
         account2023.setDoRemainingVacationDaysExpireLocally(true);
-        account2023.setExpiryDateLocally(LocalDate.of(2023, 4, 1));
+        account2023.setExpiryDateLocally(LocalDate.of(2023, APRIL, 1));
         when(accountService.getHolidaysAccount(2023, List.of(person))).thenReturn(List.of(account2023));
 
         final Year year = Year.of(2022);
@@ -321,13 +323,13 @@ class VacationDaysReminderServiceTest {
         final Account account2022 = new Account();
         account2022.setPerson(person);
         account2022.setDoRemainingVacationDaysExpireLocally(true);
-        account2022.setExpiryDateLocally(LocalDate.of(2022, 4, 1));
+        account2022.setExpiryDateLocally(LocalDate.of(2022, APRIL, 1));
         when(accountService.getHolidaysAccount(2022, List.of(person))).thenReturn(List.of(account2022));
 
         final Account account2023 = new Account();
         account2023.setPerson(person);
         account2023.setDoRemainingVacationDaysExpireLocally(true);
-        account2023.setExpiryDateLocally(LocalDate.of(2023, 4, 1));
+        account2023.setExpiryDateLocally(LocalDate.of(2023, APRIL, 1));
         when(accountService.getHolidaysAccount(2023, List.of(person))).thenReturn(List.of(account2023));
 
         final VacationDaysLeft vacationDaysLeft = VacationDaysLeft.builder()
@@ -355,7 +357,7 @@ class VacationDaysReminderServiceTest {
             entry("expiredRemainingVacationDays", BigDecimal.valueOf(9L)),
             entry("totalLeftVacationDays", BigDecimal.valueOf(11L)),
             entry("remainingVacationDaysNotExpiring", ONE),
-            entry("expiryDate", LocalDate.of(2022, 4, 1))
+            entry("expiryDate", LocalDate.of(2022, APRIL, 1))
         );
     }
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/account/VacationDaysServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/account/VacationDaysServiceTest.java
@@ -89,11 +89,11 @@ class VacationDaysServiceTest {
         application20DaysAfterApril.setEndDate(LocalDate.of(2022, APRIL, 21));
         application20DaysAfterApril.setStatus(ALLOWED);
 
-        when(applicationService.getForStatesAndPerson(activeStatuses(), List.of(person), LocalDate.of(2022, 1, 1), LocalDate.of(2022, 12, 31)))
+        when(applicationService.getForStatesAndPerson(activeStatuses(), List.of(person), LocalDate.of(2022, JANUARY, 1), LocalDate.of(2022, DECEMBER, 31)))
             .thenReturn(List.of(application20DaysBeforeExpiryDate, application20DaysAfterApril));
 
         final Year year = Year.of(2022);
-        final LocalDate firstDayOfYear = LocalDate.of(year.getValue(), 1, 1);
+        final LocalDate firstDayOfYear = LocalDate.of(year.getValue(), JANUARY, 1);
         final LocalDate lastDayOfYear = firstDayOfYear.with(lastDayOfYear());
 
         final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(firstDayOfYear, lastDayOfYear);
@@ -123,11 +123,11 @@ class VacationDaysServiceTest {
         application1Day.setEndDate(LocalDate.of(2022, MAY, 2));
         application1Day.setStatus(ALLOWED);
 
-        when(applicationService.getForStatesAndPerson(activeStatuses(), List.of(person), LocalDate.of(2022, 1, 1), LocalDate.of(2022, 12, 31)))
+        when(applicationService.getForStatesAndPerson(activeStatuses(), List.of(person), LocalDate.of(2022, JANUARY, 1), LocalDate.of(2022, DECEMBER, 31)))
             .thenReturn(List.of(application4Days, application1Day));
 
         final Year year = Year.of(2022);
-        final LocalDate firstDayOfYear = LocalDate.of(year.getValue(), 1, 1);
+        final LocalDate firstDayOfYear = LocalDate.of(year.getValue(), JANUARY, 1);
         final LocalDate lastDayOfYear = firstDayOfYear.with(lastDayOfYear());
 
         final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(firstDayOfYear, lastDayOfYear);
@@ -159,11 +159,11 @@ class VacationDaysServiceTest {
         application1Day.setEndDate(LocalDate.of(2022, MAY, 2));
         application1Day.setStatus(ALLOWED);
 
-        when(applicationService.getForStatesAndPerson(activeStatuses(), List.of(person), LocalDate.of(2022, 1, 1), LocalDate.of(2022, 12, 31)))
+        when(applicationService.getForStatesAndPerson(activeStatuses(), List.of(person), LocalDate.of(2022, JANUARY, 1), LocalDate.of(2022, DECEMBER, 31)))
             .thenReturn(List.of(application4Days, application1Day));
 
         final Year year = Year.of(2022);
-        final LocalDate firstDayOfYear = LocalDate.of(year.getValue(), 1, 1);
+        final LocalDate firstDayOfYear = LocalDate.of(year.getValue(), JANUARY, 1);
         final LocalDate lastDayOfYear = firstDayOfYear.with(lastDayOfYear());
 
         final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(firstDayOfYear, lastDayOfYear);
@@ -195,11 +195,11 @@ class VacationDaysServiceTest {
         application3Day.setEndDate(LocalDate.of(2022, MAY, 4));
         application3Day.setStatus(ALLOWED);
 
-        when(applicationService.getForStatesAndPerson(activeStatuses(), List.of(person), LocalDate.of(2022, 1, 1), LocalDate.of(2022, 12, 31)))
+        when(applicationService.getForStatesAndPerson(activeStatuses(), List.of(person), LocalDate.of(2022, JANUARY, 1), LocalDate.of(2022, DECEMBER, 31)))
             .thenReturn(List.of(application4Days, application3Day));
 
         final Year year = Year.of(2022);
-        final LocalDate firstDayOfYear = LocalDate.of(year.getValue(), 1, 1);
+        final LocalDate firstDayOfYear = LocalDate.of(year.getValue(), JANUARY, 1);
         final LocalDate lastDayOfYear = firstDayOfYear.with(lastDayOfYear());
 
         final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(firstDayOfYear, lastDayOfYear);
@@ -231,7 +231,7 @@ class VacationDaysServiceTest {
         application20Days.setEndDate(LocalDate.of(2022, APRIL, 20));
         application20Days.setStatus(ALLOWED);
 
-        when(applicationService.getForStatesAndPerson(activeStatuses(), List.of(person), LocalDate.of(2022, 1, 1), LocalDate.of(2022, 12, 31)))
+        when(applicationService.getForStatesAndPerson(activeStatuses(), List.of(person), LocalDate.of(2022, JANUARY, 1), LocalDate.of(2022, DECEMBER, 31)))
             .thenReturn(List.of(application4Days, application20Days));
 
         final Year year = Year.of(2022);
@@ -240,7 +240,7 @@ class VacationDaysServiceTest {
         account.setRemainingVacationDaysNotExpiring(new BigDecimal("2"));
         account.setDoRemainingVacationDaysExpireLocally(true);
 
-        final LocalDate firstDayOfYear = LocalDate.of(year.getValue(), 1, 1);
+        final LocalDate firstDayOfYear = LocalDate.of(year.getValue(), JANUARY, 1);
         final LocalDate lastDayOfYear = firstDayOfYear.with(lastDayOfYear());
 
         final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(firstDayOfYear, lastDayOfYear);
@@ -268,7 +268,7 @@ class VacationDaysServiceTest {
         application20Days.setEndDate(LocalDate.of(2022, APRIL, 20));
         application20Days.setStatus(ALLOWED);
 
-        when(applicationService.getForStatesAndPerson(activeStatuses(), List.of(person), LocalDate.of(2022, 1, 1), LocalDate.of(2022, 12, 31)))
+        when(applicationService.getForStatesAndPerson(activeStatuses(), List.of(person), LocalDate.of(2022, JANUARY, 1), LocalDate.of(2022, DECEMBER, 31)))
             .thenReturn(List.of(application4Days, application20Days));
 
         final Year year = Year.of(2022);
@@ -277,7 +277,7 @@ class VacationDaysServiceTest {
         account.setRemainingVacationDays(new BigDecimal("6"));
         account.setRemainingVacationDaysNotExpiring(new BigDecimal("2"));
 
-        final LocalDate firstDayOfYear = LocalDate.of(year.getValue(), 1, 1);
+        final LocalDate firstDayOfYear = LocalDate.of(year.getValue(), JANUARY, 1);
         final LocalDate lastDayOfYear = firstDayOfYear.with(lastDayOfYear());
 
         final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(firstDayOfYear, lastDayOfYear);
@@ -302,7 +302,7 @@ class VacationDaysServiceTest {
         application20Days.setStartDate(LocalDate.of(2022, APRIL, 1));
         application20Days.setEndDate(LocalDate.of(2022, APRIL, 20));
         application20Days.setStatus(ALLOWED);
-        when(applicationService.getForStatesAndPerson(activeStatuses(), List.of(person), LocalDate.of(2022, 1, 1), LocalDate.of(2022, 12, 31)))
+        when(applicationService.getForStatesAndPerson(activeStatuses(), List.of(person), LocalDate.of(2022, JANUARY, 1), LocalDate.of(2022, DECEMBER, 31)))
             .thenReturn(List.of(application4Days, application20Days));
 
         final Application application4DaysIn2023 = anyApplication(person);
@@ -313,7 +313,7 @@ class VacationDaysServiceTest {
         application20DaysIn2023.setStartDate(LocalDate.of(2022, APRIL, 1));
         application20DaysIn2023.setEndDate(LocalDate.of(2022, APRIL, 20));
         application20DaysIn2023.setStatus(ALLOWED);
-        when(applicationService.getForStatesAndPerson(activeStatuses(), List.of(person), LocalDate.of(2023, 1, 1), LocalDate.of(2023, 12, 31)))
+        when(applicationService.getForStatesAndPerson(activeStatuses(), List.of(person), LocalDate.of(2023, JANUARY, 1), LocalDate.of(2023, DECEMBER, 31)))
             .thenReturn(List.of(application4DaysIn2023, application20DaysIn2023));
 
         // 36 Total, using 24, so 12 left
@@ -353,7 +353,7 @@ class VacationDaysServiceTest {
         final Person person = anyPerson();
 
         final Year year = Year.of(2022);
-        final LocalDate firstDayOfYear = LocalDate.of(year.getValue(), 1, 1);
+        final LocalDate firstDayOfYear = LocalDate.of(year.getValue(), JANUARY, 1);
         final LocalDate lastDayOfYear = firstDayOfYear.with(lastDayOfYear());
 
         final Account account = anyAccount(person, Year.of(2022));
@@ -398,7 +398,7 @@ class VacationDaysServiceTest {
         final Person person = anyPerson();
 
         final int year = 2022;
-        final LocalDate firstDayOfYear = LocalDate.of(2022, 1, 1);
+        final LocalDate firstDayOfYear = LocalDate.of(2022, JANUARY, 1);
         final LocalDate lastDayOfYear = firstDayOfYear.with(lastDayOfYear());
 
         final Account account = anyAccount(person, Year.of(2022));
@@ -443,7 +443,7 @@ class VacationDaysServiceTest {
         final Person person = anyPerson();
 
         final int year = 2022;
-        final LocalDate firstDayOfYear = LocalDate.of(2022, 1, 1);
+        final LocalDate firstDayOfYear = LocalDate.of(2022, JANUARY, 1);
         final LocalDate lastDayOfYear = firstDayOfYear.with(lastDayOfYear());
 
         final Account account = anyAccount(person, Year.of(2022));
@@ -486,7 +486,7 @@ class VacationDaysServiceTest {
         final Person person = anyPerson();
 
         final int year = 2022;
-        final LocalDate firstDayOfYear = LocalDate.of(2022, 1, 1);
+        final LocalDate firstDayOfYear = LocalDate.of(2022, JANUARY, 1);
         final LocalDate lastDayOfYear = firstDayOfYear.with(lastDayOfYear());
 
         final Account account = anyAccount(person, Year.of(2022));
@@ -529,7 +529,7 @@ class VacationDaysServiceTest {
         final Person person = anyPerson();
 
         final int year = 2022;
-        final LocalDate firstDayOfYear = LocalDate.of(2022, 1, 1);
+        final LocalDate firstDayOfYear = LocalDate.of(2022, JANUARY, 1);
         final LocalDate lastDayOfYear = firstDayOfYear.with(lastDayOfYear());
 
         final Account account = anyAccount(person, Year.of(2022));
@@ -572,7 +572,7 @@ class VacationDaysServiceTest {
         final Person person = anyPerson();
 
         final int year = 2022;
-        final LocalDate firstDayOfYear = LocalDate.of(2022, 1, 1);
+        final LocalDate firstDayOfYear = LocalDate.of(2022, JANUARY, 1);
         final LocalDate lastDayOfYear = firstDayOfYear.with(lastDayOfYear());
 
         final Account account = anyAccount(person, Year.of(2022));
@@ -615,7 +615,7 @@ class VacationDaysServiceTest {
         final Person person = anyPerson();
 
         final int year = 2022;
-        final LocalDate firstDayOfYear = LocalDate.of(2022, 1, 1);
+        final LocalDate firstDayOfYear = LocalDate.of(2022, JANUARY, 1);
         final LocalDate lastDayOfYear = firstDayOfYear.with(lastDayOfYear());
 
         final Account account = anyAccount(person, Year.of(2022));
@@ -727,7 +727,7 @@ class VacationDaysServiceTest {
         account.setRemainingVacationDaysNotExpiring(BigDecimal.valueOf(2));
         account.setDoRemainingVacationDaysExpireLocally(true);
 
-        when(applicationService.getForStatesAndPerson(activeStatuses(), List.of(person), LocalDate.of(year, 1, 1), LocalDate.of(year, 12, 31)))
+        when(applicationService.getForStatesAndPerson(activeStatuses(), List.of(person), LocalDate.of(year, JANUARY, 1), LocalDate.of(year, DECEMBER, 31)))
             .thenReturn(List.of());
 
         when(workingTimeCalendarService.getWorkingTimesByPersons(List.of(person), Year.of(year)))

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewControllerTest.java
@@ -45,6 +45,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
 import static java.util.Locale.GERMAN;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -1568,7 +1570,7 @@ class ApplicationForLeaveDetailsViewControllerTest {
         final LocalDate now = LocalDate.now(clock);
         final LocalDate expiryDate = now.minusDays(1);
 
-        final Account account = new Account(person, LocalDate.of(year, 1, 1), LocalDate.of(year, 12, 31), true, expiryDate,
+        final Account account = new Account(person, LocalDate.of(year, JANUARY, 1), LocalDate.of(year, DECEMBER, 31), true, expiryDate,
             BigDecimal.valueOf(10), BigDecimal.valueOf(5), BigDecimal.valueOf(1), "");
 
         when(accountService.getHolidaysAccount(year, person)).thenReturn(Optional.of(account));

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveFormTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveFormTest.java
@@ -11,6 +11,8 @@ import java.time.LocalTime;
 import java.util.List;
 
 import static java.math.BigDecimal.ONE;
+import static java.time.Month.FEBRUARY;
+import static java.time.Month.JANUARY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.synyx.urlaubsverwaltung.application.vacationtype.VacationCategory.HOLIDAY;
 
@@ -132,10 +134,10 @@ class ApplicationForLeaveFormTest {
         final Person person = new Person();
         final Person holidayReplacement = new Person();
 
-        final LocalDate startDate = LocalDate.of(2022, 1, 2);
+        final LocalDate startDate = LocalDate.of(2022, JANUARY, 2);
         final LocalTime startTime = LocalTime.of(11, 10, 0);
 
-        final LocalDate endDate = LocalDate.of(2022, 2, 2);
+        final LocalDate endDate = LocalDate.of(2022, FEBRUARY, 2);
         final LocalTime endTime = LocalTime.of(12, 10, 0);
 
         final HolidayReplacementDto replacementDto = new HolidayReplacementDto();

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveFormValidatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveFormValidatorTest.java
@@ -41,6 +41,9 @@ import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.ZERO;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
+import static java.time.Month.OCTOBER;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -145,8 +148,8 @@ class ApplicationForLeaveFormValidatorTest {
         when(vacationTypeService.getById(1L)).thenReturn(Optional.of(anyVacationType()));
 
         final ApplicationForLeaveForm appForm = appFormBuilderWithDefaults()
-            .startDate(LocalDate.of(2012, 1, 17))
-            .endDate(LocalDate.of(2012, 1, 12))
+            .startDate(LocalDate.of(2012, JANUARY, 17))
+            .endDate(LocalDate.of(2012, JANUARY, 12))
             .build();
 
         sut.validate(appForm, errors);
@@ -291,7 +294,7 @@ class ApplicationForLeaveFormValidatorTest {
         when(calculationService.checkApplication(any(Application.class))).thenReturn(TRUE);
         when(vacationTypeService.getById(1L)).thenReturn(Optional.of(anyVacationType()));
 
-        final LocalDate date = LocalDate.of(Year.now(UTC).getValue(), 10, 10);
+        final LocalDate date = LocalDate.of(Year.now(UTC).getValue(), OCTOBER, 10);
 
         final ApplicationForLeaveForm appForm = appFormBuilderWithDefaults()
             .dayLength(NOON)
@@ -1186,8 +1189,8 @@ class ApplicationForLeaveFormValidatorTest {
 
         final ApplicationForLeaveForm appForm = appFormBuilderWithDefaults()
             .dayLength(MORNING)
-            .startDate(LocalDate.of(actualYear, 12, 24))
-            .endDate(LocalDate.of(actualYear, 12, 24))
+            .startDate(LocalDate.of(actualYear, DECEMBER, 24))
+            .endDate(LocalDate.of(actualYear, DECEMBER, 24))
             .build();
 
         sut.validate(appForm, errors);
@@ -1211,8 +1214,8 @@ class ApplicationForLeaveFormValidatorTest {
 
         final ApplicationForLeaveForm appForm = appFormBuilderWithDefaults()
             .dayLength(MORNING)
-            .startDate(LocalDate.of(actualYear, 12, 24))
-            .endDate(LocalDate.of(actualYear, 12, 24))
+            .startDate(LocalDate.of(actualYear, DECEMBER, 24))
+            .endDate(LocalDate.of(actualYear, DECEMBER, 24))
             .build();
 
         sut.validate(appForm, errors);
@@ -1235,8 +1238,8 @@ class ApplicationForLeaveFormValidatorTest {
 
         final ApplicationForLeaveForm appForm = appFormBuilderWithDefaults()
             .dayLength(NOON)
-            .startDate(LocalDate.of(actualYear, 12, 24))
-            .endDate(LocalDate.of(actualYear, 12, 24))
+            .startDate(LocalDate.of(actualYear, DECEMBER, 24))
+            .endDate(LocalDate.of(actualYear, DECEMBER, 24))
             .build();
 
         sut.validate(appForm, errors);
@@ -1258,7 +1261,7 @@ class ApplicationForLeaveFormValidatorTest {
 
         final int actualYear = Year.now().getValue();
 
-        final LocalDate christmasEve = LocalDate.of(actualYear, 12, 24);
+        final LocalDate christmasEve = LocalDate.of(actualYear, DECEMBER, 24);
         final ApplicationForLeaveForm appForm = appFormBuilderWithDefaults()
             .dayLength(dayLength)
             .startDate(christmasEve)
@@ -1285,8 +1288,8 @@ class ApplicationForLeaveFormValidatorTest {
 
         final ApplicationForLeaveForm appForm = appFormBuilderWithDefaults()
             .dayLength(MORNING)
-            .startDate(LocalDate.of(actualYear, 12, 31))
-            .endDate(LocalDate.of(actualYear, 12, 31))
+            .startDate(LocalDate.of(actualYear, DECEMBER, 31))
+            .endDate(LocalDate.of(actualYear, DECEMBER, 31))
             .build();
 
         sut.validate(appForm, errors);
@@ -1309,8 +1312,8 @@ class ApplicationForLeaveFormValidatorTest {
 
         final ApplicationForLeaveForm appForm = appFormBuilderWithDefaults()
             .dayLength(MORNING)
-            .startDate(LocalDate.of(actualYear, 12, 31))
-            .endDate(LocalDate.of(actualYear, 12, 31))
+            .startDate(LocalDate.of(actualYear, DECEMBER, 31))
+            .endDate(LocalDate.of(actualYear, DECEMBER, 31))
             .build();
 
         sut.validate(appForm, errors);
@@ -1333,8 +1336,8 @@ class ApplicationForLeaveFormValidatorTest {
 
         final ApplicationForLeaveForm appForm = appFormBuilderWithDefaults()
             .dayLength(NOON)
-            .startDate(LocalDate.of(actualYear, 12, 31))
-            .endDate(LocalDate.of(actualYear, 12, 31))
+            .startDate(LocalDate.of(actualYear, DECEMBER, 31))
+            .endDate(LocalDate.of(actualYear, DECEMBER, 31))
             .build();
 
         sut.validate(appForm, errors);
@@ -1356,7 +1359,7 @@ class ApplicationForLeaveFormValidatorTest {
 
         final int actualYear = Year.now().getValue();
 
-        final LocalDate christmasEve = LocalDate.of(actualYear, 12, 31);
+        final LocalDate christmasEve = LocalDate.of(actualYear, DECEMBER, 31);
         final ApplicationForLeaveForm appForm = appFormBuilderWithDefaults()
             .dayLength(dayLength)
             .startDate(christmasEve)

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveTest.java
@@ -12,6 +12,9 @@ import static java.math.BigDecimal.TEN;
 import static java.time.DayOfWeek.FRIDAY;
 import static java.time.DayOfWeek.TUESDAY;
 import static java.time.LocalDate.of;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
+import static java.time.Month.MARCH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.synyx.urlaubsverwaltung.TestDataCreator.createApplication;
@@ -24,7 +27,7 @@ class ApplicationForLeaveTest {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
 
-        final Application application = createApplication(person, of(2015, 3, 3), of(2015, 3, 6), FULL, new StaticMessageSource());
+        final Application application = createApplication(person, of(2015, MARCH, 3), of(2015, MARCH, 6), FULL, new StaticMessageSource());
 
         final SortedMap<Integer, BigDecimal> workDaysByYear = new TreeMap<>();
         workDaysByYear.put(2015, TEN);
@@ -42,7 +45,7 @@ class ApplicationForLeaveTest {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
 
-        final Application application = createApplication(person, of(2025, 12, 29), of(2026, 1, 2), FULL, new StaticMessageSource());
+        final Application application = createApplication(person, of(2025, DECEMBER, 29), of(2026, JANUARY, 2), FULL, new StaticMessageSource());
 
         final SortedMap<Integer, BigDecimal> workDaysByYear = new TreeMap<>();
         workDaysByYear.put(2025, BigDecimal.valueOf(3));
@@ -58,7 +61,7 @@ class ApplicationForLeaveTest {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
 
-        final Application application = createApplication(person, of(2016, 3, 1), of(2016, 3, 4), FULL, new StaticMessageSource());
+        final Application application = createApplication(person, of(2016, MARCH, 1), of(2016, MARCH, 4), FULL, new StaticMessageSource());
 
         final SortedMap<Integer, BigDecimal> workDaysByYear = new TreeMap<>();
         workDaysByYear.put(2016, BigDecimal.valueOf(4));

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveViewControllerTest.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import static java.time.Month.JANUARY;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -1573,8 +1574,8 @@ class ApplicationForLeaveViewControllerTest {
         final Person person = new Person();
         person.setFirstName("Hans");
         person.setLastName("Dampf");
-        final LocalDate startDate = LocalDate.of(2024, 1, 4);
-        final LocalDate endDate = LocalDate.of(2024, 1, 5);
+        final LocalDate startDate = LocalDate.of(2024, JANUARY, 4);
+        final LocalDate endDate = LocalDate.of(2024, JANUARY, 5);
         final Map<LocalDate, WorkingTimeCalendar.WorkingDayInformation> workingDays = Map.of(
             startDate, new WorkingTimeCalendar.WorkingDayInformation(FULL, WORKDAY, WORKDAY),
             endDate, new WorkingTimeCalendar.WorkingDayInformation(FULL, WORKDAY, WORKDAY)
@@ -1628,8 +1629,8 @@ class ApplicationForLeaveViewControllerTest {
         final Person person = new Person();
         person.setFirstName("Hans");
         person.setLastName("Dampf");
-        final LocalDate startDate = LocalDate.of(2024, 1, 4);
-        final LocalDate endDate = LocalDate.of(2024, 1, 5);
+        final LocalDate startDate = LocalDate.of(2024, JANUARY, 4);
+        final LocalDate endDate = LocalDate.of(2024, JANUARY, 5);
         final Map<LocalDate, WorkingTimeCalendar.WorkingDayInformation> workingDays = Map.of(
             startDate, new WorkingTimeCalendar.WorkingDayInformation(FULL, WORKDAY, WORKDAY),
             endDate, new WorkingTimeCalendar.WorkingDayInformation(FULL, WORKDAY, WORKDAY)
@@ -1683,8 +1684,8 @@ class ApplicationForLeaveViewControllerTest {
         final Person person = new Person();
         person.setFirstName("Hans");
         person.setLastName("Dampf");
-        final LocalDate startDate = LocalDate.of(2024, 1, 4);
-        final LocalDate endDate = LocalDate.of(2024, 1, 5);
+        final LocalDate startDate = LocalDate.of(2024, JANUARY, 4);
+        final LocalDate endDate = LocalDate.of(2024, JANUARY, 5);
         final Map<LocalDate, WorkingTimeCalendar.WorkingDayInformation> workingDays = Map.of(
             startDate, new WorkingTimeCalendar.WorkingDayInformation(FULL, WORKDAY, WORKDAY),
             endDate, new WorkingTimeCalendar.WorkingDayInformation(FULL, WORKDAY, WORKDAY)
@@ -1738,8 +1739,8 @@ class ApplicationForLeaveViewControllerTest {
         final Person person = new Person();
         person.setFirstName("Hans");
         person.setLastName("Dampf");
-        final LocalDate startDate = LocalDate.of(2024, 1, 4);
-        final LocalDate endDate = LocalDate.of(2024, 1, 5);
+        final LocalDate startDate = LocalDate.of(2024, JANUARY, 4);
+        final LocalDate endDate = LocalDate.of(2024, JANUARY, 5);
         final Map<LocalDate, WorkingTimeCalendar.WorkingDayInformation> workingDays = Map.of(
             startDate, new WorkingTimeCalendar.WorkingDayInformation(FULL, WORKDAY, WORKDAY),
             endDate, new WorkingTimeCalendar.WorkingDayInformation(FULL, WORKDAY, WORKDAY)

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationInteractionServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationInteractionServiceImplTest.java
@@ -28,6 +28,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static java.time.Month.DECEMBER;
+import static java.time.Month.FEBRUARY;
+import static java.time.Month.JANUARY;
+import static java.time.Month.OCTOBER;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -1015,8 +1019,8 @@ class ApplicationInteractionServiceImplTest {
         final Application applicationForLeave = new Application();
         applicationForLeave.setPerson(person);
         applicationForLeave.setStatus(ALLOWED);
-        applicationForLeave.setStartDate(LocalDate.of(2014, 12, 24));
-        applicationForLeave.setEndDate(LocalDate.of(2015, 1, 7));
+        applicationForLeave.setStartDate(LocalDate.of(2014, DECEMBER, 24));
+        applicationForLeave.setEndDate(LocalDate.of(2015, JANUARY, 7));
         applicationForLeave.setDayLength(DayLength.FULL);
         when(applicationService.save(applicationForLeave)).thenReturn(applicationForLeave);
 
@@ -1114,8 +1118,8 @@ class ApplicationInteractionServiceImplTest {
         final Application applicationForLeave = new Application();
         applicationForLeave.setPerson(person);
         applicationForLeave.setStatus(ALLOWED_CANCELLATION_REQUESTED);
-        applicationForLeave.setStartDate(LocalDate.of(2014, 12, 24));
-        applicationForLeave.setEndDate(LocalDate.of(2015, 1, 7));
+        applicationForLeave.setStartDate(LocalDate.of(2014, DECEMBER, 24));
+        applicationForLeave.setEndDate(LocalDate.of(2015, JANUARY, 7));
         applicationForLeave.setDayLength(DayLength.FULL);
         when(applicationService.save(applicationForLeave)).thenReturn(applicationForLeave);
 
@@ -1149,8 +1153,8 @@ class ApplicationInteractionServiceImplTest {
         final Application applicationForLeave = new Application();
         applicationForLeave.setPerson(person);
         applicationForLeave.setStatus(ALLOWED);
-        applicationForLeave.setStartDate(LocalDate.of(2014, 12, 24));
-        applicationForLeave.setEndDate(LocalDate.of(2015, 1, 7));
+        applicationForLeave.setStartDate(LocalDate.of(2014, DECEMBER, 24));
+        applicationForLeave.setEndDate(LocalDate.of(2015, JANUARY, 7));
         applicationForLeave.setDayLength(DayLength.FULL);
 
         assertThatThrownBy(() -> sut.declineCancellationRequest(applicationForLeave, canceller, comment))
@@ -1169,8 +1173,8 @@ class ApplicationInteractionServiceImplTest {
         final Application applicationForLeave = new Application();
         applicationForLeave.setPerson(person);
         applicationForLeave.setStatus(null);
-        applicationForLeave.setStartDate(LocalDate.of(2014, 12, 24));
-        applicationForLeave.setEndDate(LocalDate.of(2015, 1, 7));
+        applicationForLeave.setStartDate(LocalDate.of(2014, DECEMBER, 24));
+        applicationForLeave.setEndDate(LocalDate.of(2015, JANUARY, 7));
         applicationForLeave.setDayLength(DayLength.FULL);
         when(applicationService.save(applicationForLeave)).thenReturn(applicationForLeave);
 
@@ -1527,15 +1531,15 @@ class ApplicationInteractionServiceImplTest {
         final Application newApplication = createApplication(person, createVacationType(1L, HOLIDAY, new StaticMessageSource()));
         newApplication.setStatus(WAITING);
         newApplication.setId(applicationId);
-        newApplication.setStartDate(LocalDate.of(2020, 10, 3));
-        newApplication.setEndDate(LocalDate.of(2020, 10, 3));
+        newApplication.setStartDate(LocalDate.of(2020, OCTOBER, 3));
+        newApplication.setEndDate(LocalDate.of(2020, OCTOBER, 3));
         newApplication.setHolidayReplacements(List.of(replacementEntity));
         when(applicationService.save(newApplication)).thenReturn(newApplication);
 
         final Application oldApplication = createApplication(person, createVacationType(1L, HOLIDAY, new StaticMessageSource()));
         oldApplication.setHolidayReplacements(List.of(replacementEntity));
-        oldApplication.setStartDate(LocalDate.of(2020, 10, 4));
-        oldApplication.setEndDate(LocalDate.of(2020, 10, 4));
+        oldApplication.setStartDate(LocalDate.of(2020, OCTOBER, 4));
+        oldApplication.setEndDate(LocalDate.of(2020, OCTOBER, 4));
 
         final Optional<String> comment = of("Comment");
 
@@ -1688,8 +1692,8 @@ class ApplicationInteractionServiceImplTest {
 
         final Application applicationForLeave = new Application();
         applicationForLeave.setPerson(person);
-        applicationForLeave.setStartDate(LocalDate.of(2013, 2, 1));
-        applicationForLeave.setEndDate(LocalDate.of(2013, 2, 5));
+        applicationForLeave.setStartDate(LocalDate.of(2013, FEBRUARY, 1));
+        applicationForLeave.setEndDate(LocalDate.of(2013, FEBRUARY, 5));
         applicationForLeave.setDayLength(DayLength.FULL);
         applicationForLeave.setHolidayReplacements(List.of(replacementEntity));
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationMailServiceIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationMailServiceIT.java
@@ -32,14 +32,16 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.Month;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Objects;
 
 import static java.time.Month.APRIL;
+import static java.time.Month.AUGUST;
 import static java.time.Month.DECEMBER;
 import static java.time.Month.FEBRUARY;
+import static java.time.Month.JANUARY;
+import static java.time.Month.JUNE;
 import static java.time.Month.MAY;
 import static java.time.Month.NOVEMBER;
 import static java.time.ZoneOffset.UTC;
@@ -500,9 +502,9 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         boss.setNotifications(List.of(NOTIFICATION_EMAIL_APPLICATION_MANAGEMENT_REJECTED));
 
         final Application application = createApplication(person);
-        application.setStartDate(LocalDate.of(2023, 5, 22));
-        application.setEndDate(LocalDate.of(2023, 5, 22));
-        application.setApplicationDate(LocalDate.of(2023, 5, 22));
+        application.setStartDate(LocalDate.of(2023, MAY, 22));
+        application.setEndDate(LocalDate.of(2023, MAY, 22));
+        application.setApplicationDate(LocalDate.of(2023, MAY, 22));
         application.setBoss(boss);
 
         final ApplicationComment comment = new ApplicationComment(
@@ -591,9 +593,9 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         final Person boss = new Person("boss", "Boss", "Hugo", "boss@example.org");
 
         final Application application = createApplication(recipient);
-        application.setApplicationDate(LocalDate.of(2022, 5, 19));
-        application.setStartDate(LocalDate.of(2022, 5, 20));
-        application.setEndDate(LocalDate.of(2022, 5, 29));
+        application.setApplicationDate(LocalDate.of(2022, MAY, 19));
+        application.setStartDate(LocalDate.of(2022, MAY, 20));
+        application.setEndDate(LocalDate.of(2022, MAY, 29));
         application.setBoss(boss);
 
         sut.sendReferredToManagementNotification(application, recipient, sender);
@@ -646,8 +648,8 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
 
         final Application application = createApplication(person);
         application.setStatus(ApplicationStatus.ALLOWED);
-        application.setStartDate(LocalDate.of(2020, 5, 29));
-        application.setEndDate(LocalDate.of(2020, 5, 29));
+        application.setStartDate(LocalDate.of(2020, MAY, 29));
+        application.setEndDate(LocalDate.of(2020, MAY, 29));
 
         final ApplicationComment comment = new ApplicationComment(
             1L, Instant.now(clock), application, ApplicationCommentAction.CANCEL_REQUESTED_DECLINED, office, "Stornierung abgelehnt!");
@@ -735,8 +737,8 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         final Person office = personService.create("office", "Marlene", "Muster", "office@example.org", List.of(NOTIFICATION_EMAIL_APPLICATION_MANAGEMENT_CANCELLATION_REQUESTED), List.of(OFFICE));
 
         final Application application = createApplication(person);
-        application.setStartDate(LocalDate.of(2020, 5, 29));
-        application.setEndDate(LocalDate.of(2020, 5, 29));
+        application.setStartDate(LocalDate.of(2020, MAY, 29));
+        application.setEndDate(LocalDate.of(2020, MAY, 29));
 
         final ApplicationComment comment = new ApplicationComment(
             1L, Instant.now(clock), application, ApplicationCommentAction.CANCEL_REQUESTED, person, "Bitte stornieren!");
@@ -1088,8 +1090,8 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         final Person person = new Person("user", "Müller", "Lieschen", "lieschen@example.org");
 
         final Application application = createApplication(person);
-        application.setStartDate(LocalDate.of(2020, 12, 18));
-        application.setEndDate(LocalDate.of(2020, 12, 18));
+        application.setStartDate(LocalDate.of(2020, DECEMBER, 18));
+        application.setEndDate(LocalDate.of(2020, DECEMBER, 18));
         application.setApplier(applier);
 
         final Person holidayReplacement = new Person("replacement", "Teria", "Mar", "replacement@example.org");
@@ -1141,8 +1143,8 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
 
         final Person person = new Person("user", "Müller", "Lieschen", "lieschen@example.org");
         final Application application = createApplication(person);
-        application.setStartDate(LocalDate.of(2020, 12, 18));
-        application.setEndDate(LocalDate.of(2020, 12, 18));
+        application.setStartDate(LocalDate.of(2020, DECEMBER, 18));
+        application.setEndDate(LocalDate.of(2020, DECEMBER, 18));
 
         final Person holidayReplacement = new Person("replacement", "Teria", "Mar", "replacement@example.org");
         holidayReplacement.setId(1L);
@@ -1190,8 +1192,8 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         final Person person = new Person("user", "Müller", "Lieschen", "lieschen@example.org");
         final Application application = createApplication(person);
         application.setBoss(boss);
-        application.setStartDate(LocalDate.of(2020, 5, 29));
-        application.setEndDate(LocalDate.of(2020, 5, 29));
+        application.setStartDate(LocalDate.of(2020, MAY, 29));
+        application.setEndDate(LocalDate.of(2020, MAY, 29));
 
         final Person holidayReplacement = new Person("replacement", "Teria", "Mar", "replacement@example.org");
         holidayReplacement.setId(1L);
@@ -1241,8 +1243,8 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
 
         final Person person = new Person("user", "Müller", "Lieschen", "lieschen@example.org");
         final Application application = createApplication(person);
-        application.setStartDate(LocalDate.of(2020, 12, 18));
-        application.setEndDate(LocalDate.of(2020, 12, 18));
+        application.setStartDate(LocalDate.of(2020, DECEMBER, 18));
+        application.setEndDate(LocalDate.of(2020, DECEMBER, 18));
 
         final Person holidayReplacement = new Person("replacement", "Teria", "Mar", "replacement@example.org");
         holidayReplacement.setId(1L);
@@ -1288,8 +1290,8 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         final Person person = new Person("user", "Müller", "Lieschen", "lieschen@example.org");
         final Application application = createApplication(person);
         application.setStatus(WAITING);
-        application.setStartDate(LocalDate.of(2020, 12, 18));
-        application.setEndDate(LocalDate.of(2020, 12, 18));
+        application.setStartDate(LocalDate.of(2020, DECEMBER, 18));
+        application.setEndDate(LocalDate.of(2020, DECEMBER, 18));
 
         final Person holidayReplacement = new Person("replacement", "Teria", "Mar", "replacement@example.org");
         holidayReplacement.setNotifications(List.of(NOTIFICATION_EMAIL_APPLICATION_HOLIDAY_REPLACEMENT));
@@ -1336,8 +1338,8 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         final Person person = new Person("user", "Müller", "Lieschen", "lieschen@example.org");
         final Application application = createApplication(person);
         application.setStatus(ALLOWED);
-        application.setStartDate(LocalDate.of(2020, 12, 18));
-        application.setEndDate(LocalDate.of(2020, 12, 18));
+        application.setStartDate(LocalDate.of(2020, DECEMBER, 18));
+        application.setEndDate(LocalDate.of(2020, DECEMBER, 18));
 
         final Person holidayReplacement = new Person("replacement", "Teria", "Mar", "replacement@example.org");
         holidayReplacement.setNotifications(List.of(NOTIFICATION_EMAIL_APPLICATION_HOLIDAY_REPLACEMENT));
@@ -1408,9 +1410,9 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         person.setNotifications(List.of(NOTIFICATION_EMAIL_APPLICATION_APPLIED));
 
         final Application application = createApplication(person);
-        application.setStartDate(LocalDate.of(2024, 8, 8));
-        application.setEndDate(LocalDate.of(2024, 8, 8));
-        application.setApplicationDate(LocalDate.of(2024, 8, 8));
+        application.setStartDate(LocalDate.of(2024, AUGUST, 8));
+        application.setEndDate(LocalDate.of(2024, AUGUST, 8));
+        application.setApplicationDate(LocalDate.of(2024, AUGUST, 8));
 
         final ApplicationComment comment = new ApplicationComment(
             1L, Instant.now(clock), application, ApplicationCommentAction.APPLIED, person, "Hätte gerne Urlaub");
@@ -1578,9 +1580,9 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         person.setNotifications(List.of(NOTIFICATION_EMAIL_APPLICATION_APPLIED));
 
         final Application application = createApplication(person);
-        application.setStartDate(LocalDate.of(2024, 8, 8));
-        application.setEndDate(LocalDate.of(2024, 8, 8));
-        application.setApplicationDate(LocalDate.of(2024, 8, 8));
+        application.setStartDate(LocalDate.of(2024, AUGUST, 8));
+        application.setEndDate(LocalDate.of(2024, AUGUST, 8));
+        application.setApplicationDate(LocalDate.of(2024, AUGUST, 8));
 
         final ApplicationComment comment = new ApplicationComment(
             1L, Instant.now(clock), application, ApplicationCommentAction.APPLIED, person, "Habe das mal für dich beantragt");
@@ -1760,7 +1762,7 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
 
         final Application application = createApplication(person);
         application.setCanceller(person);
-        application.setApplicationDate(LocalDate.of(2024, 8, 8));
+        application.setApplicationDate(LocalDate.of(2024, AUGUST, 8));
 
         final ApplicationComment comment = new ApplicationComment(
             1L, Instant.now(clock), application, ApplicationCommentAction.REVOKED, person, "Wrong date - revoked");
@@ -1825,7 +1827,7 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         person.setNotifications(List.of(NOTIFICATION_EMAIL_APPLICATION_REVOKED));
 
         final Application application = createApplication(person);
-        application.setApplicationDate(LocalDate.of(2024, 8, 8));
+        application.setApplicationDate(LocalDate.of(2024, AUGUST, 8));
 
         final Person office = new Person("office", "Person", "Office", "office@example.org");
         application.setCanceller(office);
@@ -2121,9 +2123,9 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         office.setNotifications(List.of(NOTIFICATION_EMAIL_APPLICATION_MANAGEMENT_CANCELLATION));
 
         final Application application = createApplication(person);
-        application.setApplicationDate(LocalDate.of(2020, 5, 29));
-        application.setStartDate(LocalDate.of(2020, 6, 15));
-        application.setEndDate(LocalDate.of(2020, 6, 15));
+        application.setApplicationDate(LocalDate.of(2020, MAY, 29));
+        application.setStartDate(LocalDate.of(2020, JUNE, 15));
+        application.setEndDate(LocalDate.of(2020, JUNE, 15));
         application.setCanceller(office);
         application.setDayLength(FULL);
 
@@ -2245,9 +2247,9 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         final Person person = new Person("user", "Müller", "Lieschen", "lieschen@example.org");
 
         final Application application = createApplication(person);
-        application.setStartDate(LocalDate.of(2023, 5, 22));
-        application.setEndDate(LocalDate.of(2023, 5, 22));
-        application.setApplicationDate(LocalDate.of(2023, 5, 22));
+        application.setStartDate(LocalDate.of(2023, MAY, 22));
+        application.setEndDate(LocalDate.of(2023, MAY, 22));
+        application.setApplicationDate(LocalDate.of(2023, MAY, 22));
 
         final ApplicationComment comment = new ApplicationComment(
             1L, Instant.now(clock), application, ApplicationCommentAction.APPLIED, person, "Hätte gerne Urlaub");
@@ -2348,9 +2350,9 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         departmentHead.setNotifications(List.of(NOTIFICATION_EMAIL_APPLICATION_MANAGEMENT_APPLIED));
 
         final Application application = createApplication(secondStage);
-        application.setStartDate(LocalDate.of(2023, 5, 22));
-        application.setEndDate(LocalDate.of(2023, 5, 22));
-        application.setApplicationDate(LocalDate.of(2023, 5, 22));
+        application.setStartDate(LocalDate.of(2023, MAY, 22));
+        application.setEndDate(LocalDate.of(2023, MAY, 22));
+        application.setApplicationDate(LocalDate.of(2023, MAY, 22));
 
         final ApplicationComment comment = new ApplicationComment(
             1L, Instant.now(clock), application, ApplicationCommentAction.APPLIED, secondStage, "Hätte gerne Urlaub");
@@ -2453,9 +2455,9 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         departmentHead.setPermissions(List.of(DEPARTMENT_HEAD));
 
         final Application application = createApplication(departmentHead);
-        application.setStartDate(LocalDate.of(2023, 5, 22));
-        application.setEndDate(LocalDate.of(2023, 5, 22));
-        application.setApplicationDate(LocalDate.of(2023, 5, 22));
+        application.setStartDate(LocalDate.of(2023, MAY, 22));
+        application.setEndDate(LocalDate.of(2023, MAY, 22));
+        application.setApplicationDate(LocalDate.of(2023, MAY, 22));
 
         final ApplicationComment comment = new ApplicationComment(
             1L, Instant.now(clock), application, ApplicationCommentAction.APPLIED, departmentHead, "Hätte gerne Urlaub");
@@ -3301,7 +3303,7 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
 
         final Person person = new Person("user", "Müller", "Lieschen", "lieschen@example.org");
         final Application application = createApplication(person);
-        application.setApplicationDate(LocalDate.of(2024, 8, 8));
+        application.setApplicationDate(LocalDate.of(2024, AUGUST, 8));
 
         when(mailRecipientService.getResponsibleManagersOf(application.getPerson())).thenReturn(asList(boss, departmentHead));
 
@@ -3665,8 +3667,8 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         final Person holidayReplacement = new Person("holidayReplacement", "holiday", "replacement", "holidayreplacement@example.org");
 
         final Application application = createApplication(person);
-        application.setStartDate(LocalDate.of(2022, Month.JANUARY, 2));
-        application.setEndDate(LocalDate.of(2022, Month.JANUARY, 3));
+        application.setStartDate(LocalDate.of(2022, JANUARY, 2));
+        application.setEndDate(LocalDate.of(2022, JANUARY, 3));
 
         final HolidayReplacementEntity holidayReplacementEntity = new HolidayReplacementEntity();
         holidayReplacementEntity.setPerson(holidayReplacement);
@@ -3715,8 +3717,8 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         final Person holidayReplacement = new Person("holidayReplacement", "holiday", "replacement", "holidayreplacement@example.org");
 
         final Application application = createApplication(person);
-        application.setStartDate(LocalDate.of(2022, Month.JANUARY, 3));
-        application.setEndDate(LocalDate.of(2022, Month.JANUARY, 3));
+        application.setStartDate(LocalDate.of(2022, JANUARY, 3));
+        application.setEndDate(LocalDate.of(2022, JANUARY, 3));
         final HolidayReplacementEntity holidayReplacementEntity = new HolidayReplacementEntity();
         holidayReplacementEntity.setPerson(holidayReplacement);
         holidayReplacementEntity.setNote("Some notes");
@@ -3842,8 +3844,8 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         person.setId(1L);
         person.setNotifications(List.of(NOTIFICATION_EMAIL_APPLICATION_UPCOMING));
         final Application application = createApplication(person);
-        application.setStartDate(LocalDate.of(2022, Month.JANUARY, 31));
-        application.setEndDate(LocalDate.of(2022, Month.JANUARY, 31));
+        application.setStartDate(LocalDate.of(2022, JANUARY, 31));
+        application.setEndDate(LocalDate.of(2022, JANUARY, 31));
 
         sut.sendRemindForUpcomingApplicationsReminderNotification(List.of(application));
 
@@ -3882,8 +3884,8 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         person.setId(1L);
         person.setNotifications(List.of(NOTIFICATION_EMAIL_APPLICATION_UPCOMING));
         final Application application = createApplication(person);
-        application.setStartDate(LocalDate.of(2022, Month.JANUARY, 31));
-        application.setEndDate(LocalDate.of(2022, Month.JANUARY, 31));
+        application.setStartDate(LocalDate.of(2022, JANUARY, 31));
+        application.setEndDate(LocalDate.of(2022, JANUARY, 31));
 
         sut.sendRemindForUpcomingApplicationsReminderNotification(List.of(application));
 
@@ -3924,8 +3926,8 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         final Person holidayReplacement = new Person("pennyworth", "Pennyworth", "Alfred", "pennyworth@example.org");
 
         final Application application = createApplication(person);
-        application.setStartDate(LocalDate.of(2022, Month.JANUARY, 2));
-        application.setEndDate(LocalDate.of(2022, Month.JANUARY, 2));
+        application.setStartDate(LocalDate.of(2022, JANUARY, 2));
+        application.setEndDate(LocalDate.of(2022, JANUARY, 2));
 
         final HolidayReplacementEntity holidayReplacementEntity = new HolidayReplacementEntity();
         holidayReplacementEntity.setPerson(holidayReplacement);
@@ -3976,8 +3978,8 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         final Person holidayReplacement = new Person("pennyworth", "Pennyworth", "Alfred", "pennyworth@example.org");
 
         final Application application = createApplication(person);
-        application.setStartDate(LocalDate.of(2022, Month.JANUARY, 2));
-        application.setEndDate(LocalDate.of(2022, Month.JANUARY, 2));
+        application.setStartDate(LocalDate.of(2022, JANUARY, 2));
+        application.setEndDate(LocalDate.of(2022, JANUARY, 2));
 
         final HolidayReplacementEntity holidayReplacementEntity = new HolidayReplacementEntity();
         holidayReplacementEntity.setPerson(holidayReplacement);
@@ -4031,8 +4033,8 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         final Person holidayReplacementTwo = new Person("rob", "", "Robin", "robin@example.org");
 
         final Application application = createApplication(person);
-        application.setStartDate(LocalDate.of(2022, Month.JANUARY, 2));
-        application.setEndDate(LocalDate.of(2022, Month.JANUARY, 2));
+        application.setStartDate(LocalDate.of(2022, JANUARY, 2));
+        application.setEndDate(LocalDate.of(2022, JANUARY, 2));
 
         final HolidayReplacementEntity holidayReplacementOneEntity = new HolidayReplacementEntity();
         holidayReplacementOneEntity.setPerson(holidayReplacementOne);
@@ -4090,8 +4092,8 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         final Person holidayReplacementTwo = new Person("rob", "", "Robin", "robin@example.org");
 
         final Application application = createApplication(person);
-        application.setStartDate(LocalDate.of(2022, Month.JANUARY, 2));
-        application.setEndDate(LocalDate.of(2022, Month.JANUARY, 2));
+        application.setStartDate(LocalDate.of(2022, JANUARY, 2));
+        application.setEndDate(LocalDate.of(2022, JANUARY, 2));
 
         final HolidayReplacementEntity holidayReplacementOneEntity = new HolidayReplacementEntity();
         holidayReplacementOneEntity.setPerson(holidayReplacementOne);
@@ -4148,8 +4150,8 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         final Person holidayReplacement = new Person("holidayReplacement", "holiday", "replacement", "holidayreplacement@example.org");
 
         final Application application = createApplication(person);
-        application.setStartDate(LocalDate.of(2022, Month.JANUARY, 31));
-        application.setEndDate(LocalDate.of(2022, Month.JANUARY, 31));
+        application.setStartDate(LocalDate.of(2022, JANUARY, 31));
+        application.setEndDate(LocalDate.of(2022, JANUARY, 31));
 
         final HolidayReplacementEntity holidayReplacementEntity = new HolidayReplacementEntity();
         holidayReplacementEntity.setPerson(holidayReplacement);
@@ -4242,8 +4244,8 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         holidayReplacement.setNotifications(List.of(NOTIFICATION_EMAIL_APPLICATION_HOLIDAY_REPLACEMENT_UPCOMING));
 
         final Application application = createApplication(person);
-        application.setStartDate(LocalDate.of(2022, Month.JANUARY, 2));
-        application.setEndDate(LocalDate.of(2022, Month.JANUARY, 3));
+        application.setStartDate(LocalDate.of(2022, JANUARY, 2));
+        application.setEndDate(LocalDate.of(2022, JANUARY, 3));
 
         final HolidayReplacementEntity holidayReplacementEntity = new HolidayReplacementEntity();
         holidayReplacementEntity.setPerson(holidayReplacement);
@@ -4285,8 +4287,8 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         holidayReplacement.setNotifications(List.of(NOTIFICATION_EMAIL_APPLICATION_HOLIDAY_REPLACEMENT_UPCOMING));
 
         final Application application = createApplication(person);
-        application.setStartDate(LocalDate.of(2022, Month.JANUARY, 4));
-        application.setEndDate(LocalDate.of(2022, Month.JANUARY, 5));
+        application.setStartDate(LocalDate.of(2022, JANUARY, 4));
+        application.setEndDate(LocalDate.of(2022, JANUARY, 5));
 
         final HolidayReplacementEntity holidayReplacementEntity = new HolidayReplacementEntity();
         holidayReplacementEntity.setPerson(holidayReplacement);
@@ -4327,8 +4329,8 @@ class ApplicationMailServiceIT extends SingleTenantTestContainersBase {
         holidayReplacement.setNotifications(List.of(NOTIFICATION_EMAIL_APPLICATION_HOLIDAY_REPLACEMENT_UPCOMING));
 
         final Application application = createApplication(person);
-        application.setStartDate(LocalDate.of(2022, Month.JANUARY, 2));
-        application.setEndDate(LocalDate.of(2022, Month.JANUARY, 2));
+        application.setStartDate(LocalDate.of(2022, JANUARY, 2));
+        application.setEndDate(LocalDate.of(2022, JANUARY, 2));
 
         final HolidayReplacementEntity holidayReplacementEntity = new HolidayReplacementEntity();
         holidayReplacementEntity.setPerson(holidayReplacement);

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationMailServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationMailServiceTest.java
@@ -34,6 +34,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
+import static java.time.Month.MARCH;
+import static java.time.Month.OCTOBER;
 import static java.util.Collections.singletonList;
 import static java.util.Locale.GERMAN;
 import static java.util.Locale.JAPANESE;
@@ -122,8 +126,8 @@ class ApplicationMailServiceTest {
         application.setDayLength(FULL);
         application.setPerson(person);
         application.setBoss(applier);
-        application.setStartDate(LocalDate.of(2020, 12, 1));
-        application.setEndDate(LocalDate.of(2020, 12, 2));
+        application.setStartDate(LocalDate.of(2020, DECEMBER, 1));
+        application.setEndDate(LocalDate.of(2020, DECEMBER, 2));
         application.setStatus(ALLOWED);
 
         final ApplicationComment applicationComment = new ApplicationComment(
@@ -198,8 +202,8 @@ class ApplicationMailServiceTest {
         application.setDayLength(FULL);
         application.setPerson(person);
         application.setBoss(rejector);
-        application.setStartDate(LocalDate.of(2020, 12, 1));
-        application.setEndDate(LocalDate.of(2020, 12, 2));
+        application.setStartDate(LocalDate.of(2020, DECEMBER, 1));
+        application.setEndDate(LocalDate.of(2020, DECEMBER, 2));
         application.setStatus(ALLOWED);
 
         final ApplicationComment applicationComment = new ApplicationComment(
@@ -248,8 +252,8 @@ class ApplicationMailServiceTest {
         application.setVacationType(vacationType);
         application.setDayLength(FULL);
         application.setPerson(recipient);
-        application.setStartDate(LocalDate.of(2020, 12, 1));
-        application.setEndDate(LocalDate.of(2020, 12, 2));
+        application.setStartDate(LocalDate.of(2020, DECEMBER, 1));
+        application.setEndDate(LocalDate.of(2020, DECEMBER, 2));
         application.setStatus(ALLOWED);
 
         Map<String, Object> model = new HashMap<>();
@@ -284,8 +288,8 @@ class ApplicationMailServiceTest {
         application.setVacationType(vacationType);
         application.setDayLength(FULL);
         application.setPerson(editor);
-        application.setStartDate(LocalDate.of(2020, 12, 1));
-        application.setEndDate(LocalDate.of(2020, 12, 2));
+        application.setStartDate(LocalDate.of(2020, DECEMBER, 1));
+        application.setEndDate(LocalDate.of(2020, DECEMBER, 2));
         application.setStatus(ALLOWED);
 
         final Person relevantPerson = new Person();
@@ -326,8 +330,8 @@ class ApplicationMailServiceTest {
         application.setVacationType(vacationType);
         application.setDayLength(FULL);
         application.setPerson(applicant);
-        application.setStartDate(LocalDate.of(2020, 12, 1));
-        application.setEndDate(LocalDate.of(2020, 12, 2));
+        application.setStartDate(LocalDate.of(2020, DECEMBER, 1));
+        application.setEndDate(LocalDate.of(2020, DECEMBER, 2));
         application.setStatus(ALLOWED);
 
         final Person relevantPerson = new Person();
@@ -485,8 +489,8 @@ class ApplicationMailServiceTest {
         application.setBoss(boss);
         application.setHolidayReplacements(List.of(replacementEntity));
         application.setDayLength(FULL);
-        application.setStartDate(LocalDate.of(2020, 3, 5));
-        application.setEndDate(LocalDate.of(2020, 3, 6));
+        application.setStartDate(LocalDate.of(2020, MARCH, 5));
+        application.setEndDate(LocalDate.of(2020, MARCH, 6));
 
         final Map<String, Object> model = new HashMap<>();
         model.put("application", application);
@@ -657,8 +661,8 @@ class ApplicationMailServiceTest {
         application.setCanceller(canceller);
         application.setHolidayReplacements(List.of(replacementEntity));
         application.setDayLength(FULL);
-        application.setStartDate(LocalDate.of(2020, 10, 2));
-        application.setEndDate(LocalDate.of(2020, 10, 3));
+        application.setStartDate(LocalDate.of(2020, OCTOBER, 2));
+        application.setEndDate(LocalDate.of(2020, OCTOBER, 3));
 
         final Map<String, Object> model = new HashMap<>();
         model.put("application", application);
@@ -699,8 +703,8 @@ class ApplicationMailServiceTest {
         application.setPerson(person);
         application.setApplier(person);
         application.setDayLength(FULL);
-        application.setStartDate(LocalDate.of(2020, 12, 1));
-        application.setEndDate(LocalDate.of(2020, 12, 2));
+        application.setStartDate(LocalDate.of(2020, DECEMBER, 1));
+        application.setEndDate(LocalDate.of(2020, DECEMBER, 2));
         application.setStatus(WAITING);
 
         final ApplicationComment comment = new ApplicationComment(
@@ -752,8 +756,8 @@ class ApplicationMailServiceTest {
         application.setVacationType(vacationType);
         application.setPerson(person);
         application.setDayLength(FULL);
-        application.setStartDate(LocalDate.of(2020, 12, 1));
-        application.setEndDate(LocalDate.of(2020, 12, 2));
+        application.setStartDate(LocalDate.of(2020, DECEMBER, 1));
+        application.setEndDate(LocalDate.of(2020, DECEMBER, 2));
         application.setStatus(WAITING);
 
         final ApplicationComment comment = new ApplicationComment(
@@ -814,8 +818,8 @@ class ApplicationMailServiceTest {
         application.setPerson(person);
         application.setApplier(office);
         application.setDayLength(FULL);
-        application.setStartDate(LocalDate.of(2020, 12, 1));
-        application.setEndDate(LocalDate.of(2020, 12, 2));
+        application.setStartDate(LocalDate.of(2020, DECEMBER, 1));
+        application.setEndDate(LocalDate.of(2020, DECEMBER, 2));
         application.setStatus(WAITING);
 
         final ApplicationComment comment = new ApplicationComment(
@@ -871,8 +875,8 @@ class ApplicationMailServiceTest {
         application.setVacationType(vacationType);
         application.setPerson(person);
         application.setDayLength(FULL);
-        application.setStartDate(LocalDate.of(2020, 12, 1));
-        application.setEndDate(LocalDate.of(2020, 12, 2));
+        application.setStartDate(LocalDate.of(2020, DECEMBER, 1));
+        application.setEndDate(LocalDate.of(2020, DECEMBER, 2));
         application.setStatus(WAITING);
 
         final List<Person> recipients = singletonList(person);
@@ -921,8 +925,8 @@ class ApplicationMailServiceTest {
         application.setApplier(applicant);
         application.setHolidayReplacements(List.of(replacementEntity));
         application.setDayLength(FULL);
-        application.setStartDate(LocalDate.of(2020, 10, 2));
-        application.setEndDate(LocalDate.of(2020, 10, 3));
+        application.setStartDate(LocalDate.of(2020, OCTOBER, 2));
+        application.setEndDate(LocalDate.of(2020, OCTOBER, 3));
 
         final Map<String, Object> model = new HashMap<>();
         model.put("application", application);
@@ -1052,8 +1056,8 @@ class ApplicationMailServiceTest {
         person.setNotifications(List.of(NOTIFICATION_EMAIL_APPLICATION_CANCELLATION));
 
         final Application application = new Application();
-        application.setStartDate(LocalDate.of(2022, 3, 3));
-        application.setEndDate(LocalDate.of(2022, 3, 3));
+        application.setStartDate(LocalDate.of(2022, MARCH, 3));
+        application.setEndDate(LocalDate.of(2022, MARCH, 3));
         application.setVacationType(vacationType);
         application.setPerson(person);
         application.setDayLength(FULL);
@@ -1178,8 +1182,8 @@ class ApplicationMailServiceTest {
         application.setVacationType(vacationType);
         application.setCanceller(canceller);
         application.setDayLength(FULL);
-        application.setStartDate(LocalDate.of(2020, 10, 2));
-        application.setEndDate(LocalDate.of(2020, 10, 3));
+        application.setStartDate(LocalDate.of(2020, OCTOBER, 2));
+        application.setEndDate(LocalDate.of(2020, OCTOBER, 3));
 
         final ApplicationComment comment = new ApplicationComment(
             1L, Instant.now(clock), application, ApplicationCommentAction.ALLOWED, person, "");
@@ -1244,8 +1248,8 @@ class ApplicationMailServiceTest {
         application.setVacationType(vacationType);
         application.setPerson(person);
         application.setDayLength(FULL);
-        application.setStartDate(LocalDate.of(2020, 12, 1));
-        application.setEndDate(LocalDate.of(2020, 12, 2));
+        application.setStartDate(LocalDate.of(2020, DECEMBER, 1));
+        application.setEndDate(LocalDate.of(2020, DECEMBER, 2));
         application.setStatus(WAITING);
 
         final List<Person> recipients = singletonList(person);
@@ -1256,7 +1260,7 @@ class ApplicationMailServiceTest {
 
         final Application applicationForLeave = new Application();
         final List<Application> applicationsForLeave = singletonList(applicationForLeave);
-        when(departmentService.getApplicationsFromColleaguesOf(person, LocalDate.of(2020, 12, 1), LocalDate.of(2020, 12, 2))).thenReturn(applicationsForLeave);
+        when(departmentService.getApplicationsFromColleaguesOf(person, LocalDate.of(2020, DECEMBER, 1), LocalDate.of(2020, DECEMBER, 2))).thenReturn(applicationsForLeave);
 
         final Map<String, Object> model = new HashMap<>();
         model.put("application", application);
@@ -1299,8 +1303,8 @@ class ApplicationMailServiceTest {
         application.setVacationType(vacationType);
         application.setPerson(person);
         application.setDayLength(FULL);
-        application.setStartDate(LocalDate.of(2020, 12, 1));
-        application.setEndDate(LocalDate.of(2020, 12, 2));
+        application.setStartDate(LocalDate.of(2020, DECEMBER, 1));
+        application.setEndDate(LocalDate.of(2020, DECEMBER, 2));
         application.setStatus(WAITING);
         when(mailRecipientService.getRecipientsOfInterest(person, NOTIFICATION_EMAIL_APPLICATION_MANAGEMENT_TEMPORARY_ALLOWED)).thenReturn(recipients);
 
@@ -1309,7 +1313,7 @@ class ApplicationMailServiceTest {
 
         final Application applicationForLeave = new Application();
         final List<Application> applicationsForLeave = singletonList(applicationForLeave);
-        when(departmentService.getApplicationsFromColleaguesOf(person, LocalDate.of(2020, 12, 1), LocalDate.of(2020, 12, 2))).thenReturn(applicationsForLeave);
+        when(departmentService.getApplicationsFromColleaguesOf(person, LocalDate.of(2020, DECEMBER, 1), LocalDate.of(2020, DECEMBER, 2))).thenReturn(applicationsForLeave);
 
         final Map<String, Object> model = new HashMap<>();
         model.put("application", application);
@@ -1352,8 +1356,8 @@ class ApplicationMailServiceTest {
         application.setVacationType(vacationType);
         application.setPerson(person);
         application.setDayLength(FULL);
-        application.setStartDate(LocalDate.of(2022, 1, 2));
-        application.setEndDate(LocalDate.of(2022, 1, 3));
+        application.setStartDate(LocalDate.of(2022, JANUARY, 2));
+        application.setEndDate(LocalDate.of(2022, JANUARY, 3));
         application.setStatus(ALLOWED);
 
         final Map<String, Object> model = new HashMap<>();
@@ -1402,8 +1406,8 @@ class ApplicationMailServiceTest {
         application.setVacationType(vacationType);
         application.setPerson(applicant);
         application.setDayLength(FULL);
-        application.setStartDate(LocalDate.of(2022, 1, 3));
-        application.setEndDate(LocalDate.of(2022, 1, 4));
+        application.setStartDate(LocalDate.of(2022, JANUARY, 3));
+        application.setEndDate(LocalDate.of(2022, JANUARY, 4));
         application.setStatus(ALLOWED);
         application.setHolidayReplacements(List.of(holidayReplacementEntity, holidayReplacementEntityTwo));
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationRepositoryIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationRepositoryIT.java
@@ -18,6 +18,8 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.util.List;
 
+import static java.time.Month.MAY;
+import static java.time.Month.OCTOBER;
 import static java.time.ZoneOffset.UTC;
 import static java.time.temporal.TemporalAdjusters.firstDayOfMonth;
 import static java.time.temporal.TemporalAdjusters.lastDayOfMonth;
@@ -156,7 +158,7 @@ class ApplicationRepositoryIT extends SingleTenantTestContainersBase {
         revokedOvertimeReduction.setStatus(REVOKED);
         sut.save(revokedOvertimeReduction);
 
-        final List<ApplicationEntity> allowedApplications = sut.findByStatusInAndEndDateGreaterThanEqual(List.of(ALLOWED), LocalDate.of(2020, 10, 3));
+        final List<ApplicationEntity> allowedApplications = sut.findByStatusInAndEndDateGreaterThanEqual(List.of(ALLOWED), LocalDate.of(2020, OCTOBER, 3));
         assertThat(allowedApplications)
             .contains(fullDayOvertimeReduction, fullDayHoliday)
             .hasSize(2);
@@ -198,7 +200,7 @@ class ApplicationRepositoryIT extends SingleTenantTestContainersBase {
         revokedOvertimeReduction.setStatus(REVOKED);
         sut.save(revokedOvertimeReduction);
 
-        final List<ApplicationEntity> allowedApplications = sut.findByStatusInAndEndDateGreaterThanEqual(List.of(ALLOWED, REJECTED), LocalDate.of(2020, 10, 3));
+        final List<ApplicationEntity> allowedApplications = sut.findByStatusInAndEndDateGreaterThanEqual(List.of(ALLOWED, REJECTED), LocalDate.of(2020, OCTOBER, 3));
         assertThat(allowedApplications)
             .contains(fullDayOvertimeReduction, fullDayHoliday, rejectedOvertimeReduction)
             .hasSize(3);
@@ -216,7 +218,7 @@ class ApplicationRepositoryIT extends SingleTenantTestContainersBase {
         revokedOvertimeReduction.setStatus(REVOKED);
         sut.save(revokedOvertimeReduction);
 
-        final List<ApplicationEntity> allowedApplications = sut.findByStatusInAndEndDateGreaterThanEqual(List.of(), LocalDate.of(2020, 10, 3));
+        final List<ApplicationEntity> allowedApplications = sut.findByStatusInAndEndDateGreaterThanEqual(List.of(), LocalDate.of(2020, OCTOBER, 3));
         assertThat(allowedApplications)
             .isEmpty();
     }
@@ -423,8 +425,8 @@ class ApplicationRepositoryIT extends SingleTenantTestContainersBase {
         holidayReplacementEntity.setPerson(holidayReplacement);
 
         // correct
-        final LocalDate from = LocalDate.of(2020, 5, 3);
-        final LocalDate to = LocalDate.of(2020, 5, 10);
+        final LocalDate from = LocalDate.of(2020, MAY, 3);
+        final LocalDate to = LocalDate.of(2020, MAY, 10);
         final ApplicationEntity waitingApplication = applicationEntity(person, getVacationType(OVERTIME), from, to, FULL);
         waitingApplication.setHolidayReplacements(List.of(holidayReplacementEntity));
         waitingApplication.setStatus(WAITING);
@@ -437,8 +439,8 @@ class ApplicationRepositoryIT extends SingleTenantTestContainersBase {
         sut.save(allowedApplication);
 
         // other date
-        final LocalDate otherStartDate = LocalDate.of(2020, 5, 3);
-        final LocalDate otherEndDate = LocalDate.of(2020, 5, 4);
+        final LocalDate otherStartDate = LocalDate.of(2020, MAY, 3);
+        final LocalDate otherEndDate = LocalDate.of(2020, MAY, 4);
         final ApplicationEntity wrongDateApplication = applicationEntity(person, getVacationType(OVERTIME), otherStartDate, otherEndDate, FULL);
         wrongDateApplication.setHolidayReplacements(List.of(holidayReplacementEntity));
         wrongDateApplication.setStatus(WAITING);
@@ -453,7 +455,7 @@ class ApplicationRepositoryIT extends SingleTenantTestContainersBase {
         otherHolidayReplacementApplication.setStatus(WAITING);
         sut.save(otherHolidayReplacementApplication);
 
-        final LocalDate requestDate = LocalDate.of(2020, 5, 5);
+        final LocalDate requestDate = LocalDate.of(2020, MAY, 5);
         final List<ApplicationStatus> requestStatus = List.of(WAITING);
         final List<ApplicationEntity> applications = sut.findByHolidayReplacements_PersonAndEndDateIsGreaterThanEqualAndStatusIn(holidayReplacement, requestDate, requestStatus);
         assertThat(applications).hasSize(1).contains(waitingApplication);
@@ -465,19 +467,19 @@ class ApplicationRepositoryIT extends SingleTenantTestContainersBase {
         final Person savedPerson = personService.create("sam", "sam", "smith", "smith@example.org");
 
         // yesterday
-        final LocalDate yesterdayDates = LocalDate.of(2020, 5, 3);
+        final LocalDate yesterdayDates = LocalDate.of(2020, MAY, 3);
         final ApplicationEntity yesterdayApplication = applicationEntity(savedPerson, getVacationType(HOLIDAY), yesterdayDates, yesterdayDates, FULL);
         yesterdayApplication.setStatus(ALLOWED);
         sut.save(yesterdayApplication);
 
         // today
-        final LocalDate todayDates = LocalDate.of(2020, 5, 4);
+        final LocalDate todayDates = LocalDate.of(2020, MAY, 4);
         final ApplicationEntity todayApplication = applicationEntity(savedPerson, getVacationType(HOLIDAY), todayDates, todayDates, FULL);
         todayApplication.setStatus(ALLOWED);
         sut.save(todayApplication);
 
         // tomorrow
-        final LocalDate tomorrowAllowedDates = LocalDate.of(2020, 5, 5);
+        final LocalDate tomorrowAllowedDates = LocalDate.of(2020, MAY, 5);
         final ApplicationEntity tomorrowDateApplication = applicationEntity(savedPerson, getVacationType(HOLIDAY), tomorrowAllowedDates, tomorrowAllowedDates, FULL);
         tomorrowDateApplication.setStatus(ALLOWED);
         sut.save(tomorrowDateApplication);
@@ -495,14 +497,14 @@ class ApplicationRepositoryIT extends SingleTenantTestContainersBase {
         sut.save(tomorrowWaitingDateApplication);
 
         // day after tomorrow
-        final LocalDate dayAfterTomorrowAllowedDates = LocalDate.of(2020, 5, 6);
+        final LocalDate dayAfterTomorrowAllowedDates = LocalDate.of(2020, MAY, 6);
 
         final ApplicationEntity dayAfterTomorrowDateApplication = applicationEntity(savedPerson, getVacationType(HOLIDAY), dayAfterTomorrowAllowedDates, dayAfterTomorrowAllowedDates, FULL);
         dayAfterTomorrowDateApplication.setStatus(ALLOWED);
         sut.save(dayAfterTomorrowDateApplication);
 
-        final LocalDate requestedStartDateFrom = LocalDate.of(2020, 5, 4);
-        final LocalDate requestedStartDateTo = LocalDate.of(2020, 5, 5);
+        final LocalDate requestedStartDateFrom = LocalDate.of(2020, MAY, 4);
+        final LocalDate requestedStartDateTo = LocalDate.of(2020, MAY, 5);
         final List<ApplicationStatus> requestStatuses = List.of(ALLOWED, ALLOWED_CANCELLATION_REQUESTED, TEMPORARY_ALLOWED);
         final List<ApplicationEntity> applications = sut.findByStatusInAndStartDateBetweenAndUpcomingApplicationsReminderSendIsNull(requestStatuses, requestedStartDateFrom, requestedStartDateTo);
         assertThat(applications)
@@ -519,20 +521,20 @@ class ApplicationRepositoryIT extends SingleTenantTestContainersBase {
         holidayReplacement.setNote("Note");
 
         // yesterday
-        final LocalDate yesterdayDates = LocalDate.of(2020, 5, 3);
+        final LocalDate yesterdayDates = LocalDate.of(2020, MAY, 3);
         final ApplicationEntity yesterdayApplication = applicationEntity(savedPerson, getVacationType(HOLIDAY), yesterdayDates, yesterdayDates, FULL);
         yesterdayApplication.setHolidayReplacements(List.of(holidayReplacement));
         yesterdayApplication.setStatus(ALLOWED);
         sut.save(yesterdayApplication);
 
         // today
-        final LocalDate todayDates = LocalDate.of(2020, 5, 4);
+        final LocalDate todayDates = LocalDate.of(2020, MAY, 4);
         final ApplicationEntity todayApplication = applicationEntity(savedPerson, getVacationType(HOLIDAY), todayDates, todayDates, FULL);
         todayApplication.setStatus(ALLOWED);
         sut.save(todayApplication);
 
         // tomorrow
-        final LocalDate tomorrowAllowedDates = LocalDate.of(2020, 5, 5);
+        final LocalDate tomorrowAllowedDates = LocalDate.of(2020, MAY, 5);
 
         final ApplicationEntity tomorrowDateApplicationNoHolidayReplacement = applicationEntity(savedPerson, getVacationType(HOLIDAY), tomorrowAllowedDates, tomorrowAllowedDates, FULL);
         tomorrowDateApplicationNoHolidayReplacement.setStatus(ALLOWED);
@@ -564,15 +566,15 @@ class ApplicationRepositoryIT extends SingleTenantTestContainersBase {
         sut.save(tomorrowWaitingDateApplication);
 
         // day after tomorrow
-        final LocalDate dayAfterTomorrowAllowedDates = LocalDate.of(2020, 5, 6);
+        final LocalDate dayAfterTomorrowAllowedDates = LocalDate.of(2020, MAY, 6);
 
         final ApplicationEntity dayAfterTomorrowDateApplication = applicationEntity(savedPerson, getVacationType(HOLIDAY), dayAfterTomorrowAllowedDates, dayAfterTomorrowAllowedDates, FULL);
         dayAfterTomorrowDateApplication.setHolidayReplacements(List.of(holidayReplacement));
         dayAfterTomorrowDateApplication.setStatus(ALLOWED);
         sut.save(dayAfterTomorrowDateApplication);
 
-        final LocalDate requestedStartDateFrom = LocalDate.of(2020, 5, 4);
-        final LocalDate requestedStartDateTo = LocalDate.of(2020, 5, 5);
+        final LocalDate requestedStartDateFrom = LocalDate.of(2020, MAY, 4);
+        final LocalDate requestedStartDateTo = LocalDate.of(2020, MAY, 5);
         final List<ApplicationStatus> requestStatuses = List.of(ALLOWED, ALLOWED_CANCELLATION_REQUESTED, TEMPORARY_ALLOWED);
         final List<ApplicationEntity> applications = sut.findByStatusInAndStartDateBetweenAndHolidayReplacementsIsNotEmptyAndUpcomingHolidayReplacementNotificationSendIsNull(requestStatuses, requestedStartDateFrom, requestedStartDateTo);
         assertThat(applications)

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationServiceImplTest.java
@@ -29,6 +29,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import static java.time.Duration.ZERO;
+import static java.time.Month.AUGUST;
+import static java.time.Month.OCTOBER;
 import static java.util.Locale.JAPANESE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -185,16 +187,16 @@ class ApplicationServiceImplTest {
         @Test
         void ensureSaveCallsCorrectDaoMethod() {
 
-            final LocalDate applicationDate = LocalDate.of(2023, 10, 14);
-            final LocalDate cancelDate = LocalDate.of(2023, 10, 15);
-            final LocalDate editedDate = LocalDate.of(2023, 10, 16);
-            final LocalDate startDate = LocalDate.of(2023, 10, 17);
+            final LocalDate applicationDate = LocalDate.of(2023, OCTOBER, 14);
+            final LocalDate cancelDate = LocalDate.of(2023, OCTOBER, 15);
+            final LocalDate editedDate = LocalDate.of(2023, OCTOBER, 16);
+            final LocalDate startDate = LocalDate.of(2023, OCTOBER, 17);
             final LocalTime startTime = LocalTime.of(11, 0);
-            final LocalDate endDate = LocalDate.of(2023, 10, 18);
+            final LocalDate endDate = LocalDate.of(2023, OCTOBER, 18);
             final LocalTime endTime = LocalTime.of(15, 30);
-            final LocalDate remindDate = LocalDate.of(2023, 10, 19);
-            final LocalDate upcomingApplicationReminderSend = LocalDate.of(2023, 10, 20);
-            final LocalDate upcomingApplicationsReminderSend = LocalDate.of(2023, 10, 21);
+            final LocalDate remindDate = LocalDate.of(2023, OCTOBER, 19);
+            final LocalDate upcomingApplicationReminderSend = LocalDate.of(2023, OCTOBER, 20);
+            final LocalDate upcomingApplicationsReminderSend = LocalDate.of(2023, OCTOBER, 21);
 
             final Person applier = new Person();
             applier.setId(1L);
@@ -321,10 +323,10 @@ class ApplicationServiceImplTest {
             applicationEntity.setId(1L);
             applicationEntity.setVacationType(new VacationTypeEntity());
 
-            when(applicationRepository.findByStatusInAndEndDateGreaterThanEqual(List.of(WAITING), LocalDate.of(2020, 10, 3)))
+            when(applicationRepository.findByStatusInAndEndDateGreaterThanEqual(List.of(WAITING), LocalDate.of(2020, OCTOBER, 3)))
                 .thenReturn(List.of(applicationEntity));
 
-            final List<Application> result = sut.getForStatesSince(List.of(WAITING), LocalDate.of(2020, 10, 3));
+            final List<Application> result = sut.getForStatesSince(List.of(WAITING), LocalDate.of(2020, OCTOBER, 3));
             assertThat(result).isEqualTo(List.of(application));
         }
     }
@@ -359,7 +361,7 @@ class ApplicationServiceImplTest {
         void getForHolidayReplacement() {
 
             final Person holidayReplacement = new Person();
-            final LocalDate localDate = LocalDate.of(2020, 10, 1);
+            final LocalDate localDate = LocalDate.of(2020, OCTOBER, 1);
 
             final Application application = new Application();
             application.setId(1L);
@@ -381,8 +383,8 @@ class ApplicationServiceImplTest {
 
         @Test
         void getApplicationsWithStartDateAndState() {
-            final LocalDate from = LocalDate.of(2020, 10, 1);
-            final LocalDate to = LocalDate.of(2020, 10, 3);
+            final LocalDate from = LocalDate.of(2020, OCTOBER, 1);
+            final LocalDate to = LocalDate.of(2020, OCTOBER, 3);
 
             final Application application = new Application();
             application.setId(1L);
@@ -405,8 +407,8 @@ class ApplicationServiceImplTest {
 
         @Test
         void getApplicationsWhereHolidayReplacementShouldBeNotified() {
-            final LocalDate from = LocalDate.of(2020, 10, 1);
-            final LocalDate to = LocalDate.of(2020, 10, 3);
+            final LocalDate from = LocalDate.of(2020, OCTOBER, 1);
+            final LocalDate to = LocalDate.of(2020, OCTOBER, 3);
 
             final Application application = new Application();
             application.setId(1L);
@@ -430,8 +432,8 @@ class ApplicationServiceImplTest {
         @Test
         void getApplicationsForACertainPeriodAndPersonAndVacationCategory() {
             final Person person = new Person();
-            final LocalDate from = LocalDate.of(2020, 10, 1);
-            final LocalDate to = LocalDate.of(2020, 10, 3);
+            final LocalDate from = LocalDate.of(2020, OCTOBER, 1);
+            final LocalDate to = LocalDate.of(2020, OCTOBER, 3);
 
             final Application application = new Application();
             application.setId(1L);
@@ -458,8 +460,8 @@ class ApplicationServiceImplTest {
             final Person person = new Person();
             person.setId(1L);
 
-            final LocalDate startDate = LocalDate.of(2022, 8, 18);
-            final LocalDate endDate = LocalDate.of(2022, 8, 18);
+            final LocalDate startDate = LocalDate.of(2022, AUGUST, 18);
+            final LocalDate endDate = LocalDate.of(2022, AUGUST, 18);
             final List<Person> persons = List.of(person);
 
             final Application application = new Application();
@@ -790,7 +792,7 @@ class ApplicationServiceImplTest {
             alfred.setId(3L);
 
             final Set<Person> persons = Set.of(batman, robin, alfred);
-            final LocalDate until = LocalDate.of(2022, 8, 30);
+            final LocalDate until = LocalDate.of(2022, AUGUST, 30);
 
             when(applicationRepository.findByPersonInAndVacationTypeCategoryAndStatusInAndStartDateIsLessThanEqual(persons, OVERTIME, activeStatuses(), until))
                 .thenReturn(List.of());
@@ -810,8 +812,8 @@ class ApplicationServiceImplTest {
             final VacationTypeEntity vacationTypeOvertime = new VacationTypeEntity();
             vacationTypeOvertime.setCategory(OVERTIME);
 
-            final LocalDate startDate = LocalDate.of(2022, 8, 10);
-            final LocalDate endDate = LocalDate.of(2022, 8, 12);
+            final LocalDate startDate = LocalDate.of(2022, AUGUST, 10);
+            final LocalDate endDate = LocalDate.of(2022, AUGUST, 12);
 
             final ApplicationEntity applicationEntity = new ApplicationEntity();
             applicationEntity.setPerson(batman);
@@ -823,7 +825,7 @@ class ApplicationServiceImplTest {
             applicationEntity.setHours(Duration.ofHours(10));
 
             final Set<Person> persons = Set.of(batman);
-            final LocalDate until = LocalDate.of(2022, 8, 30);
+            final LocalDate until = LocalDate.of(2022, AUGUST, 30);
 
             when(applicationRepository.findByPersonInAndVacationTypeCategoryAndStatusInAndStartDateIsLessThanEqual(
                 persons,
@@ -848,8 +850,8 @@ class ApplicationServiceImplTest {
             final VacationTypeEntity vacationTypeOvertime = new VacationTypeEntity();
             vacationTypeOvertime.setCategory(OVERTIME);
 
-            final LocalDate startDate = LocalDate.of(2022, 8, 10);
-            final LocalDate endDate = LocalDate.of(2022, 8, 19);
+            final LocalDate startDate = LocalDate.of(2022, AUGUST, 10);
+            final LocalDate endDate = LocalDate.of(2022, AUGUST, 19);
 
             final ApplicationEntity applicationEntity = new ApplicationEntity();
             applicationEntity.setPerson(batman);
@@ -861,7 +863,7 @@ class ApplicationServiceImplTest {
             applicationEntity.setHours(Duration.ofHours(10));
 
             final Set<Person> persons = Set.of(batman);
-            final LocalDate until = LocalDate.of(2022, 8, 14);
+            final LocalDate until = LocalDate.of(2022, AUGUST, 14);
 
             when(applicationRepository.findByPersonInAndVacationTypeCategoryAndStatusInAndStartDateIsLessThanEqual(
                 persons,

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationTest.java
@@ -22,6 +22,10 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static java.time.Duration.ofHours;
+import static java.time.Month.AUGUST;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.FEBRUARY;
+import static java.time.Month.JANUARY;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -106,7 +110,7 @@ class ApplicationTest {
     @Test
     void ensureGetStartDateWithTimeReturnsCorrectDateTime() {
 
-        LocalDate startDate = LocalDate.of(2016, 2, 1);
+        LocalDate startDate = LocalDate.of(2016, FEBRUARY, 1);
 
         Application application = new Application();
         application.setStartDate(startDate);
@@ -145,7 +149,7 @@ class ApplicationTest {
     void ensureGetEndDateWithTimeReturnsCorrectDateTime() {
 
         final Application application = new Application();
-        application.setEndDate(LocalDate.of(2016, 12, 21));
+        application.setEndDate(LocalDate.of(2016, DECEMBER, 21));
         application.setEndTime(LocalTime.of(12, 30, 0));
 
         final ZonedDateTime endDateWithTime = application.getEndDateWithTime();
@@ -184,8 +188,8 @@ class ApplicationTest {
 
         final Application application = new Application();
         application.setPerson(person);
-        application.setStartDate(LocalDate.of(2022, 12, 30));
-        application.setEndDate(LocalDate.of(2023, 1, 2));
+        application.setStartDate(LocalDate.of(2022, DECEMBER, 30));
+        application.setEndDate(LocalDate.of(2023, JANUARY, 2));
         application.setDayLength(FULL);
         application.setVacationType(createVacationType(1L, OVERTIME, new StaticMessageSource()));
 
@@ -202,13 +206,13 @@ class ApplicationTest {
 
         final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(Map.of(
             // 1h reduction
-            LocalDate.of(2022, 12, 30), new WorkingTimeCalendar.WorkingDayInformation(FULL, WORKDAY, WORKDAY),
+            LocalDate.of(2022, DECEMBER, 30), new WorkingTimeCalendar.WorkingDayInformation(FULL, WORKDAY, WORKDAY),
             // 0.5h reduction
-            LocalDate.of(2022, 12, 31), new WorkingTimeCalendar.WorkingDayInformation(MORNING, WORKDAY, NO_WORKDAY),
+            LocalDate.of(2022, DECEMBER, 31), new WorkingTimeCalendar.WorkingDayInformation(MORNING, WORKDAY, NO_WORKDAY),
             // 0h
-            LocalDate.of(2023, 1, 1), new WorkingTimeCalendar.WorkingDayInformation(DayLength.ZERO, NO_WORKDAY, NO_WORKDAY),
+            LocalDate.of(2023, JANUARY, 1), new WorkingTimeCalendar.WorkingDayInformation(DayLength.ZERO, NO_WORKDAY, NO_WORKDAY),
             // 1h reduction
-            LocalDate.of(2023, 1, 2), new WorkingTimeCalendar.WorkingDayInformation(FULL, WORKDAY, WORKDAY)
+            LocalDate.of(2023, JANUARY, 2), new WorkingTimeCalendar.WorkingDayInformation(FULL, WORKDAY, WORKDAY)
         ));
 
         final Map<Integer, Duration> hoursByYear = application.getHoursByYear((_, _) -> workingTimeCalendar);
@@ -271,7 +275,7 @@ class ApplicationTest {
 
     @Test
     void ensureGetOvertimeReductionSharesForSingleDays() {
-        final LocalDate date = LocalDate.of(2022, 8, 10);
+        final LocalDate date = LocalDate.of(2022, AUGUST, 10);
 
         final Person person = new Person();
         person.setId(1L);
@@ -316,7 +320,7 @@ class ApplicationTest {
         DayLength applicationDayLength, Duration applicationDuration,
         WorkingTimeCalendar.WorkingDayInformation workingDayInformation, Duration overtimeHours
     ) {
-        final LocalDate date = LocalDate.of(2022, 8, 10);
+        final LocalDate date = LocalDate.of(2022, AUGUST, 10);
 
         final Person person = new Person();
         person.setId(1L);
@@ -339,9 +343,9 @@ class ApplicationTest {
 
     @Test
     void ensureGetOvertimeReductionSharesForMultipleDays() {
-        final LocalDate startDate = LocalDate.of(2022, 8, 10);
-        final LocalDate middleDate = LocalDate.of(2022, 8, 11);
-        final LocalDate endDate = LocalDate.of(2022, 8, 12);
+        final LocalDate startDate = LocalDate.of(2022, AUGUST, 10);
+        final LocalDate middleDate = LocalDate.of(2022, AUGUST, 11);
+        final LocalDate endDate = LocalDate.of(2022, AUGUST, 12);
 
         final Person person = new Person();
         person.setId(1L);
@@ -356,9 +360,9 @@ class ApplicationTest {
         application.setHours(Duration.ofHours(12));
 
         final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(Map.of(
-            LocalDate.of(2022, 8, 10), fullWorkday(),
-            LocalDate.of(2022, 8, 11), fullWorkday(),
-            LocalDate.of(2022, 8, 12), fullWorkday()
+            LocalDate.of(2022, AUGUST, 10), fullWorkday(),
+            LocalDate.of(2022, AUGUST, 11), fullWorkday(),
+            LocalDate.of(2022, AUGUST, 12), fullWorkday()
         ));
 
         final var partitionedDurations = application.getOvertimeReductionShares((_, _) -> workingTimeCalendar);
@@ -371,9 +375,9 @@ class ApplicationTest {
 
     @Test
     void ensureGetOvertimeReductionSharesForMultipleDaysWithOneNoWorkday() {
-        final LocalDate startDate = LocalDate.of(2022, 8, 10);
-        final LocalDate middleDate = LocalDate.of(2022, 8, 11);
-        final LocalDate endDate = LocalDate.of(2022, 8, 12);
+        final LocalDate startDate = LocalDate.of(2022, AUGUST, 10);
+        final LocalDate middleDate = LocalDate.of(2022, AUGUST, 11);
+        final LocalDate endDate = LocalDate.of(2022, AUGUST, 12);
 
         final Person person = new Person();
         person.setId(1L);
@@ -388,9 +392,9 @@ class ApplicationTest {
         application.setHours(Duration.ofHours(12));
 
         final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(Map.of(
-            LocalDate.of(2022, 8, 10), fullWorkday(),
-            LocalDate.of(2022, 8, 11), noWorkday(),
-            LocalDate.of(2022, 8, 12), fullWorkday()
+            LocalDate.of(2022, AUGUST, 10), fullWorkday(),
+            LocalDate.of(2022, AUGUST, 11), noWorkday(),
+            LocalDate.of(2022, AUGUST, 12), fullWorkday()
         ));
 
         final var partitionedDurations = application.getOvertimeReductionShares((_, _) -> workingTimeCalendar);
@@ -403,8 +407,8 @@ class ApplicationTest {
 
     @Test
     void ensureGetOvertimeReductionHoursWhenConvertingFromSickNoteWithDefaultZero() {
-        final LocalDate startDate = LocalDate.of(2022, 8, 10);
-        final LocalDate endDate = LocalDate.of(2022, 8, 12);
+        final LocalDate startDate = LocalDate.of(2022, AUGUST, 10);
+        final LocalDate endDate = LocalDate.of(2022, AUGUST, 12);
 
         final Person person = new Person();
         person.setId(1L);

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/export/ApplicationForLeaveExportServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/export/ApplicationForLeaveExportServiceTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import static java.time.Month.JANUARY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -82,8 +83,8 @@ class ApplicationForLeaveExportServiceTest {
         final PersonPageRequest personPageRequest = PersonPageRequest.of(0, 10, Sort.unsorted());
         when(personService.getActivePersons(personPageRequest, "")).thenReturn(new PageImpl<>(personsForExport));
 
-        final LocalDate from = LocalDate.of(2023, 1, 1);
-        final LocalDate to = LocalDate.of(2023, 1, 31);
+        final LocalDate from = LocalDate.of(2023, JANUARY, 1);
+        final LocalDate to = LocalDate.of(2023, JANUARY, 31);
         final ApplicationForLeave app = new ApplicationForLeave(new Application(), new TreeMap<>());
         app.setId(1L);
         app.setPerson(user);
@@ -128,8 +129,8 @@ class ApplicationForLeaveExportServiceTest {
         when(departmentService.getManagedMembersOfPerson(person, personPageRequest, ""))
             .thenReturn(new PageImpl<>(List.of(departmentMember)));
 
-        final LocalDate from = LocalDate.of(2023, 1, 1);
-        final LocalDate to = LocalDate.of(2023, 1, 31);
+        final LocalDate from = LocalDate.of(2023, JANUARY, 1);
+        final LocalDate to = LocalDate.of(2023, JANUARY, 31);
         final ApplicationForLeave app = new ApplicationForLeave(new Application(), new TreeMap<>());
         app.setId(1L);
         app.setPerson(departmentMember);
@@ -142,7 +143,7 @@ class ApplicationForLeaveExportServiceTest {
         when(departmentService.getDepartmentNamesByMembers(personsForExport)).thenReturn(Map.of(departmentMemberId, List.of("department")));
 
         final PageableSearchQuery personSearchQuery = new PageableSearchQuery(PageRequest.of(0, 10), "");
-        final Page<ApplicationForLeaveExport> export = sut.getAll(person, LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 31), personSearchQuery);
+        final Page<ApplicationForLeaveExport> export = sut.getAll(person, LocalDate.of(2023, JANUARY, 1), LocalDate.of(2023, JANUARY, 31), personSearchQuery);
 
         final ApplicationForLeaveExport applicationForLeaveExport = export.getContent().getFirst();
         assertThat(applicationForLeaveExport.getFirstName()).isEqualTo("Marlene");
@@ -164,7 +165,7 @@ class ApplicationForLeaveExportServiceTest {
             .thenReturn(new PageImpl<>(List.of()));
 
         final PageableSearchQuery personSearchQuery = new PageableSearchQuery(PageRequest.of(0, 10), "");
-        final Page<ApplicationForLeaveExport> export = sut.getAll(person, LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 31), personSearchQuery);
+        final Page<ApplicationForLeaveExport> export = sut.getAll(person, LocalDate.of(2023, JANUARY, 1), LocalDate.of(2023, JANUARY, 31), personSearchQuery);
 
         verifyNoMoreInteractions(departmentService);
         verifyNoInteractions(applicationService, personBasedataService);
@@ -190,8 +191,8 @@ class ApplicationForLeaveExportServiceTest {
         final PersonPageRequest personPageRequest = PersonPageRequest.of(0, 10, Sort.by("firstName"));
         when(personService.getActivePersons(personPageRequest, "")).thenReturn(new PageImpl<>(personsForExport));
 
-        final LocalDate from = LocalDate.of(2023, 1, 1);
-        final LocalDate to = LocalDate.of(2023, 1, 31);
+        final LocalDate from = LocalDate.of(2023, JANUARY, 1);
+        final LocalDate to = LocalDate.of(2023, JANUARY, 31);
         final ApplicationForLeave app = new ApplicationForLeave(new Application(), new TreeMap<>());
         app.setId(1L);
         app.setPerson(user);
@@ -240,8 +241,8 @@ class ApplicationForLeaveExportServiceTest {
         final PersonPageRequest personPageRequest = PersonPageRequest.of(0, 10);
         when(personService.getActivePersons(personPageRequest, "")).thenReturn(new PageImpl<>(personsForExport));
 
-        final LocalDate from = LocalDate.of(2023, 1, 1);
-        final LocalDate to = LocalDate.of(2023, 1, 31);
+        final LocalDate from = LocalDate.of(2023, JANUARY, 1);
+        final LocalDate to = LocalDate.of(2023, JANUARY, 31);
         final ApplicationForLeave app = new ApplicationForLeave(new Application(), new TreeMap<>());
         app.setId(1L);
         app.setPerson(user);

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/export/ApplicationForLeaveExportViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/export/ApplicationForLeaveExportViewControllerTest.java
@@ -35,6 +35,8 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import static java.math.BigDecimal.TEN;
+import static java.time.Month.AUGUST;
+import static java.time.Month.JANUARY;
 import static java.util.Locale.JAPANESE;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -71,8 +73,8 @@ class ApplicationForLeaveExportViewControllerTest {
 
         final Locale locale = Locale.GERMAN;
 
-        when(dateFormatAware.parse("01.01.2022", locale)).thenReturn(Optional.of(LocalDate.of(2022, 1, 1)));
-        when(dateFormatAware.parse("01.01.2023", locale)).thenReturn(Optional.of(LocalDate.of(2023, 1, 1)));
+        when(dateFormatAware.parse("01.01.2022", locale)).thenReturn(Optional.of(LocalDate.of(2022, JANUARY, 1)));
+        when(dateFormatAware.parse("01.01.2023", locale)).thenReturn(Optional.of(LocalDate.of(2023, JANUARY, 1)));
 
         perform(
             get("/web/application/export")
@@ -121,8 +123,8 @@ class ApplicationForLeaveExportViewControllerTest {
         final CSVFile csvFile = new CSVFile("csv-file-name", new ByteArrayResource("csv-resource".getBytes()));
         when(applicationForLeaveCsvExportService.generateCSV(filterPeriod, locale, List.of(applicationForLeaveExport))).thenReturn(csvFile);
 
-        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 1, 1)));
-        when(dateFormatAware.parse("01.08.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 8, 1)));
+        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, JANUARY, 1)));
+        when(dateFormatAware.parse("01.08.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, AUGUST, 1)));
 
         perform(get("/web/application/export")
             .locale(locale)
@@ -170,8 +172,8 @@ class ApplicationForLeaveExportViewControllerTest {
         final CSVFile csvFile = new CSVFile("csv-file-name", new ByteArrayResource("csv-resource".getBytes()));
         when(applicationForLeaveCsvExportService.generateCSV(filterPeriod, locale, List.of(applicationForLeaveExport))).thenReturn(csvFile);
 
-        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 1, 1)));
-        when(dateFormatAware.parse("01.08.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 8, 1)));
+        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, JANUARY, 1)));
+        when(dateFormatAware.parse("01.08.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, AUGUST, 1)));
 
         perform(get("/web/application/export")
             .locale(locale)
@@ -196,8 +198,8 @@ class ApplicationForLeaveExportViewControllerTest {
         final LocalDate endDate = LocalDate.parse("2019-08-01");
         final FilterPeriod filterPeriod = new FilterPeriod(startDate, endDate);
 
-        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 1, 1)));
-        when(dateFormatAware.parse("01.08.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 8, 1)));
+        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, JANUARY, 1)));
+        when(dateFormatAware.parse("01.08.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, AUGUST, 1)));
 
         final VacationType<?> vacationType = ProvidedVacationType.builder(new StaticMessageSource())
             .id(1L)
@@ -271,8 +273,8 @@ class ApplicationForLeaveExportViewControllerTest {
         final CSVFile csvFile = new CSVFile("csv-file-name", new ByteArrayResource("csv-resource".getBytes()));
         when(applicationForLeaveCsvExportService.generateCSV(filterPeriod, locale, List.of(applicationForLeaveExport))).thenReturn(csvFile);
 
-        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 1, 1)));
-        when(dateFormatAware.parse("01.08.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 8, 1)));
+        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, JANUARY, 1)));
+        when(dateFormatAware.parse("01.08.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, AUGUST, 1)));
 
         perform(get("/web/application/export")
             .locale(locale)

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/me/ApplicationsViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/me/ApplicationsViewControllerTest.java
@@ -41,6 +41,8 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import static java.math.BigDecimal.ONE;
+import static java.time.Month.JANUARY;
+import static java.time.Month.JUNE;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -94,7 +96,7 @@ class ApplicationsViewControllerTest {
     private PersonSearchUiFragmentSupplier personSearchUiFragmentSupplier;
 
     private final Clock clock = Clock.fixed(
-        ZonedDateTime.of(LocalDate.of(2022, 6, 15).atStartOfDay(), ZoneId.systemDefault()).toInstant(),
+        ZonedDateTime.of(LocalDate.of(2022, JUNE, 15).atStartOfDay(), ZoneId.systemDefault()).toInstant(),
         ZoneId.systemDefault()
     );
 
@@ -215,8 +217,8 @@ class ApplicationsViewControllerTest {
         final Application application = new Application();
         application.setId(99L);
         application.setPerson(person);
-        application.setStartDate(LocalDate.of(2022, 1, 10));
-        application.setEndDate(LocalDate.of(2022, 1, 12));
+        application.setStartDate(LocalDate.of(2022, JANUARY, 10));
+        application.setEndDate(LocalDate.of(2022, JANUARY, 12));
 
         final VacationType<?> vacationType = mock(VacationType.class);
         when(vacationType.getLabel(any(Locale.class))).thenReturn("label");
@@ -854,8 +856,8 @@ class ApplicationsViewControllerTest {
         application.setId(id);
         application.setPerson(person);
         application.setStatus(status);
-        application.setStartDate(LocalDate.of(2022, 1, 10));
-        application.setEndDate(LocalDate.of(2022, 1, 12));
+        application.setStartDate(LocalDate.of(2022, JANUARY, 10));
+        application.setEndDate(LocalDate.of(2022, JANUARY, 12));
 
         final VacationType<?> vacationType = mock(VacationType.class);
         when(vacationType.getLabel(any(Locale.class))).thenReturn("label");

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/me/YearlyUsedDaysSummaryTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/me/YearlyUsedDaysSummaryTest.java
@@ -19,6 +19,10 @@ import java.util.List;
 
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.ZERO;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
+import static java.time.Month.MARCH;
+import static java.time.Month.OCTOBER;
 import static java.util.Collections.singletonList;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
@@ -50,8 +54,8 @@ class YearlyUsedDaysSummaryTest {
 
         final Application holidayAllowed = anyApplication();
         holidayAllowed.setVacationType(createVacationType(1L, HOLIDAY, new StaticMessageSource()));
-        holidayAllowed.setStartDate(LocalDate.of(2014, 3, 5));
-        holidayAllowed.setEndDate(LocalDate.of(2016, 12, 30));
+        holidayAllowed.setStartDate(LocalDate.of(2014, MARCH, 5));
+        holidayAllowed.setEndDate(LocalDate.of(2016, DECEMBER, 30));
         holidayAllowed.setStatus(ALLOWED);
 
         final BigDecimal workingDays = BigDecimal.valueOf(499);
@@ -70,62 +74,62 @@ class YearlyUsedDaysSummaryTest {
 
         final Application holiday = anyApplication();
         holiday.setVacationType(createVacationType(1L, HOLIDAY, new StaticMessageSource()));
-        holiday.setStartDate(LocalDate.of(2014, 10, 13));
-        holiday.setEndDate(LocalDate.of(2014, 10, 13));
+        holiday.setStartDate(LocalDate.of(2014, OCTOBER, 13));
+        holiday.setEndDate(LocalDate.of(2014, OCTOBER, 13));
         holiday.setStatus(WAITING);
 
         final Application holidayAllowed = anyApplication();
         holidayAllowed.setVacationType(createVacationType(1L, HOLIDAY, new StaticMessageSource()));
-        holidayAllowed.setStartDate(LocalDate.of(2014, 10, 14));
-        holidayAllowed.setEndDate(LocalDate.of(2014, 10, 14));
+        holidayAllowed.setStartDate(LocalDate.of(2014, OCTOBER, 14));
+        holidayAllowed.setEndDate(LocalDate.of(2014, OCTOBER, 14));
         holidayAllowed.setStatus(ALLOWED);
 
         final Application holidayAllowedRequestCancellation = anyApplication();
         holidayAllowedRequestCancellation.setVacationType(createVacationType(1L, HOLIDAY, new StaticMessageSource()));
-        holidayAllowedRequestCancellation.setStartDate(LocalDate.of(2014, 10, 14));
-        holidayAllowedRequestCancellation.setEndDate(LocalDate.of(2014, 10, 14));
+        holidayAllowedRequestCancellation.setStartDate(LocalDate.of(2014, OCTOBER, 14));
+        holidayAllowedRequestCancellation.setEndDate(LocalDate.of(2014, OCTOBER, 14));
         holidayAllowedRequestCancellation.setStatus(ALLOWED_CANCELLATION_REQUESTED);
 
         final Application specialLeave = anyApplication();
         specialLeave.setVacationType(createVacationType(1L, SPECIALLEAVE, new StaticMessageSource()));
-        specialLeave.setStartDate(LocalDate.of(2014, 10, 15));
-        specialLeave.setEndDate(LocalDate.of(2014, 10, 15));
+        specialLeave.setStartDate(LocalDate.of(2014, OCTOBER, 15));
+        specialLeave.setEndDate(LocalDate.of(2014, OCTOBER, 15));
         specialLeave.setStatus(WAITING);
 
         final Application specialLeaveAllowed = anyApplication();
         specialLeaveAllowed.setVacationType(createVacationType(1L, SPECIALLEAVE, new StaticMessageSource()));
-        specialLeaveAllowed.setStartDate(LocalDate.of(2014, 10, 16));
-        specialLeaveAllowed.setEndDate(LocalDate.of(2014, 10, 16));
+        specialLeaveAllowed.setStartDate(LocalDate.of(2014, OCTOBER, 16));
+        specialLeaveAllowed.setEndDate(LocalDate.of(2014, OCTOBER, 16));
         specialLeaveAllowed.setStatus(ALLOWED);
 
         final Application unpaidLeave = anyApplication();
         unpaidLeave.setVacationType(createVacationType(1L, UNPAIDLEAVE, new StaticMessageSource()));
-        unpaidLeave.setStartDate(LocalDate.of(2014, 10, 17));
-        unpaidLeave.setEndDate(LocalDate.of(2014, 10, 17));
+        unpaidLeave.setStartDate(LocalDate.of(2014, OCTOBER, 17));
+        unpaidLeave.setEndDate(LocalDate.of(2014, OCTOBER, 17));
         unpaidLeave.setStatus(WAITING);
 
         final Application unpaidLeaveAllowed = anyApplication();
         unpaidLeaveAllowed.setVacationType(createVacationType(1L, UNPAIDLEAVE, new StaticMessageSource()));
-        unpaidLeaveAllowed.setStartDate(LocalDate.of(2014, 10, 20));
-        unpaidLeaveAllowed.setEndDate(LocalDate.of(2014, 10, 20));
+        unpaidLeaveAllowed.setStartDate(LocalDate.of(2014, OCTOBER, 20));
+        unpaidLeaveAllowed.setEndDate(LocalDate.of(2014, OCTOBER, 20));
         unpaidLeaveAllowed.setStatus(ALLOWED);
 
         final Application overtimeLeave = anyApplication();
         overtimeLeave.setVacationType(createVacationType(1L, OVERTIME, new StaticMessageSource()));
-        overtimeLeave.setStartDate(LocalDate.of(2014, 10, 21));
-        overtimeLeave.setEndDate(LocalDate.of(2014, 10, 21));
+        overtimeLeave.setStartDate(LocalDate.of(2014, OCTOBER, 21));
+        overtimeLeave.setEndDate(LocalDate.of(2014, OCTOBER, 21));
         overtimeLeave.setStatus(WAITING);
 
         final Application overtimeLeaveAllowed = anyApplication();
         overtimeLeaveAllowed.setVacationType(createVacationType(1L, OVERTIME, new StaticMessageSource()));
-        overtimeLeaveAllowed.setStartDate(LocalDate.of(2014, 10, 22));
-        overtimeLeaveAllowed.setEndDate(LocalDate.of(2014, 10, 22));
+        overtimeLeaveAllowed.setStartDate(LocalDate.of(2014, OCTOBER, 22));
+        overtimeLeaveAllowed.setEndDate(LocalDate.of(2014, OCTOBER, 22));
         overtimeLeaveAllowed.setStatus(ALLOWED);
 
         final Application overtimeLeaveRequestCancellation = anyApplication();
         overtimeLeaveRequestCancellation.setVacationType(createVacationType(1L, OVERTIME, new StaticMessageSource()));
-        overtimeLeaveRequestCancellation.setStartDate(LocalDate.of(2014, 10, 22));
-        overtimeLeaveRequestCancellation.setEndDate(LocalDate.of(2014, 10, 22));
+        overtimeLeaveRequestCancellation.setStartDate(LocalDate.of(2014, OCTOBER, 22));
+        overtimeLeaveRequestCancellation.setEndDate(LocalDate.of(2014, OCTOBER, 22));
         overtimeLeaveRequestCancellation.setStatus(ALLOWED_CANCELLATION_REQUESTED);
 
         final List<Application> applications = Arrays.asList(holiday, holidayAllowed, holidayAllowedRequestCancellation,
@@ -164,8 +168,8 @@ class YearlyUsedDaysSummaryTest {
     void ensureCalculatesDaysForGivenYearForApplicationsSpanningTwoYears() {
 
         Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        LocalDate startDate = LocalDate.of(2013, 12, 24);
-        LocalDate endDate = LocalDate.of(2014, 1, 6);
+        LocalDate startDate = LocalDate.of(2013, DECEMBER, 24);
+        LocalDate endDate = LocalDate.of(2014, JANUARY, 6);
 
         // 3 days in 2013, 2 days in 2014
         Application holiday = createApplication(person, createVacationType(1L, HOLIDAY, new StaticMessageSource()), startDate, endDate, DayLength.FULL);
@@ -190,20 +194,20 @@ class YearlyUsedDaysSummaryTest {
 
         final Application holiday = anyApplication();
         holiday.setVacationType(createVacationType(1L, HOLIDAY, new StaticMessageSource()));
-        holiday.setStartDate(LocalDate.of(2014, 10, 13));
-        holiday.setEndDate(LocalDate.of(2014, 10, 13));
+        holiday.setStartDate(LocalDate.of(2014, OCTOBER, 13));
+        holiday.setEndDate(LocalDate.of(2014, OCTOBER, 13));
         holiday.setStatus(WAITING);
 
         final Application holidayAllowed = anyApplication();
         holidayAllowed.setVacationType(createVacationType(1L, HOLIDAY, new StaticMessageSource()));
-        holidayAllowed.setStartDate(LocalDate.of(2014, 10, 14));
-        holidayAllowed.setEndDate(LocalDate.of(2014, 10, 14));
+        holidayAllowed.setStartDate(LocalDate.of(2014, OCTOBER, 14));
+        holidayAllowed.setEndDate(LocalDate.of(2014, OCTOBER, 14));
         holidayAllowed.setStatus(ALLOWED);
 
         final Application holidayTemporaryAllowed = anyApplication();
         holidayTemporaryAllowed.setVacationType(createVacationType(1L, HOLIDAY, new StaticMessageSource()));
-        holidayTemporaryAllowed.setStartDate(LocalDate.of(2014, 10, 15));
-        holidayTemporaryAllowed.setEndDate(LocalDate.of(2014, 10, 15));
+        holidayTemporaryAllowed.setStartDate(LocalDate.of(2014, OCTOBER, 15));
+        holidayTemporaryAllowed.setEndDate(LocalDate.of(2014, OCTOBER, 15));
         holidayTemporaryAllowed.setStatus(TEMPORARY_ALLOWED);
 
         List<Application> applications = Arrays.asList(holiday, holidayTemporaryAllowed, holidayAllowed);

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsBuilderTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsBuilderTest.java
@@ -38,6 +38,7 @@ import static java.time.LocalDate.of;
 import static java.time.Month.APRIL;
 import static java.time.Month.DECEMBER;
 import static java.time.Month.JANUARY;
+import static java.time.Month.NOVEMBER;
 import static java.time.Month.OCTOBER;
 import static java.time.temporal.TemporalAdjusters.firstDayOfYear;
 import static java.time.temporal.TemporalAdjusters.lastDayOfYear;
@@ -80,7 +81,7 @@ class ApplicationForLeaveStatisticsBuilderTest {
         final VacationType<?> type = ProvidedVacationType.builder(new StaticMessageSource()).build();
 
         assertThatIllegalArgumentException()
-            .isThrownBy(() -> sut.build(List.of(new Person()), of(2014, 1, 1), of(2015, 1, 1), List.of(type)));
+            .isThrownBy(() -> sut.build(List.of(new Person()), of(2014, JANUARY, 1), of(2015, JANUARY, 1), List.of(type)));
     }
 
     @Test
@@ -108,8 +109,8 @@ class ApplicationForLeaveStatisticsBuilderTest {
         applicationForLeave.setPerson(person);
         applicationForLeave.setDayLength(FULL);
         applicationForLeave.setVacationType(vacationTypes.getFirst());
-        applicationForLeave.setStartDate(of(2014, 10, 13));
-        applicationForLeave.setEndDate(of(2014, 10, 13));
+        applicationForLeave.setStartDate(of(2014, OCTOBER, 13));
+        applicationForLeave.setEndDate(of(2014, OCTOBER, 13));
         applicationForLeave.setStatus(ALLOWED);
 
         final List<Application> applications = List.of(applicationForLeave);
@@ -167,8 +168,8 @@ class ApplicationForLeaveStatisticsBuilderTest {
         applicationForLeave.setPerson(person);
         applicationForLeave.setDayLength(FULL);
         applicationForLeave.setVacationType(vacationTypes.getFirst());
-        applicationForLeave.setStartDate(of(2014, 10, 13));
-        applicationForLeave.setEndDate(of(2014, 10, 13));
+        applicationForLeave.setStartDate(of(2014, OCTOBER, 13));
+        applicationForLeave.setEndDate(of(2014, OCTOBER, 13));
         applicationForLeave.setStatus(ALLOWED);
 
         final List<Application> applications = List.of(applicationForLeave);
@@ -224,8 +225,8 @@ class ApplicationForLeaveStatisticsBuilderTest {
         applicationForLeave.setPerson(person);
         applicationForLeave.setDayLength(FULL);
         applicationForLeave.setVacationType(vacationTypes.getFirst());
-        applicationForLeave.setStartDate(of(2014, 10, 13));
-        applicationForLeave.setEndDate(of(2014, 10, 13));
+        applicationForLeave.setStartDate(of(2014, OCTOBER, 13));
+        applicationForLeave.setEndDate(of(2014, OCTOBER, 13));
         applicationForLeave.setStatus(ALLOWED);
 
         final List<Application> applications = List.of(applicationForLeave);
@@ -291,8 +292,8 @@ class ApplicationForLeaveStatisticsBuilderTest {
         applicationForLeave.setPerson(person);
         applicationForLeave.setDayLength(FULL);
         applicationForLeave.setVacationType(vacationTypes.getFirst());
-        applicationForLeave.setStartDate(of(2014, 10, 13));
-        applicationForLeave.setEndDate(of(2014, 10, 13));
+        applicationForLeave.setStartDate(of(2014, OCTOBER, 13));
+        applicationForLeave.setEndDate(of(2014, OCTOBER, 13));
         applicationForLeave.setStatus(ALLOWED);
 
         final List<Application> applications = List.of(applicationForLeave);
@@ -357,56 +358,56 @@ class ApplicationForLeaveStatisticsBuilderTest {
         holidayWaiting.setPerson(person);
         holidayWaiting.setDayLength(FULL);
         holidayWaiting.setVacationType(vacationTypes.getFirst());
-        holidayWaiting.setStartDate(of(2014, 10, 13));
-        holidayWaiting.setEndDate(of(2014, 10, 13));
+        holidayWaiting.setStartDate(of(2014, OCTOBER, 13));
+        holidayWaiting.setEndDate(of(2014, OCTOBER, 13));
         holidayWaiting.setStatus(WAITING);
 
         final Application holidayTemporaryAllowed = new Application();
         holidayTemporaryAllowed.setPerson(person);
         holidayTemporaryAllowed.setDayLength(FULL);
         holidayTemporaryAllowed.setVacationType(vacationTypes.getFirst());
-        holidayTemporaryAllowed.setStartDate(of(2014, 10, 12));
-        holidayTemporaryAllowed.setEndDate(of(2014, 10, 12));
+        holidayTemporaryAllowed.setStartDate(of(2014, OCTOBER, 12));
+        holidayTemporaryAllowed.setEndDate(of(2014, OCTOBER, 12));
         holidayTemporaryAllowed.setStatus(TEMPORARY_ALLOWED);
 
         final Application holidayAllowed = new Application();
         holidayAllowed.setPerson(person);
         holidayAllowed.setDayLength(FULL);
         holidayAllowed.setVacationType(vacationTypes.getFirst());
-        holidayAllowed.setStartDate(of(2014, 10, 14));
-        holidayAllowed.setEndDate(of(2014, 10, 14));
+        holidayAllowed.setStartDate(of(2014, OCTOBER, 14));
+        holidayAllowed.setEndDate(of(2014, OCTOBER, 14));
         holidayAllowed.setStatus(ALLOWED);
 
         final Application holidayAllowedCancellationRequested = new Application();
         holidayAllowedCancellationRequested.setPerson(person);
         holidayAllowedCancellationRequested.setDayLength(FULL);
         holidayAllowedCancellationRequested.setVacationType(vacationTypes.getFirst());
-        holidayAllowedCancellationRequested.setStartDate(of(2014, 10, 15));
-        holidayAllowedCancellationRequested.setEndDate(of(2014, 10, 15));
+        holidayAllowedCancellationRequested.setStartDate(of(2014, OCTOBER, 15));
+        holidayAllowedCancellationRequested.setEndDate(of(2014, OCTOBER, 15));
         holidayAllowedCancellationRequested.setStatus(ALLOWED_CANCELLATION_REQUESTED);
 
         final Application specialLeaveWaiting = new Application();
         specialLeaveWaiting.setPerson(person);
         specialLeaveWaiting.setDayLength(FULL);
         specialLeaveWaiting.setVacationType(vacationTypes.get(1));
-        specialLeaveWaiting.setStartDate(of(2014, 10, 15));
-        specialLeaveWaiting.setEndDate(of(2014, 10, 15));
+        specialLeaveWaiting.setStartDate(of(2014, OCTOBER, 15));
+        specialLeaveWaiting.setEndDate(of(2014, OCTOBER, 15));
         specialLeaveWaiting.setStatus(WAITING);
 
         final Application unpaidLeaveAllowed = new Application();
         unpaidLeaveAllowed.setPerson(person);
         unpaidLeaveAllowed.setDayLength(FULL);
         unpaidLeaveAllowed.setVacationType(vacationTypes.get(2));
-        unpaidLeaveAllowed.setStartDate(of(2014, 10, 16));
-        unpaidLeaveAllowed.setEndDate(of(2014, 10, 16));
+        unpaidLeaveAllowed.setStartDate(of(2014, OCTOBER, 16));
+        unpaidLeaveAllowed.setEndDate(of(2014, OCTOBER, 16));
         unpaidLeaveAllowed.setStatus(ALLOWED);
 
         final Application overTimeWaiting = new Application();
         overTimeWaiting.setPerson(person);
         overTimeWaiting.setDayLength(FULL);
         overTimeWaiting.setVacationType(vacationTypes.get(3));
-        overTimeWaiting.setStartDate(of(2014, 11, 3));
-        overTimeWaiting.setEndDate(of(2014, 11, 3));
+        overTimeWaiting.setStartDate(of(2014, NOVEMBER, 3));
+        overTimeWaiting.setEndDate(of(2014, NOVEMBER, 3));
         overTimeWaiting.setStatus(WAITING);
 
         final List<Application> applications = List.of(holidayWaiting, holidayTemporaryAllowed, holidayAllowed,

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsViewControllerTest.java
@@ -46,6 +46,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
+import static java.time.Month.AUGUST;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
 import static java.util.Locale.JAPANESE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -135,8 +138,8 @@ class ApplicationForLeaveStatisticsViewControllerTest {
 
         final Locale locale = Locale.GERMAN;
 
-        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 1, 1)));
-        when(dateFormatAware.parse("01.08.2020", locale)).thenReturn(Optional.of(LocalDate.of(2020, 8, 1)));
+        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, JANUARY, 1)));
+        when(dateFormatAware.parse("01.08.2020", locale)).thenReturn(Optional.of(LocalDate.of(2020, AUGUST, 1)));
 
         perform(
             get(givenRequestUrl)
@@ -156,8 +159,8 @@ class ApplicationForLeaveStatisticsViewControllerTest {
 
         final Locale locale = Locale.GERMAN;
 
-        when(dateFormatAware.parse("01.12.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 12, 1)));
-        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 1, 1)));
+        when(dateFormatAware.parse("01.12.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, DECEMBER, 1)));
+        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, JANUARY, 1)));
 
         perform(
             get(givenRequestUrl)
@@ -193,8 +196,8 @@ class ApplicationForLeaveStatisticsViewControllerTest {
         final List<VacationType<?>> vacationType = List.of(ProvidedVacationType.builder(messageSource).messageKey("vacation-type-label-message-key").id(1L).build());
         when(vacationTypeService.getAllVacationTypes()).thenReturn(vacationType);
 
-        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 1, 1)));
-        when(dateFormatAware.parse("01.08.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 8, 1)));
+        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, JANUARY, 1)));
+        when(dateFormatAware.parse("01.08.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, AUGUST, 1)));
 
         final ResultActions resultActions = perform(
             get(givenRequestUrl)
@@ -251,8 +254,8 @@ class ApplicationForLeaveStatisticsViewControllerTest {
         when(applicationForLeaveStatisticsService.getStatisticsSortedByPerson(signedInUser, filterPeriod, pageRequest, ""))
             .thenReturn(new PageImpl<>(List.of(statistic)));
 
-        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 1, 1)));
-        when(dateFormatAware.parse("01.08.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 8, 1)));
+        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, JANUARY, 1)));
+        when(dateFormatAware.parse("01.08.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, AUGUST, 1)));
 
         final ResultActions resultActions = perform(
             get(givenRequestUrl)
@@ -469,8 +472,8 @@ class ApplicationForLeaveStatisticsViewControllerTest {
 
         final Locale locale = Locale.GERMAN;
 
-        when(dateFormatAware.parse("01.01.2000", locale)).thenReturn(Optional.of(LocalDate.of(2000, 1, 1)));
-        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 1, 1)));
+        when(dateFormatAware.parse("01.01.2000", locale)).thenReturn(Optional.of(LocalDate.of(2000, JANUARY, 1)));
+        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, JANUARY, 1)));
 
         perform(
             get(givenRequestUrl)
@@ -530,8 +533,8 @@ class ApplicationForLeaveStatisticsViewControllerTest {
         final CSVFile csvFile = new CSVFile("csv-file-name", new ByteArrayResource("csv-resource".getBytes()));
         when(applicationForLeaveStatisticsCsvExportService.generateCSV(filterPeriod, locale, List.of(statistics))).thenReturn(csvFile);
 
-        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 1, 1)));
-        when(dateFormatAware.parse("01.08.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 8, 1)));
+        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, JANUARY, 1)));
+        when(dateFormatAware.parse("01.08.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, AUGUST, 1)));
 
         perform(get(givenRequestUrl)
             .locale(locale)
@@ -565,8 +568,8 @@ class ApplicationForLeaveStatisticsViewControllerTest {
         final CSVFile csvFile = new CSVFile("csv-file-name", new ByteArrayResource("csv-resource".getBytes()));
         when(applicationForLeaveStatisticsCsvExportService.generateCSV(filterPeriod, locale, List.of(statistics))).thenReturn(csvFile);
 
-        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 1, 1)));
-        when(dateFormatAware.parse("01.08.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 8, 1)));
+        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, JANUARY, 1)));
+        when(dateFormatAware.parse("01.08.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, AUGUST, 1)));
 
         perform(get(givenRequestUrl)
             .locale(locale)
@@ -602,8 +605,8 @@ class ApplicationForLeaveStatisticsViewControllerTest {
         final CSVFile csvFile = new CSVFile("csv-file-name", new ByteArrayResource("csv-resource".getBytes()));
         when(applicationForLeaveStatisticsCsvExportService.generateCSV(filterPeriod, locale, List.of(statistics))).thenReturn(csvFile);
 
-        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 1, 1)));
-        when(dateFormatAware.parse("01.08.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 8, 1)));
+        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, JANUARY, 1)));
+        when(dateFormatAware.parse("01.08.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, AUGUST, 1)));
 
         perform(get(givenRequestUrl)
             .locale(locale)
@@ -638,8 +641,8 @@ class ApplicationForLeaveStatisticsViewControllerTest {
         final CSVFile csvFile = new CSVFile("csv-file-name", new ByteArrayResource("csv-resource".getBytes()));
         when(applicationForLeaveStatisticsCsvExportService.generateCSV(filterPeriod, locale, List.of(statistics))).thenReturn(csvFile);
 
-        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 1, 1)));
-        when(dateFormatAware.parse("01.08.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, 8, 1)));
+        when(dateFormatAware.parse("01.01.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, JANUARY, 1)));
+        when(dateFormatAware.parse("01.08.2019", locale)).thenReturn(Optional.of(LocalDate.of(2019, AUGUST, 1)));
 
         perform(get(givenRequestUrl)
             .locale(locale)

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendar/CalendarAbsenceServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendar/CalendarAbsenceServiceImplTest.java
@@ -18,6 +18,9 @@ import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.List;
 
+import static java.time.Month.DECEMBER;
+import static java.time.Month.NOVEMBER;
+import static java.time.Month.OCTOBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static org.synyx.urlaubsverwaltung.TestDataCreator.createApplication;
@@ -55,15 +58,15 @@ class CalendarAbsenceServiceImplTest {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
 
-        final LocalDate since = LocalDate.of(2020, 10, 13);
+        final LocalDate since = LocalDate.of(2020, OCTOBER, 13);
 
-        final LocalDate startDate = LocalDate.of(2019, 12, 10);
-        final LocalDate endDate = LocalDate.of(2019, 12, 23);
+        final LocalDate startDate = LocalDate.of(2019, DECEMBER, 10);
+        final LocalDate endDate = LocalDate.of(2019, DECEMBER, 23);
         final Application application = createApplication(person, startDate, endDate, FULL, new StaticMessageSource());
         when(applicationService.getForStatesAndPersonSince(activeStatuses(), List.of(person), since)).thenReturn(List.of(application));
 
-        final LocalDate startDateSickNote = LocalDate.of(2019, 10, 10);
-        final LocalDate endDateSickNote = LocalDate.of(2019, 10, 23);
+        final LocalDate startDateSickNote = LocalDate.of(2019, OCTOBER, 10);
+        final LocalDate endDateSickNote = LocalDate.of(2019, OCTOBER, 23);
         final SickNote sickNote = createSickNote(person, startDateSickNote, endDateSickNote, FULL);
         when(sickNoteService.getForStatesAndPersonSince(List.of(SUBMITTED, ACTIVE), List.of(person), since)).thenReturn(List.of(sickNote));
 
@@ -88,15 +91,15 @@ class CalendarAbsenceServiceImplTest {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
 
-        final LocalDate since = LocalDate.of(2020, 11, 13);
+        final LocalDate since = LocalDate.of(2020, NOVEMBER, 13);
 
-        final LocalDate startDate = LocalDate.of(2019, 11, 10);
-        final LocalDate endDate = LocalDate.of(2019, 11, 23);
+        final LocalDate startDate = LocalDate.of(2019, NOVEMBER, 10);
+        final LocalDate endDate = LocalDate.of(2019, NOVEMBER, 23);
         final Application application = createApplication(person, startDate, endDate, FULL, new StaticMessageSource());
         when(applicationService.getForStatesSince(activeStatuses(), since)).thenReturn(List.of(application));
 
-        final LocalDate startDateSickNote = LocalDate.of(2019, 10, 10);
-        final LocalDate endDateSickNote = LocalDate.of(2019, 10, 23);
+        final LocalDate startDateSickNote = LocalDate.of(2019, OCTOBER, 10);
+        final LocalDate endDateSickNote = LocalDate.of(2019, OCTOBER, 23);
         final SickNote sickNote = createSickNote(person, startDateSickNote, endDateSickNote, FULL);
         when(sickNoteService.getForStatesSince(List.of(SUBMITTED, ACTIVE), since)).thenReturn(List.of(sickNote));
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendar/CalendarAbsenceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendar/CalendarAbsenceTest.java
@@ -12,6 +12,8 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
+import static java.time.Month.OCTOBER;
+import static java.time.Month.SEPTEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.synyx.urlaubsverwaltung.calendar.CalendarAbsenceType.HOLIDAY_REPLACEMENT;
 
@@ -29,8 +31,8 @@ class CalendarAbsenceTest {
     @Test
     void ensureCanBeInstantiatedWithCorrectProperties() {
 
-        final LocalDate start = LocalDate.of(2015, 9, 21);
-        final LocalDate end = LocalDate.of(2015, 9, 23);
+        final LocalDate start = LocalDate.of(2015, SEPTEMBER, 21);
+        final LocalDate end = LocalDate.of(2015, SEPTEMBER, 23);
         final Period period = new Period(start, end, DayLength.FULL);
 
         final CalendarAbsence absence = new CalendarAbsence(person, period, getAbsenceTimeConfiguration());
@@ -43,8 +45,8 @@ class CalendarAbsenceTest {
     @Test
     void ensureCanBeInstantiatedWithCorrectPropertiesInDifferentTimeZone() {
 
-        final LocalDate start = LocalDate.of(2015, 9, 21);
-        final LocalDate end = LocalDate.of(2015, 9, 23);
+        final LocalDate start = LocalDate.of(2015, SEPTEMBER, 21);
+        final LocalDate end = LocalDate.of(2015, SEPTEMBER, 23);
         final Period period = new Period(start, end, DayLength.FULL);
 
         final CalendarAbsence absence = new CalendarAbsence(person, period, getAbsenceTimeConfiguration("Europe/Berlin"));
@@ -58,8 +60,8 @@ class CalendarAbsenceTest {
     void ensureCanBeInstantiatedWithCorrectPropertiesConsideringDaylightSavingTime() {
 
         // Date where daylight saving time is relevant
-        final LocalDate start = LocalDate.of(2015, 10, 23);
-        final LocalDate end = LocalDate.of(2015, 10, 25);
+        final LocalDate start = LocalDate.of(2015, OCTOBER, 23);
+        final LocalDate end = LocalDate.of(2015, OCTOBER, 25);
         final Period period = new Period(start, end, DayLength.FULL);
 
         final CalendarAbsence absence = new CalendarAbsence(person, period, getAbsenceTimeConfiguration());
@@ -149,8 +151,8 @@ class CalendarAbsenceTest {
     @Test
     void toStringTest() {
         // Date where daylight saving time is relevant
-        final LocalDate start = LocalDate.of(2015, 10, 23);
-        final LocalDate end = LocalDate.of(2015, 10, 25);
+        final LocalDate start = LocalDate.of(2015, OCTOBER, 23);
+        final LocalDate end = LocalDate.of(2015, OCTOBER, 25);
         final CalendarAbsence absence = new CalendarAbsence(person, new Period(start, end, DayLength.FULL), getAbsenceTimeConfiguration());
 
         final String absenceToString = absence.toString();

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendar/DepartmentCalendarServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendar/DepartmentCalendarServiceTest.java
@@ -23,6 +23,9 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.time.LocalDate.parse;
+import static java.time.Month.JANUARY;
+import static java.time.Month.JUNE;
+import static java.time.Month.MAY;
 import static java.time.format.DateTimeFormatter.ofPattern;
 import static java.util.Locale.GERMAN;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -93,7 +96,7 @@ class DepartmentCalendarServiceTest {
 
         final Department department = createDepartment("DepartmentName");
         department.setId(1L);
-        department.setCreatedAt(LocalDate.of(2018, 1, 1));
+        department.setCreatedAt(LocalDate.of(2018, JANUARY, 1));
         when(departmentService.getDepartmentById(1L)).thenReturn(Optional.of(department));
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
@@ -272,7 +275,7 @@ class DepartmentCalendarServiceTest {
 
         final Department department = createDepartment("DepartmentName");
         department.setId(1L);
-        final LocalDate createdAt = LocalDate.of(2018, 5, 1);
+        final LocalDate createdAt = LocalDate.of(2018, MAY, 1);
         department.setCreatedAt(createdAt);
         when(departmentService.getDepartmentById(1L)).thenReturn(Optional.of(department));
 
@@ -304,7 +307,7 @@ class DepartmentCalendarServiceTest {
 
         final Department department = createDepartment("DepartmentName");
         department.setId(1L);
-        final LocalDate createdAt = LocalDate.of(2018, 5, 1);
+        final LocalDate createdAt = LocalDate.of(2018, MAY, 1);
         department.setCreatedAt(createdAt);
         when(departmentService.getDepartmentById(1L)).thenReturn(Optional.of(department));
 
@@ -321,10 +324,10 @@ class DepartmentCalendarServiceTest {
         when(departmentCalendarRepository.findBySecretAndPerson("secret", person)).thenReturn(Optional.of(departmentCalendar));
 
         final List<CalendarAbsence> fullDayAbsences = List.of(absence(person, parse("2018-03-26", ofPattern("yyyy-MM-dd")), parse("2018-03-26", ofPattern("yyyy-MM-dd")), FULL));
-        when(calendarAbsenceService.getOpenAbsencesSince(List.of(person), LocalDate.of(2018, 6, 15))).thenReturn(fullDayAbsences);
+        when(calendarAbsenceService.getOpenAbsencesSince(List.of(person), LocalDate.of(2018, JUNE, 15))).thenReturn(fullDayAbsences);
 
         departmentCalendarService.getCalendarForDepartment(1L, 10L, "secret", GERMAN);
-        verify(calendarAbsenceService).getOpenAbsencesSince(List.of(person), LocalDate.of(2018, 6, 15));
+        verify(calendarAbsenceService).getOpenAbsencesSince(List.of(person), LocalDate.of(2018, JUNE, 15));
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendarintegration/CalendarSyncServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendarintegration/CalendarSyncServiceTest.java
@@ -26,6 +26,7 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
+import static java.time.Month.DECEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
@@ -88,7 +89,7 @@ class CalendarSyncServiceTest {
     @Test
     void ensureToCreateCalendarEventOnApplicationUpdatedEvent() {
 
-        final LocalDate now = LocalDate.of(2022, 12, 10);
+        final LocalDate now = LocalDate.of(2022, DECEMBER, 10);
 
         final Application application = new Application();
         application.setId(1L);
@@ -124,7 +125,7 @@ class CalendarSyncServiceTest {
     @Test
     void ensureToCreateCalendarEventOnApplicationRejectedEvent() {
 
-        final LocalDate now = LocalDate.of(2022, 12, 10);
+        final LocalDate now = LocalDate.of(2022, DECEMBER, 10);
 
         final Application application = new Application();
         application.setId(1L);
@@ -191,7 +192,7 @@ class CalendarSyncServiceTest {
     @Test
     void ensureToUpdateCalendarEventOnSickNoteUpdatedEvent() {
 
-        final LocalDate now = LocalDate.of(2022, 12, 10);
+        final LocalDate now = LocalDate.of(2022, DECEMBER, 10);
 
         final Person person = new Person();
         person.setFirstName("first");

--- a/src/test/java/org/synyx/urlaubsverwaltung/company/CompanyControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/company/CompanyControllerTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.time.Month.JANUARY;
 import static java.time.ZoneOffset.UTC;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -160,8 +161,8 @@ class CompanyControllerTest {
         final Person signedInUser = new Person();
         when(personService.getSignedInUser()).thenReturn(signedInUser);
 
-        final LocalDate berlinToday = LocalDate.of(2026, 1, 15);
-        final LocalDate monthStart = LocalDate.of(2026, 1, 1);
+        final LocalDate berlinToday = LocalDate.of(2026, JANUARY, 15);
+        final LocalDate monthStart = LocalDate.of(2026, JANUARY, 1);
         stubCurrentAndPreviousRange(signedInUser, monthStart, berlinToday, OvertimeStatistic.empty());
 
         final Model model = new ConcurrentModel();
@@ -241,7 +242,7 @@ class CompanyControllerTest {
     }
 
     private static Overtime overtimeOf(PersonId personId, Duration duration) {
-        final LocalDate day = LocalDate.of(2024, 1, 1);
+        final LocalDate day = LocalDate.of(2024, JANUARY, 1);
         return new Overtime(new OvertimeId(personId.value()), personId, new DateRange(day, day), duration, OvertimeType.UV_INTERNAL, Instant.EPOCH);
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/company/OvertimeStatisticServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/company/OvertimeStatisticServiceTest.java
@@ -21,6 +21,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
+import static java.time.Month.JANUARY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -176,7 +177,7 @@ class OvertimeStatisticServiceTest {
 
     private static Overtime overtime(PersonId personId, Duration duration) {
         return new Overtime(new OvertimeId(1L), personId,
-            new DateRange(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 2)),
+            new DateRange(LocalDate.of(2026, JANUARY, 1), LocalDate.of(2026, JANUARY, 2)),
             duration, UV_INTERNAL, Instant.parse("2026-01-01T00:00:00.00Z"));
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/company/OvertimeStatisticTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/company/OvertimeStatisticTest.java
@@ -12,6 +12,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
+import static java.time.Month.JANUARY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.synyx.urlaubsverwaltung.overtime.OvertimeType.UV_INTERNAL;
@@ -81,7 +82,7 @@ class OvertimeStatisticTest {
         return new Overtime(
             new OvertimeId(1L),
             personId,
-            new DateRange(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 2)),
+            new DateRange(LocalDate.of(2024, JANUARY, 1), LocalDate.of(2024, JANUARY, 2)),
             duration,
             UV_INTERNAL,
             Instant.now()

--- a/src/test/java/org/synyx/urlaubsverwaltung/companyvacation/CompanyVacationServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/companyvacation/CompanyVacationServiceImplTest.java
@@ -18,6 +18,7 @@ import org.synyx.urlaubsverwaltung.settings.WorkingDurationForNewYearsEveUpdated
 import java.time.Clock;
 import java.time.LocalDate;
 
+import static java.time.Month.DECEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -60,8 +61,8 @@ class CompanyVacationServiceImplTest {
         assertThat(publishedEvent.dayLength()).isEqualTo(DayLength.NOON);
 
         final int currentYear = LocalDate.now().getYear();
-        assertThat(publishedEvent.startDate()).isEqualTo(LocalDate.of(currentYear, 12, 24));
-        assertThat(publishedEvent.endDate()).isEqualTo(LocalDate.of(currentYear, 12, 24));
+        assertThat(publishedEvent.startDate()).isEqualTo(LocalDate.of(currentYear, DECEMBER, 24));
+        assertThat(publishedEvent.endDate()).isEqualTo(LocalDate.of(currentYear, DECEMBER, 24));
         assertThat(publishedEvent.sourceId()).isEqualTo("settings-christmas-eve");
     }
 
@@ -95,8 +96,8 @@ class CompanyVacationServiceImplTest {
         assertThat(publishedEvent.dayLength()).isEqualTo(DayLength.MORNING);
 
         final int currentYear = LocalDate.now().getYear();
-        assertThat(publishedEvent.startDate()).isEqualTo(LocalDate.of(currentYear, 12, 31));
-        assertThat(publishedEvent.endDate()).isEqualTo(LocalDate.of(currentYear, 12, 31));
+        assertThat(publishedEvent.startDate()).isEqualTo(LocalDate.of(currentYear, DECEMBER, 31));
+        assertThat(publishedEvent.endDate()).isEqualTo(LocalDate.of(currentYear, DECEMBER, 31));
         assertThat(publishedEvent.sourceId()).isEqualTo("settings-new-years-eve");
     }
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/csv/CsvExportServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/csv/CsvExportServiceTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Locale;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.Month.OCTOBER;
 import static java.util.Locale.JAPANESE;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,7 +31,7 @@ class CsvExportServiceTest {
 
     @Test
     void ensureBomIsUsedAsDefault() {
-        final FilterPeriod period = new FilterPeriod(LocalDate.of(2022, 10, 2), LocalDate.of(2022, 10, 3));
+        final FilterPeriod period = new FilterPeriod(LocalDate.of(2022, OCTOBER, 2), LocalDate.of(2022, OCTOBER, 3));
         final ByteArrayResource aLotOfData = sut.resource(period, JAPANESE, List.of());
         assertThat(aLotOfData.getByteArray()).startsWith((byte) 239, (byte) 187, (byte) 191);
     }
@@ -59,7 +60,7 @@ class CsvExportServiceTest {
             }
         };
 
-        final FilterPeriod period = new FilterPeriod(LocalDate.of(2022, 10, 2), LocalDate.of(2022, 10, 3));
+        final FilterPeriod period = new FilterPeriod(LocalDate.of(2022, OCTOBER, 2), LocalDate.of(2022, OCTOBER, 3));
         final ByteArrayResource aLotOfData = sut.resource(period, JAPANESE, List.of("A lot of data", "Next data"));
         assertThat(new String(aLotOfData.getByteArray(), UTF_8)).contains("A lot of data;Next data");
     }
@@ -80,7 +81,7 @@ class CsvExportServiceTest {
             }
         };
 
-        final FilterPeriod period = new FilterPeriod(LocalDate.of(2022, 10, 2), LocalDate.of(2022, 10, 3));
+        final FilterPeriod period = new FilterPeriod(LocalDate.of(2022, OCTOBER, 2), LocalDate.of(2022, OCTOBER, 3));
         final ByteArrayResource aLotOfData = sut.resource(period, JAPANESE, List.of("A lot of data"));
         assertThat(new String(aLotOfData.getByteArray(), UTF_8)).contains("A lot of data");
     }

--- a/src/test/java/org/synyx/urlaubsverwaltung/extension/backup/model/AccountDTOTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/extension/backup/model/AccountDTOTest.java
@@ -7,6 +7,9 @@ import org.synyx.urlaubsverwaltung.person.Person;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
+import static java.time.Month.NOVEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AccountDTOTest {
@@ -14,13 +17,13 @@ class AccountDTOTest {
     @Test
     void happyPath() {
         final AccountDTO accountDTO = new AccountDTO(
-            LocalDate.of(2023, 1, 1),
-            LocalDate.of(2023, 12, 31),
+            LocalDate.of(2023, JANUARY, 1),
+            LocalDate.of(2023, DECEMBER, 31),
             true,
             false,
-            LocalDate.of(2023, 12, 31),
+            LocalDate.of(2023, DECEMBER, 31),
             null,
-            LocalDate.of(2023, 11, 1),
+            LocalDate.of(2023, NOVEMBER, 1),
             BigDecimal.valueOf(30),
             BigDecimal.valueOf(25),
             BigDecimal.valueOf(5),

--- a/src/test/java/org/synyx/urlaubsverwaltung/extension/backup/model/ApplicationDTOTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/extension/backup/model/ApplicationDTOTest.java
@@ -13,13 +13,14 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
+import static java.time.Month.JANUARY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ApplicationDTOTest {
 
     @Test
     void happyPath() {
-        ApplicationDTO applicationDTO = new ApplicationDTO(1L, "personExternalId", "applierExternalId", "bossExternalId", "cancellerExternalId", true, LocalDate.of(2023, 1, 1), LocalDate.of(2023, 1, 10), LocalTime.of(9, 0), LocalTime.of(17, 0), 1L, DayLengthDTO.FULL, "Vacation", List.of(), "Address", LocalDate.of(2023, 1, 1), null, null, null, ApplicationStatusDTO.ALLOWED, true, Duration.ofHours(8), null, null, List.of());
+        ApplicationDTO applicationDTO = new ApplicationDTO(1L, "personExternalId", "applierExternalId", "bossExternalId", "cancellerExternalId", true, LocalDate.of(2023, JANUARY, 1), LocalDate.of(2023, JANUARY, 10), LocalTime.of(9, 0), LocalTime.of(17, 0), 1L, DayLengthDTO.FULL, "Vacation", List.of(), "Address", LocalDate.of(2023, JANUARY, 1), null, null, null, ApplicationStatusDTO.ALLOWED, true, Duration.ofHours(8), null, null, List.of());
         VacationTypeEntity vacationType = new VacationTypeEntity();
         Person person = new Person();
         Person applier = new Person();

--- a/src/test/java/org/synyx/urlaubsverwaltung/extension/backup/model/WorkingTimeDTOTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/extension/backup/model/WorkingTimeDTOTest.java
@@ -6,13 +6,14 @@ import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeEntity;
 
 import java.time.LocalDate;
 
+import static java.time.Month.JANUARY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class WorkingTimeDTOTest {
 
     @Test
     void happyPathWithDefaultFederalState() {
-        final WorkingTimeDTO dto = new WorkingTimeDTO(DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.ZERO, DayLengthDTO.ZERO, LocalDate.of(2023, 1, 1), FederalStateDTO.GERMANY_BADEN_WUERTTEMBERG, true);
+        final WorkingTimeDTO dto = new WorkingTimeDTO(DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.ZERO, DayLengthDTO.ZERO, LocalDate.of(2023, JANUARY, 1), FederalStateDTO.GERMANY_BADEN_WUERTTEMBERG, true);
         final Person person = new Person();
 
         final WorkingTimeEntity entity = dto.toWorkingTimeEntity(person);
@@ -31,7 +32,7 @@ class WorkingTimeDTOTest {
 
     @Test
     void happyPathWithoutDefaultFederalState() {
-        final WorkingTimeDTO dto = new WorkingTimeDTO(DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.ZERO, DayLengthDTO.ZERO, LocalDate.of(2023, 1, 1), FederalStateDTO.GERMANY_BADEN_WUERTTEMBERG, false);
+        final WorkingTimeDTO dto = new WorkingTimeDTO(DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.FULL, DayLengthDTO.ZERO, DayLengthDTO.ZERO, LocalDate.of(2023, JANUARY, 1), FederalStateDTO.GERMANY_BADEN_WUERTTEMBERG, false);
         final Person person = new Person();
 
         final WorkingTimeEntity entity = dto.toWorkingTimeEntity(person);

--- a/src/test/java/org/synyx/urlaubsverwaltung/extension/companyvacation/CompanyVacationEventHandlerExtensionTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/extension/companyvacation/CompanyVacationEventHandlerExtensionTest.java
@@ -23,6 +23,7 @@ import java.time.LocalDate;
 import java.util.UUID;
 import java.util.stream.Stream;
 
+import static java.time.Month.DECEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
@@ -72,8 +73,8 @@ class CompanyVacationEventHandlerExtensionTest {
             id1,
             createdAt1,
             org.synyx.urlaubsverwaltung.period.DayLength.NOON,
-            LocalDate.of(year, 12, 24),
-            LocalDate.of(year, 12, 24)
+            LocalDate.of(year, DECEMBER, 24),
+            LocalDate.of(year, DECEMBER, 24)
         );
 
         final UUID id2 = UUID.randomUUID();
@@ -83,13 +84,13 @@ class CompanyVacationEventHandlerExtensionTest {
             id2,
             createdAt2,
             org.synyx.urlaubsverwaltung.period.DayLength.MORNING,
-            LocalDate.of(year, 12, 31),
-            LocalDate.of(year, 12, 31)
+            LocalDate.of(year, DECEMBER, 31),
+            LocalDate.of(year, DECEMBER, 31)
         );
 
         return Stream.of(
-            Arguments.of(christmasEvent, DayLength.NOON, LocalDate.of(year, 12, 24), "settings-christmas-eve"),
-            Arguments.of(newYearsEvent, DayLength.MORNING, LocalDate.of(year, 12, 31), "settings-new-years-eve")
+            Arguments.of(christmasEvent, DayLength.NOON, LocalDate.of(year, DECEMBER, 24), "settings-christmas-eve"),
+            Arguments.of(newYearsEvent, DayLength.MORNING, LocalDate.of(year, DECEMBER, 31), "settings-new-years-eve")
         );
     }
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/extension/overtime/OvertimeEventHandlerExtensionTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/extension/overtime/OvertimeEventHandlerExtensionTest.java
@@ -23,6 +23,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 
+import static java.time.Month.MARCH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -48,8 +49,8 @@ class OvertimeEventHandlerExtensionTest {
         @Test
         void ensureEventIsConvertedToDTO() {
 
-            final LocalDate startDate = LocalDate.of(2025, 3, 1);
-            final LocalDate endDate = LocalDate.of(2025, 3, 1);
+            final LocalDate startDate = LocalDate.of(2025, MARCH, 1);
+            final LocalDate endDate = LocalDate.of(2025, MARCH, 1);
             final Duration duration = Duration.ofHours(2);
 
             final OvertimeCreatedEvent event = OvertimeCreatedEvent.of(42L, "muster", startDate, endDate, duration);
@@ -84,8 +85,8 @@ class OvertimeEventHandlerExtensionTest {
         @Test
         void ensureEventIsConvertedToDTO() {
 
-            final LocalDate startDate = LocalDate.of(2025, 3, 1);
-            final LocalDate endDate = LocalDate.of(2025, 3, 5);
+            final LocalDate startDate = LocalDate.of(2025, MARCH, 1);
+            final LocalDate endDate = LocalDate.of(2025, MARCH, 5);
             final Duration duration = Duration.ofHours(8);
 
             final OvertimeUpdatedEvent event = OvertimeUpdatedEvent.of(99L, "muster", startDate, endDate, duration);

--- a/src/test/java/org/synyx/urlaubsverwaltung/extension/workingtime/WorkingTimeEventHandlerExtensionTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/extension/workingtime/WorkingTimeEventHandlerExtensionTest.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 
+import static java.time.Month.JANUARY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -38,7 +39,7 @@ class WorkingTimeEventHandlerExtensionTest {
     @Test
     void ensureWorkingTimeConfiguredEventIsConvertedToDTO() {
 
-        final LocalDate validFrom = LocalDate.of(2025, 1, 1);
+        final LocalDate validFrom = LocalDate.of(2025, JANUARY, 1);
         final List<Integer> workingDays = List.of(1, 2, 3, 4, 5);
 
         final WorkingTimeConfiguredEvent event = WorkingTimeConfiguredEvent.of("muster", validFrom, workingDays, "GERMANY_BADEN_WUERTTEMBERG");
@@ -65,7 +66,7 @@ class WorkingTimeEventHandlerExtensionTest {
     @Test
     void ensureWorkingTimeConfiguredEventWithNullFederalStateIsConvertedToDTO() {
 
-        final LocalDate validFrom = LocalDate.of(2025, 1, 1);
+        final LocalDate validFrom = LocalDate.of(2025, JANUARY, 1);
         final List<Integer> workingDays = List.of(1, 2, 3, 4, 5);
 
         final WorkingTimeConfiguredEvent event = WorkingTimeConfiguredEvent.of("muster", validFrom, workingDays, null);

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeMailServiceIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeMailServiceIT.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.util.List;
 
+import static java.time.Month.APRIL;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.synyx.urlaubsverwaltung.overtime.OvertimeCommentAction.CREATED;
@@ -49,8 +50,8 @@ class OvertimeMailServiceIT extends SingleTenantTestContainersBase {
         final Person person = new Person("user", "Müller", "Lieschen", "lieschen12@example.org");
         person.setId(1L);
 
-        final LocalDate startDate = LocalDate.of(2020, 4, 16);
-        final LocalDate endDate = LocalDate.of(2020, 4, 23);
+        final LocalDate startDate = LocalDate.of(2020, APRIL, 16);
+        final LocalDate endDate = LocalDate.of(2020, APRIL, 23);
         final OvertimeEntity overtime = new OvertimeEntity(person, startDate, endDate, Duration.parse("P1DT30H72M"));
         overtime.setId(1L);
 
@@ -96,8 +97,8 @@ class OvertimeMailServiceIT extends SingleTenantTestContainersBase {
 
         final Person author = personService.create("office", "Marlene", "Muster", "office@example.org", List.of(), List.of(USER, OFFICE));
 
-        final LocalDate startDate = LocalDate.of(2020, 4, 16);
-        final LocalDate endDate = LocalDate.of(2020, 4, 23);
+        final LocalDate startDate = LocalDate.of(2020, APRIL, 16);
+        final LocalDate endDate = LocalDate.of(2020, APRIL, 23);
         final OvertimeEntity overtime = new OvertimeEntity(person, startDate, endDate, Duration.parse("P1DT30H72M"));
         overtime.setId(1L);
 
@@ -137,8 +138,8 @@ class OvertimeMailServiceIT extends SingleTenantTestContainersBase {
 
         final Person author = personService.create("user", "Lieschen", "Müller", "lieschen@example.org", List.of(NOTIFICATION_EMAIL_OVERTIME_APPLIED), List.of(USER));
 
-        final LocalDate startDate = LocalDate.of(2020, 4, 16);
-        final LocalDate endDate = LocalDate.of(2020, 4, 23);
+        final LocalDate startDate = LocalDate.of(2020, APRIL, 16);
+        final LocalDate endDate = LocalDate.of(2020, APRIL, 23);
         final OvertimeEntity overtime = new OvertimeEntity(author, startDate, endDate, Duration.parse("P1DT30H72M"));
         overtime.setId(1L);
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeRepositoryIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeRepositoryIT.java
@@ -14,6 +14,11 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.time.LocalDate.of;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.FEBRUARY;
+import static java.time.Month.JANUARY;
+import static java.time.Month.MARCH;
+import static java.time.Month.OCTOBER;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -75,24 +80,24 @@ class OvertimeRepositoryIT extends SingleTenantTestContainersBase {
         final Person person = personService.create("muster", "Marlene", "Muster", "muster@example.org");
 
         // records starting before 2016
-        sut.save(new OvertimeEntity(person, of(2012, 1, 1), of(2012, 1, 3), Duration.ofHours(1)));
-        sut.save(new OvertimeEntity(person, of(2014, 12, 30), of(2015, 1, 3), Duration.ofHours(2)));
-        sut.save(new OvertimeEntity(person, of(2015, 10, 5), of(2015, 10, 20), Duration.ofHours(3)));
-        sut.save(new OvertimeEntity(person, of(2015, 12, 28), of(2016, 1, 6), Duration.ofHours(4)));
+        sut.save(new OvertimeEntity(person, of(2012, JANUARY, 1), of(2012, JANUARY, 3), Duration.ofHours(1)));
+        sut.save(new OvertimeEntity(person, of(2014, DECEMBER, 30), of(2015, JANUARY, 3), Duration.ofHours(2)));
+        sut.save(new OvertimeEntity(person, of(2015, OCTOBER, 5), of(2015, OCTOBER, 20), Duration.ofHours(3)));
+        sut.save(new OvertimeEntity(person, of(2015, DECEMBER, 28), of(2016, JANUARY, 6), Duration.ofHours(4)));
 
         // record after or in 2016
-        sut.save(new OvertimeEntity(person, of(2016, 12, 5), of(2016, 12, 31), Duration.ofHours(99)));
-        sut.save(new OvertimeEntity(person, of(2016, 1, 1), of(2016, 1, 1), Duration.ofHours(99)));
+        sut.save(new OvertimeEntity(person, of(2016, DECEMBER, 5), of(2016, DECEMBER, 31), Duration.ofHours(99)));
+        sut.save(new OvertimeEntity(person, of(2016, JANUARY, 1), of(2016, JANUARY, 1), Duration.ofHours(99)));
 
-        final List<OvertimeEntity> overtimes = sut.findByPersonAndStartDateIsBefore(person, of(2016, 1, 1));
+        final List<OvertimeEntity> overtimes = sut.findByPersonAndStartDateIsBefore(person, of(2016, JANUARY, 1));
         assertThat(overtimes).hasSize(4);
-        assertThat(overtimes.getFirst().getStartDate()).isEqualTo(of(2012, 1, 1));
+        assertThat(overtimes.getFirst().getStartDate()).isEqualTo(of(2012, JANUARY, 1));
         assertThat(overtimes.getFirst().getDuration()).isEqualTo(Duration.ofHours(1));
-        assertThat(overtimes.get(1).getStartDate()).isEqualTo(of(2014, 12, 30));
+        assertThat(overtimes.get(1).getStartDate()).isEqualTo(of(2014, DECEMBER, 30));
         assertThat(overtimes.get(1).getDuration()).isEqualTo(Duration.ofHours(2));
-        assertThat(overtimes.get(2).getStartDate()).isEqualTo(of(2015, 10, 5));
+        assertThat(overtimes.get(2).getStartDate()).isEqualTo(of(2015, OCTOBER, 5));
         assertThat(overtimes.get(2).getDuration()).isEqualTo(Duration.ofHours(3));
-        assertThat(overtimes.get(3).getStartDate()).isEqualTo(of(2015, 12, 28));
+        assertThat(overtimes.get(3).getStartDate()).isEqualTo(of(2015, DECEMBER, 28));
         assertThat(overtimes.get(3).getDuration()).isEqualTo(Duration.ofHours(4));
     }
 
@@ -104,8 +109,8 @@ class OvertimeRepositoryIT extends SingleTenantTestContainersBase {
         final Person person3 = personService.create("john", "john", "doe", "john@example.org");
 
         final List<Person> persons = List.of(person, person2);
-        final LocalDate start = LocalDate.of(2022, 2, 1);
-        final LocalDate end = LocalDate.of(2022, 3, 1);
+        final LocalDate start = LocalDate.of(2022, FEBRUARY, 1);
+        final LocalDate end = LocalDate.of(2022, MARCH, 1);
 
         // should be found
         sut.save(new OvertimeEntity(person, start.minusDays(1), start.plusDays(1), Duration.ofHours(1)));
@@ -136,7 +141,7 @@ class OvertimeRepositoryIT extends SingleTenantTestContainersBase {
         final Person person = personService.create("muster", "Marlene", "Muster", "muster@example.org");
         final Person person2 = personService.create("retsum", "Enelram", "Retsum", "retsum@example.org");
 
-        final LocalDate date = LocalDate.of(2022, 2, 1);
+        final LocalDate date = LocalDate.of(2022, FEBRUARY, 1);
 
         // should be found
         sut.save(new OvertimeEntity(person, date, date, Duration.ofHours(1), true));

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeServiceImplTest.java
@@ -41,7 +41,10 @@ import java.util.Optional;
 import java.util.Set;
 
 import static java.time.Month.AUGUST;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.FEBRUARY;
 import static java.time.Month.JANUARY;
+import static java.time.Month.JUNE;
 import static java.time.ZoneOffset.UTC;
 import static java.time.temporal.TemporalAdjusters.firstDayOfMonth;
 import static java.time.temporal.TemporalAdjusters.firstDayOfYear;
@@ -712,8 +715,8 @@ class OvertimeServiceImplTest {
     void ensureReturnsZeroIfPersonHasNoOvertimeRecordsYetForTheGivenYear() {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        final LocalDate firstDayOfYear = LocalDate.of(2016, 1, 1);
-        final LocalDate lastDayOfYear = LocalDate.of(2016, 12, 31);
+        final LocalDate firstDayOfYear = LocalDate.of(2016, JANUARY, 1);
+        final LocalDate lastDayOfYear = LocalDate.of(2016, DECEMBER, 31);
         when(overtimeRepository.findByPersonAndEndDateIsGreaterThanEqualAndStartDateIsLessThanEqual(person, firstDayOfYear, lastDayOfYear)).thenReturn(List.of());
 
         final Duration totalHours = sut.getTotalOvertimeForPersonAndYear(person, 2016);
@@ -726,14 +729,14 @@ class OvertimeServiceImplTest {
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         person.setId(1L);
 
-        final OvertimeEntity overtimeRecord = new OvertimeEntity(person, LocalDate.of(2016, 1, 5), LocalDate.of(2016, 1, 5), Duration.ofHours(1));
+        final OvertimeEntity overtimeRecord = new OvertimeEntity(person, LocalDate.of(2016, JANUARY, 5), LocalDate.of(2016, JANUARY, 5), Duration.ofHours(1));
         overtimeRecord.setId(1L);
 
-        final OvertimeEntity otherOvertimeRecord = new OvertimeEntity(person, LocalDate.of(2016, 2, 5), LocalDate.of(2016, 2, 5), Duration.ofHours(10));
+        final OvertimeEntity otherOvertimeRecord = new OvertimeEntity(person, LocalDate.of(2016, FEBRUARY, 5), LocalDate.of(2016, FEBRUARY, 5), Duration.ofHours(10));
         otherOvertimeRecord.setId(2L);
 
-        final LocalDate firstDayOfYear = LocalDate.of(2016, 1, 1);
-        final LocalDate lastDayOfYear = LocalDate.of(2016, 12, 31);
+        final LocalDate firstDayOfYear = LocalDate.of(2016, JANUARY, 1);
+        final LocalDate lastDayOfYear = LocalDate.of(2016, DECEMBER, 31);
         when(overtimeRepository.findByPersonAndEndDateIsGreaterThanEqualAndStartDateIsLessThanEqual(person, firstDayOfYear, lastDayOfYear))
             .thenReturn(List.of(overtimeRecord, otherOvertimeRecord));
 
@@ -747,13 +750,13 @@ class OvertimeServiceImplTest {
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         person.setId(1L);
 
-        final OvertimeEntity overtime = new OvertimeEntity(person, LocalDate.of(2016, 1, 5), LocalDate.of(2016, 1, 5), Duration.ofHours(10));
+        final OvertimeEntity overtime = new OvertimeEntity(person, LocalDate.of(2016, JANUARY, 5), LocalDate.of(2016, JANUARY, 5), Duration.ofHours(10));
         overtime.setId(1L);
 
-        final OvertimeEntity overtime2 = new OvertimeEntity(person, LocalDate.of(2016, 2, 5), LocalDate.of(2016, 2, 5), Duration.ofHours(4));
+        final OvertimeEntity overtime2 = new OvertimeEntity(person, LocalDate.of(2016, FEBRUARY, 5), LocalDate.of(2016, FEBRUARY, 5), Duration.ofHours(4));
         overtime2.setId(2L);
 
-        final LocalDate firstDayOfYear = LocalDate.of(2017, 1, 1);
+        final LocalDate firstDayOfYear = LocalDate.of(2017, JANUARY, 1);
         final LocalDate lastDayOfBeforeYear = firstDayOfYear.minusYears(1).with(lastDayOfYear());
         when(overtimeRepository.findByPersonAndStartDateIsBefore(person, firstDayOfYear)).thenReturn(List.of(overtime, overtime2));
         when(applicationService.getTotalOvertimeReductionOfPersonUntil(person, lastDayOfBeforeYear)).thenReturn(Duration.ofHours(1));
@@ -1501,8 +1504,8 @@ class OvertimeServiceImplTest {
         @Test
         void ensureReturnsOvertimeClippedToDateRangeGroupedByPersonAndSortedByStartDate() {
 
-            final LocalDate from = LocalDate.of(2024, 6, 10);
-            final LocalDate to = LocalDate.of(2024, 6, 20);
+            final LocalDate from = LocalDate.of(2024, JUNE, 10);
+            final LocalDate to = LocalDate.of(2024, JUNE, 20);
 
             final PersonId personId = new PersonId(1L);
             final Person person = new Person();
@@ -1533,8 +1536,8 @@ class OvertimeServiceImplTest {
         @Test
         void ensureFiltersOutExternalOvertimeWithZeroDuration() {
 
-            final LocalDate from = LocalDate.of(2024, 6, 10);
-            final LocalDate to = LocalDate.of(2024, 6, 20);
+            final LocalDate from = LocalDate.of(2024, JUNE, 10);
+            final LocalDate to = LocalDate.of(2024, JUNE, 20);
 
             final PersonId personId = new PersonId(1L);
             final Person person = new Person();
@@ -1561,8 +1564,8 @@ class OvertimeServiceImplTest {
         @Test
         void ensureReturnsEmptyListForEveryRequestedPersonWithoutThrowingWhenPersonOrOvertimeIsMissing() {
 
-            final LocalDate from = LocalDate.of(2024, 6, 10);
-            final LocalDate to = LocalDate.of(2024, 6, 20);
+            final LocalDate from = LocalDate.of(2024, JUNE, 10);
+            final LocalDate to = LocalDate.of(2024, JUNE, 20);
 
             final PersonId personIdWithoutOvertime = new PersonId(1L);
             final Person personWithoutOvertime = new Person();

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeTest.java
@@ -9,6 +9,8 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Map;
 
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
@@ -20,7 +22,7 @@ class OvertimeTest {
         final Overtime overtime = new Overtime(
             new OvertimeId(1L),
             new PersonId(1L),
-            new DateRange(LocalDate.of(2022, 12, 30), LocalDate.of(2023, 1, 2)),
+            new DateRange(LocalDate.of(2022, DECEMBER, 30), LocalDate.of(2023, JANUARY, 2)),
             Duration.ofHours(20),
             OvertimeType.UV_INTERNAL,
             Instant.now()
@@ -39,7 +41,7 @@ class OvertimeTest {
         final Overtime overtime = new Overtime(
             new OvertimeId(1L),
             new PersonId(1L),
-            new DateRange(LocalDate.of(2022, 12, 30), LocalDate.of(2023, 1, 2)),
+            new DateRange(LocalDate.of(2022, DECEMBER, 30), LocalDate.of(2023, JANUARY, 2)),
             Duration.ofHours(20),
             OvertimeType.UV_INTERNAL,
             Instant.now()

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimeViewControllerTest.java
@@ -48,6 +48,11 @@ import java.util.Set;
 
 import static java.time.Duration.ofHours;
 import static java.time.Duration.ofMinutes;
+import static java.time.Month.APRIL;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.FEBRUARY;
+import static java.time.Month.JULY;
+import static java.time.Month.MARCH;
 import static java.time.temporal.TemporalAdjusters.lastDayOfYear;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -285,7 +290,7 @@ class OvertimeViewControllerTest {
         final Overtime overtime = new Overtime(
             new OvertimeId(1L),
             person.getIdAsPersonId(),
-            new DateRange(LocalDate.of(2019, 7, 2), LocalDate.of(2019, 7, 2)),
+            new DateRange(LocalDate.of(2019, JULY, 2), LocalDate.of(2019, JULY, 2)),
             ofHours(10),
             OvertimeType.UV_INTERNAL,
             Instant.now(clock)
@@ -494,7 +499,7 @@ class OvertimeViewControllerTest {
         final Overtime overtime = new Overtime(
             new OvertimeId(1L),
             person.getIdAsPersonId(),
-            new DateRange( LocalDate.of(2012, 2, 5), LocalDate.of(2012, 2, 5)),
+            new DateRange( LocalDate.of(2012, FEBRUARY, 5), LocalDate.of(2012, FEBRUARY, 5)),
             ofHours(10),
             OvertimeType.UV_INTERNAL,
             Instant.now(clock)
@@ -554,12 +559,12 @@ class OvertimeViewControllerTest {
         overtimePerson.setEmail("person@example.org");
 
         final OvertimeId overtimeId = new OvertimeId(2L);
-        final LocalDate overtimeEndDate = LocalDate.of(2016, 2, 5);
+        final LocalDate overtimeEndDate = LocalDate.of(2016, FEBRUARY, 5);
 
         final Overtime overtime = new Overtime(
            overtimeId,
             overtimePerson.getIdAsPersonId(),
-            new DateRange(LocalDate.of(2016, 2, 5), overtimeEndDate),
+            new DateRange(LocalDate.of(2016, FEBRUARY, 5), overtimeEndDate),
             ofHours(10),
             OvertimeType.UV_INTERNAL,
             Instant.now(clock)
@@ -615,7 +620,7 @@ class OvertimeViewControllerTest {
         final Overtime overtime = new Overtime(
             overtimeId,
             overtimePerson.getIdAsPersonId(),
-            new DateRange(LocalDate.of(2016, 2, 5), LocalDate.of(2016, 2, 5)),
+            new DateRange(LocalDate.of(2016, FEBRUARY, 5), LocalDate.of(2016, FEBRUARY, 5)),
             ofHours(10),
             OvertimeType.UV_INTERNAL,
             Instant.now(clock)
@@ -762,11 +767,11 @@ class OvertimeViewControllerTest {
         overtimePerson.setId(1L);
 
         final OvertimeId overtimeId = new OvertimeId(2L);
-        final LocalDate overtimeEndDate = LocalDate.of(2016, 2, 5);
+        final LocalDate overtimeEndDate = LocalDate.of(2016, FEBRUARY, 5);
         final Overtime overtime = new Overtime(
             new OvertimeId(1L),
             overtimePerson.getIdAsPersonId(),
-            new DateRange(LocalDate.of(2016, 2, 5), overtimeEndDate),
+            new DateRange(LocalDate.of(2016, FEBRUARY, 5), overtimeEndDate),
             ofHours(10),
             OvertimeType.UV_INTERNAL,
             Instant.now(clock)
@@ -797,11 +802,11 @@ class OvertimeViewControllerTest {
         overtimePerson.setPermissions(List.of(USER));
 
         final OvertimeId overtimeId = new OvertimeId(2L);
-        final LocalDate overtimeEndDate = LocalDate.of(2016, 2, 5);
+        final LocalDate overtimeEndDate = LocalDate.of(2016, FEBRUARY, 5);
         final Overtime overtime = new Overtime(
             new OvertimeId(1L),
             overtimePerson.getIdAsPersonId(),
-            new DateRange( LocalDate.of(2016, 2, 5), overtimeEndDate),
+            new DateRange( LocalDate.of(2016, FEBRUARY, 5), overtimeEndDate),
             ofHours(10),
             OvertimeType.UV_INTERNAL,
             Instant.now(clock)
@@ -826,11 +831,11 @@ class OvertimeViewControllerTest {
         overtimePerson.setId(5L);
 
         final OvertimeId overtimeId = new OvertimeId(2L);
-        final LocalDate overtimeEndDate = LocalDate.of(2016, 2, 5);
+        final LocalDate overtimeEndDate = LocalDate.of(2016, FEBRUARY, 5);
         final Overtime overtime = new Overtime(
             new OvertimeId(1L),
             overtimePerson.getIdAsPersonId(),
-            new DateRange(LocalDate.of(2016, 2, 5), overtimeEndDate),
+            new DateRange(LocalDate.of(2016, FEBRUARY, 5), overtimeEndDate),
             ofHours(10),
             OvertimeType.UV_INTERNAL,
             Instant.now(clock)
@@ -855,11 +860,11 @@ class OvertimeViewControllerTest {
         overtimePerson.setId(2L);
 
         final OvertimeId overtimeId = new OvertimeId(2L);
-        final LocalDate overtimeEndDate = LocalDate.of(2016, 2, 5);
+        final LocalDate overtimeEndDate = LocalDate.of(2016, FEBRUARY, 5);
         final Overtime overtime = new Overtime(
             new OvertimeId(1L),
             overtimePerson.getIdAsPersonId(),
-            new DateRange(LocalDate.of(2016, 2, 5), overtimeEndDate),
+            new DateRange(LocalDate.of(2016, FEBRUARY, 5), overtimeEndDate),
             ofHours(10),
             OvertimeType.UV_INTERNAL,
             Instant.now(clock)
@@ -903,8 +908,8 @@ class OvertimeViewControllerTest {
 
         when(personService.getSignedInUser()).thenReturn(overtimePerson);
 
-        final LocalDate startDate = LocalDate.of(2019, 7, 2);
-        final LocalDate endDate = LocalDate.of(2019, 7, 2);
+        final LocalDate startDate = LocalDate.of(2019, JULY, 2);
+        final LocalDate endDate = LocalDate.of(2019, JULY, 2);
         final DateRange dateRange = new DateRange(startDate, endDate);
         final Duration duration = ofHours(8);
 
@@ -947,7 +952,7 @@ class OvertimeViewControllerTest {
         final Overtime overtime = new Overtime(
             new OvertimeId(2L),
             overtimePerson.getIdAsPersonId(),
-            new DateRange(LocalDate.of(2022, 3, 1), LocalDate.of(2022, 4, 28)),
+            new DateRange(LocalDate.of(2022, MARCH, 1), LocalDate.of(2022, APRIL, 28)),
             ofHours(10),
             OvertimeType.UV_INTERNAL,
             Instant.now(clock)
@@ -1035,7 +1040,7 @@ class OvertimeViewControllerTest {
         final Overtime overtime = new Overtime(
             new OvertimeId(2L),
             overtimePerson.getIdAsPersonId(),
-            new DateRange(LocalDate.of(2020, 12, 18), LocalDate.of(2020, 12, 18)),
+            new DateRange(LocalDate.of(2020, DECEMBER, 18), LocalDate.of(2020, DECEMBER, 18)),
             ofHours(-10),
             OvertimeType.UV_INTERNAL,
             Instant.now(clock)
@@ -1067,7 +1072,7 @@ class OvertimeViewControllerTest {
         final Overtime overtime = new Overtime(
             new OvertimeId(2L),
             overtimePerson.getIdAsPersonId(),
-            new DateRange(LocalDate.of(2020, 12, 18), LocalDate.of(2020, 12, 18)),
+            new DateRange(LocalDate.of(2020, DECEMBER, 18), LocalDate.of(2020, DECEMBER, 18)),
             ofMinutes(-30),
             OvertimeType.UV_INTERNAL,
             Instant.now(clock)
@@ -1122,7 +1127,7 @@ class OvertimeViewControllerTest {
         final Overtime overtime = new Overtime(
             new OvertimeId(2L),
             overtimePerson.getIdAsPersonId(),
-            new DateRange(LocalDate.of(2019, 7, 2), LocalDate.of(2019, 7, 2)),
+            new DateRange(LocalDate.of(2019, JULY, 2), LocalDate.of(2019, JULY, 2)),
             ofHours(10),
             OvertimeType.UV_INTERNAL,
             Instant.now(clock)
@@ -1156,8 +1161,8 @@ class OvertimeViewControllerTest {
         final Person overtimePerson = new Person();
         overtimePerson.setId(overtimePersonId.value());
 
-        final LocalDate startDate = LocalDate.of(2022, 3, 1);
-        final LocalDate endDate = LocalDate.of(2022, 4, 28);
+        final LocalDate startDate = LocalDate.of(2022, MARCH, 1);
+        final LocalDate endDate = LocalDate.of(2022, APRIL, 28);
         final Overtime overtime = new Overtime(
             new OvertimeId(2L),
             overtimePerson.getIdAsPersonId(),
@@ -1202,7 +1207,7 @@ class OvertimeViewControllerTest {
         final Overtime overtime = new Overtime(
             new OvertimeId(2L),
             person.getIdAsPersonId(),
-            new DateRange(LocalDate.of(2019, 7, 2), LocalDate.of(2019, 7, 2)),
+            new DateRange(LocalDate.of(2019, JULY, 2), LocalDate.of(2019, JULY, 2)),
             ofHours(8),
             OvertimeType.UV_INTERNAL,
             Instant.now(clock)
@@ -1230,7 +1235,7 @@ class OvertimeViewControllerTest {
         final Overtime overtime = new Overtime(
             new OvertimeId(2L),
             person.getIdAsPersonId(),
-            new DateRange(LocalDate.of(2021, 7, 2), LocalDate.of(2021, 7, 2)),
+            new DateRange(LocalDate.of(2021, JULY, 2), LocalDate.of(2021, JULY, 2)),
             ofHours(8),
             OvertimeType.UV_INTERNAL,
             Instant.now(clock)
@@ -1274,7 +1279,7 @@ class OvertimeViewControllerTest {
         final Overtime overtime = new Overtime(
             new OvertimeId(2L),
             overtimePerson.getIdAsPersonId(),
-            new DateRange(LocalDate.of(2021, 7, 2), LocalDate.of(2021, 7, 2)),
+            new DateRange(LocalDate.of(2021, JULY, 2), LocalDate.of(2021, JULY, 2)),
             ofHours(10),
             OvertimeType.UV_INTERNAL,
             Instant.now(clock)
@@ -1308,7 +1313,7 @@ class OvertimeViewControllerTest {
         final Overtime overtime = new Overtime(
             new OvertimeId(2L),
             overtimePerson.getIdAsPersonId(),
-            new DateRange(LocalDate.of(2021, 7, 2), LocalDate.of(2021, 7, 2)),
+            new DateRange(LocalDate.of(2021, JULY, 2), LocalDate.of(2021, JULY, 2)),
             ofHours(10),
             OvertimeType.UV_INTERNAL,
             Instant.now(clock)
@@ -1342,7 +1347,7 @@ class OvertimeViewControllerTest {
         final Overtime overtime = new Overtime(
             new OvertimeId(2L),
             overtimePerson.getIdAsPersonId(),
-            new DateRange(LocalDate.of(2021, 7, 2), LocalDate.of(2021, 7, 2)),
+            new DateRange(LocalDate.of(2021, JULY, 2), LocalDate.of(2021, JULY, 2)),
             ofHours(10),
             OvertimeType.UV_INTERNAL,
             Instant.now(clock)
@@ -1386,7 +1391,7 @@ class OvertimeViewControllerTest {
         final Overtime overtime = new Overtime(
             new OvertimeId(2L),
             overtimePerson.getIdAsPersonId(),
-            new DateRange(LocalDate.of(2021, 7, 2), LocalDate.of(2021, 7, 2)),
+            new DateRange(LocalDate.of(2021, JULY, 2), LocalDate.of(2021, JULY, 2)),
             ofHours(10),
             OvertimeType.UV_INTERNAL,
             Instant.now(clock)
@@ -1429,7 +1434,7 @@ class OvertimeViewControllerTest {
         final Overtime overtime = new Overtime(
             new OvertimeId(2L),
             overtimePerson.getIdAsPersonId(),
-            new DateRange(LocalDate.of(2021, 7, 2), LocalDate.of(2021, 7, 2)),
+            new DateRange(LocalDate.of(2021, JULY, 2), LocalDate.of(2021, JULY, 2)),
             ofHours(10),
             OvertimeType.UV_INTERNAL,
             Instant.now(clock)
@@ -1459,7 +1464,7 @@ class OvertimeViewControllerTest {
         final Overtime overtime = new Overtime(
             new OvertimeId(2L),
             overtimePerson.getIdAsPersonId(),
-            new DateRange(LocalDate.of(2021, 7, 2), LocalDate.of(2021, 7, 2)),
+            new DateRange(LocalDate.of(2021, JULY, 2), LocalDate.of(2021, JULY, 2)),
             ofHours(10),
             OvertimeType.UV_INTERNAL,
             Instant.now(clock)

--- a/src/test/java/org/synyx/urlaubsverwaltung/overview/ApplicationDaysUsedSummaryDtoTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overview/ApplicationDaysUsedSummaryDtoTest.java
@@ -19,6 +19,10 @@ import java.util.List;
 
 import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.ZERO;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
+import static java.time.Month.MARCH;
+import static java.time.Month.OCTOBER;
 import static java.util.Collections.singletonList;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
@@ -50,8 +54,8 @@ class ApplicationDaysUsedSummaryDtoTest {
 
         final Application holidayAllowed = anyApplication();
         holidayAllowed.setVacationType(createVacationType(1L, HOLIDAY, new StaticMessageSource()));
-        holidayAllowed.setStartDate(LocalDate.of(2014, 3, 5));
-        holidayAllowed.setEndDate(LocalDate.of(2016, 12, 30));
+        holidayAllowed.setStartDate(LocalDate.of(2014, MARCH, 5));
+        holidayAllowed.setEndDate(LocalDate.of(2016, DECEMBER, 30));
         holidayAllowed.setStatus(ALLOWED);
 
         final BigDecimal workingDays = BigDecimal.valueOf(499);
@@ -70,62 +74,62 @@ class ApplicationDaysUsedSummaryDtoTest {
 
         final Application holiday = anyApplication();
         holiday.setVacationType(createVacationType(1L, HOLIDAY, new StaticMessageSource()));
-        holiday.setStartDate(LocalDate.of(2014, 10, 13));
-        holiday.setEndDate(LocalDate.of(2014, 10, 13));
+        holiday.setStartDate(LocalDate.of(2014, OCTOBER, 13));
+        holiday.setEndDate(LocalDate.of(2014, OCTOBER, 13));
         holiday.setStatus(WAITING);
 
         final Application holidayAllowed = anyApplication();
         holidayAllowed.setVacationType(createVacationType(1L, HOLIDAY, new StaticMessageSource()));
-        holidayAllowed.setStartDate(LocalDate.of(2014, 10, 14));
-        holidayAllowed.setEndDate(LocalDate.of(2014, 10, 14));
+        holidayAllowed.setStartDate(LocalDate.of(2014, OCTOBER, 14));
+        holidayAllowed.setEndDate(LocalDate.of(2014, OCTOBER, 14));
         holidayAllowed.setStatus(ALLOWED);
 
         final Application holidayAllowedRequestCancellation = anyApplication();
         holidayAllowedRequestCancellation.setVacationType(createVacationType(1L, HOLIDAY, new StaticMessageSource()));
-        holidayAllowedRequestCancellation.setStartDate(LocalDate.of(2014, 10, 14));
-        holidayAllowedRequestCancellation.setEndDate(LocalDate.of(2014, 10, 14));
+        holidayAllowedRequestCancellation.setStartDate(LocalDate.of(2014, OCTOBER, 14));
+        holidayAllowedRequestCancellation.setEndDate(LocalDate.of(2014, OCTOBER, 14));
         holidayAllowedRequestCancellation.setStatus(ALLOWED_CANCELLATION_REQUESTED);
 
         final Application specialLeave = anyApplication();
         specialLeave.setVacationType(createVacationType(1L, SPECIALLEAVE, new StaticMessageSource()));
-        specialLeave.setStartDate(LocalDate.of(2014, 10, 15));
-        specialLeave.setEndDate(LocalDate.of(2014, 10, 15));
+        specialLeave.setStartDate(LocalDate.of(2014, OCTOBER, 15));
+        specialLeave.setEndDate(LocalDate.of(2014, OCTOBER, 15));
         specialLeave.setStatus(WAITING);
 
         final Application specialLeaveAllowed = anyApplication();
         specialLeaveAllowed.setVacationType(createVacationType(1L, SPECIALLEAVE, new StaticMessageSource()));
-        specialLeaveAllowed.setStartDate(LocalDate.of(2014, 10, 16));
-        specialLeaveAllowed.setEndDate(LocalDate.of(2014, 10, 16));
+        specialLeaveAllowed.setStartDate(LocalDate.of(2014, OCTOBER, 16));
+        specialLeaveAllowed.setEndDate(LocalDate.of(2014, OCTOBER, 16));
         specialLeaveAllowed.setStatus(ALLOWED);
 
         final Application unpaidLeave = anyApplication();
         unpaidLeave.setVacationType(createVacationType(1L, UNPAIDLEAVE, new StaticMessageSource()));
-        unpaidLeave.setStartDate(LocalDate.of(2014, 10, 17));
-        unpaidLeave.setEndDate(LocalDate.of(2014, 10, 17));
+        unpaidLeave.setStartDate(LocalDate.of(2014, OCTOBER, 17));
+        unpaidLeave.setEndDate(LocalDate.of(2014, OCTOBER, 17));
         unpaidLeave.setStatus(WAITING);
 
         final Application unpaidLeaveAllowed = anyApplication();
         unpaidLeaveAllowed.setVacationType(createVacationType(1L, UNPAIDLEAVE, new StaticMessageSource()));
-        unpaidLeaveAllowed.setStartDate(LocalDate.of(2014, 10, 20));
-        unpaidLeaveAllowed.setEndDate(LocalDate.of(2014, 10, 20));
+        unpaidLeaveAllowed.setStartDate(LocalDate.of(2014, OCTOBER, 20));
+        unpaidLeaveAllowed.setEndDate(LocalDate.of(2014, OCTOBER, 20));
         unpaidLeaveAllowed.setStatus(ALLOWED);
 
         final Application overtimeLeave = anyApplication();
         overtimeLeave.setVacationType(createVacationType(1L, OVERTIME, new StaticMessageSource()));
-        overtimeLeave.setStartDate(LocalDate.of(2014, 10, 21));
-        overtimeLeave.setEndDate(LocalDate.of(2014, 10, 21));
+        overtimeLeave.setStartDate(LocalDate.of(2014, OCTOBER, 21));
+        overtimeLeave.setEndDate(LocalDate.of(2014, OCTOBER, 21));
         overtimeLeave.setStatus(WAITING);
 
         final Application overtimeLeaveAllowed = anyApplication();
         overtimeLeaveAllowed.setVacationType(createVacationType(1L, OVERTIME, new StaticMessageSource()));
-        overtimeLeaveAllowed.setStartDate(LocalDate.of(2014, 10, 22));
-        overtimeLeaveAllowed.setEndDate(LocalDate.of(2014, 10, 22));
+        overtimeLeaveAllowed.setStartDate(LocalDate.of(2014, OCTOBER, 22));
+        overtimeLeaveAllowed.setEndDate(LocalDate.of(2014, OCTOBER, 22));
         overtimeLeaveAllowed.setStatus(ALLOWED);
 
         final Application overtimeLeaveRequestCancellation = anyApplication();
         overtimeLeaveRequestCancellation.setVacationType(createVacationType(1L, OVERTIME, new StaticMessageSource()));
-        overtimeLeaveRequestCancellation.setStartDate(LocalDate.of(2014, 10, 22));
-        overtimeLeaveRequestCancellation.setEndDate(LocalDate.of(2014, 10, 22));
+        overtimeLeaveRequestCancellation.setStartDate(LocalDate.of(2014, OCTOBER, 22));
+        overtimeLeaveRequestCancellation.setEndDate(LocalDate.of(2014, OCTOBER, 22));
         overtimeLeaveRequestCancellation.setStatus(ALLOWED_CANCELLATION_REQUESTED);
 
         final List<Application> applications = Arrays.asList(holiday, holidayAllowed, holidayAllowedRequestCancellation,
@@ -164,8 +168,8 @@ class ApplicationDaysUsedSummaryDtoTest {
     void ensureCalculatesDaysForGivenYearForApplicationsSpanningTwoYears() {
 
         Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        LocalDate startDate = LocalDate.of(2013, 12, 24);
-        LocalDate endDate = LocalDate.of(2014, 1, 6);
+        LocalDate startDate = LocalDate.of(2013, DECEMBER, 24);
+        LocalDate endDate = LocalDate.of(2014, JANUARY, 6);
 
         // 3 days in 2013, 2 days in 2014
         Application holiday = createApplication(person, createVacationType(1L, HOLIDAY, new StaticMessageSource()), startDate, endDate, DayLength.FULL);
@@ -190,20 +194,20 @@ class ApplicationDaysUsedSummaryDtoTest {
 
         final Application holiday = anyApplication();
         holiday.setVacationType(createVacationType(1L, HOLIDAY, new StaticMessageSource()));
-        holiday.setStartDate(LocalDate.of(2014, 10, 13));
-        holiday.setEndDate(LocalDate.of(2014, 10, 13));
+        holiday.setStartDate(LocalDate.of(2014, OCTOBER, 13));
+        holiday.setEndDate(LocalDate.of(2014, OCTOBER, 13));
         holiday.setStatus(WAITING);
 
         final Application holidayAllowed = anyApplication();
         holidayAllowed.setVacationType(createVacationType(1L, HOLIDAY, new StaticMessageSource()));
-        holidayAllowed.setStartDate(LocalDate.of(2014, 10, 14));
-        holidayAllowed.setEndDate(LocalDate.of(2014, 10, 14));
+        holidayAllowed.setStartDate(LocalDate.of(2014, OCTOBER, 14));
+        holidayAllowed.setEndDate(LocalDate.of(2014, OCTOBER, 14));
         holidayAllowed.setStatus(ALLOWED);
 
         final Application holidayTemporaryAllowed = anyApplication();
         holidayTemporaryAllowed.setVacationType(createVacationType(1L, HOLIDAY, new StaticMessageSource()));
-        holidayTemporaryAllowed.setStartDate(LocalDate.of(2014, 10, 15));
-        holidayTemporaryAllowed.setEndDate(LocalDate.of(2014, 10, 15));
+        holidayTemporaryAllowed.setStartDate(LocalDate.of(2014, OCTOBER, 15));
+        holidayTemporaryAllowed.setEndDate(LocalDate.of(2014, OCTOBER, 15));
         holidayTemporaryAllowed.setStatus(TEMPORARY_ALLOWED);
 
         List<Application> applications = Arrays.asList(holiday, holidayTemporaryAllowed, holidayAllowed);

--- a/src/test/java/org/synyx/urlaubsverwaltung/overview/OverviewViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overview/OverviewViewControllerTest.java
@@ -61,6 +61,7 @@ import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.TEN;
 import static java.math.BigDecimal.ZERO;
 import static java.time.Month.APRIL;
+import static java.time.Month.JUNE;
 import static java.time.temporal.TemporalAdjusters.firstDayOfMonth;
 import static java.util.Arrays.asList;
 import static java.util.Locale.GERMAN;
@@ -746,8 +747,8 @@ class OverviewViewControllerTest {
         when(personService.getPersonByID(1L)).thenReturn(Optional.of(person));
         when(departmentService.isSignedInUserAllowedToAccessPersonData(person, person)).thenReturn(true);
 
-        final LocalDate startDate = LocalDate.of(2021, 6, 1);
-        final LocalDate endDate = LocalDate.of(2021, 6, 2);
+        final LocalDate startDate = LocalDate.of(2021, JUNE, 1);
+        final LocalDate endDate = LocalDate.of(2021, JUNE, 2);
         final Overtime overtime = new Overtime(
             new OvertimeId(1L),
             new PersonId(person.getId()),

--- a/src/test/java/org/synyx/urlaubsverwaltung/overview/SickDaysOverviewTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overview/SickDaysOverviewTest.java
@@ -11,6 +11,11 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static java.math.BigDecimal.ONE;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
+import static java.time.Month.JUNE;
+import static java.time.Month.MAY;
+import static java.time.Month.OCTOBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -32,10 +37,10 @@ class SickDaysOverviewTest {
         sickNoteType.setCategory(SICK_NOTE);
         sickNoteType.setMessageKey("Krankmeldung");
 
-        final LocalDate startDate = LocalDate.of(2016, 1, 1);
-        final LocalDate endDate = LocalDate.of(2016, 12, 31);
-        final LocalDate aubStartDate = LocalDate.of(2016, 5, 5);
-        final LocalDate aubEndDate = LocalDate.of(2016, 6, 6);
+        final LocalDate startDate = LocalDate.of(2016, JANUARY, 1);
+        final LocalDate endDate = LocalDate.of(2016, DECEMBER, 31);
+        final LocalDate aubStartDate = LocalDate.of(2016, MAY, 5);
+        final LocalDate aubEndDate = LocalDate.of(2016, JUNE, 6);
 
         final SickNote sickNote = SickNote.builder()
             .person(person)
@@ -56,8 +61,8 @@ class SickDaysOverviewTest {
         final BigDecimal workingDaysAub = BigDecimal.valueOf(100);
         when(workDaysCountService.getWorkDaysCount(FULL, aubStartDate, aubEndDate, person)).thenReturn(workingDaysAub);
 
-        final LocalDate from = LocalDate.of(2015, 1, 1);
-        final LocalDate to = LocalDate.of(2017, 12, 31);
+        final LocalDate from = LocalDate.of(2015, JANUARY, 1);
+        final LocalDate to = LocalDate.of(2017, DECEMBER, 31);
         final SickDaysSummaryDto sickDaysOverview = new SickDaysSummaryDto(List.of(sickNote), workDaysCountService, from, to);
         final SickDaysDto sickDays = sickDaysOverview.getSickDays();
         assertThat(sickDays.getDays())
@@ -75,10 +80,10 @@ class SickDaysOverviewTest {
         sickNoteType.setCategory(SICK_NOTE);
         sickNoteType.setMessageKey("Krankmeldung");
 
-        final LocalDate intervalStart = LocalDate.of(2026, 1, 1);
+        final LocalDate intervalStart = LocalDate.of(2026, JANUARY, 1);
 
-        final LocalDate sickNoteStartDate = LocalDate.of(2025, 12, 29);
-        final LocalDate sickNoteEndDate = LocalDate.of(2026, 1, 9);
+        final LocalDate sickNoteStartDate = LocalDate.of(2025, DECEMBER, 29);
+        final LocalDate sickNoteEndDate = LocalDate.of(2026, JANUARY, 9);
 
         final SickNote sickNote = SickNote.builder()
             .person(person)
@@ -90,7 +95,7 @@ class SickDaysOverviewTest {
             .endDate(sickNoteEndDate)
             // aub must end before the start of the requested interval below
             .aubStartDate(sickNoteStartDate)
-            .aubEndDate(LocalDate.of(2025, 12, 31))
+            .aubEndDate(LocalDate.of(2025, DECEMBER, 31))
             .build();
 
         final WorkDaysCountService workDaysCountService = mock(WorkDaysCountService.class);
@@ -98,8 +103,8 @@ class SickDaysOverviewTest {
         final BigDecimal sickNoteWorkingDays = BigDecimal.valueOf(42);
         when(workDaysCountService.getWorkDaysCount(FULL, intervalStart, sickNoteEndDate, person)).thenReturn(sickNoteWorkingDays);
 
-        final LocalDate from = LocalDate.of(2026, 1, 1);
-        final LocalDate to = LocalDate.of(2026, 12, 31);
+        final LocalDate from = LocalDate.of(2026, JANUARY, 1);
+        final LocalDate to = LocalDate.of(2026, DECEMBER, 31);
         final SickDaysSummaryDto sut = new SickDaysSummaryDto(List.of(sickNote), workDaysCountService, from, to);
 
         final SickDaysDto actual = sut.getSickDays();
@@ -130,10 +135,10 @@ class SickDaysOverviewTest {
             .dayLength(FULL)
             .sickNoteType(sickNoteType)
             .status(ACTIVE)
-            .startDate(LocalDate.of(2014, 10, 13))
-            .endDate(LocalDate.of(2014, 10, 13))
+            .startDate(LocalDate.of(2014, OCTOBER, 13))
+            .endDate(LocalDate.of(2014, OCTOBER, 13))
             .build();
-        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, 10, 13), LocalDate.of(2014, 10, 13), person))
+        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, OCTOBER, 13), LocalDate.of(2014, OCTOBER, 13), person))
             .thenReturn(ONE);
 
         final SickNote sickNoteWithAUB = SickNote.builder()
@@ -141,14 +146,14 @@ class SickDaysOverviewTest {
             .dayLength(FULL)
             .sickNoteType(sickNoteType)
             .status(ACTIVE)
-            .startDate(LocalDate.of(2014, 10, 14))
-            .endDate(LocalDate.of(2014, 10, 16))
-            .aubStartDate(LocalDate.of(2014, 10, 15))
-            .aubEndDate(LocalDate.of(2014, 10, 15))
+            .startDate(LocalDate.of(2014, OCTOBER, 14))
+            .endDate(LocalDate.of(2014, OCTOBER, 16))
+            .aubStartDate(LocalDate.of(2014, OCTOBER, 15))
+            .aubEndDate(LocalDate.of(2014, OCTOBER, 15))
             .build();
-        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, 10, 14), LocalDate.of(2014, 10, 16), person))
+        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, OCTOBER, 14), LocalDate.of(2014, OCTOBER, 16), person))
             .thenReturn(BigDecimal.valueOf(3));
-        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, 10, 15), LocalDate.of(2014, 10, 15), person))
+        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, OCTOBER, 15), LocalDate.of(2014, OCTOBER, 15), person))
             .thenReturn(ONE);
 
         final SickNote childSickNoteWithoutAUB = SickNote.builder()
@@ -156,10 +161,10 @@ class SickDaysOverviewTest {
             .dayLength(FULL)
             .sickNoteType(sickNoteTypeChild)
             .status(ACTIVE)
-            .startDate(LocalDate.of(2014, 10, 15))
-            .endDate(LocalDate.of(2014, 10, 15))
+            .startDate(LocalDate.of(2014, OCTOBER, 15))
+            .endDate(LocalDate.of(2014, OCTOBER, 15))
             .build();
-        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, 10, 15), LocalDate.of(2014, 10, 15), person))
+        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, OCTOBER, 15), LocalDate.of(2014, OCTOBER, 15), person))
             .thenReturn(ONE);
 
         final SickNote childSickNoteWithAUB = SickNote.builder()
@@ -167,14 +172,14 @@ class SickDaysOverviewTest {
             .dayLength(FULL)
             .sickNoteType(sickNoteTypeChild)
             .status(ACTIVE)
-            .startDate(LocalDate.of(2014, 10, 16))
-            .endDate(LocalDate.of(2014, 10, 18))
-            .aubStartDate(LocalDate.of(2014, 10, 16))
-            .aubEndDate(LocalDate.of(2014, 10, 17))
+            .startDate(LocalDate.of(2014, OCTOBER, 16))
+            .endDate(LocalDate.of(2014, OCTOBER, 18))
+            .aubStartDate(LocalDate.of(2014, OCTOBER, 16))
+            .aubEndDate(LocalDate.of(2014, OCTOBER, 17))
             .build();
-        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, 10, 16), LocalDate.of(2014, 10, 18), person))
+        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, OCTOBER, 16), LocalDate.of(2014, OCTOBER, 18), person))
             .thenReturn(BigDecimal.valueOf(3));
-        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, 10, 16), LocalDate.of(2014, 10, 17), person))
+        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, OCTOBER, 16), LocalDate.of(2014, OCTOBER, 17), person))
             .thenReturn(BigDecimal.valueOf(2));
 
         final SickNote inactiveSickNote = SickNote.builder()
@@ -182,27 +187,27 @@ class SickDaysOverviewTest {
             .dayLength(FULL)
             .sickNoteType(sickNoteTypeChild)
             .status(CANCELLED)
-            .startDate(LocalDate.of(2014, 10, 17))
-            .endDate(LocalDate.of(2014, 10, 17))
+            .startDate(LocalDate.of(2014, OCTOBER, 17))
+            .endDate(LocalDate.of(2014, OCTOBER, 17))
             .build();
-        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, 10, 17), LocalDate.of(2014, 10, 17), person))
+        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, OCTOBER, 17), LocalDate.of(2014, OCTOBER, 17), person))
             .thenReturn(ONE);
 
         final SickNote inactiveChildSickNote = SickNote.builder()
             .person(person)
             .sickNoteType(sickNoteTypeChild)
             .status(CANCELLED)
-            .startDate(LocalDate.of(2014, 10, 18))
-            .endDate(LocalDate.of(2014, 10, 18))
+            .startDate(LocalDate.of(2014, OCTOBER, 18))
+            .endDate(LocalDate.of(2014, OCTOBER, 18))
             .build();
-        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, 10, 18), LocalDate.of(2014, 10, 18), person))
+        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, OCTOBER, 18), LocalDate.of(2014, OCTOBER, 18), person))
             .thenReturn(ONE);
 
         final List<SickNote> sickNotes = List.of(sickNoteWithoutAUB, sickNoteWithAUB, childSickNoteWithoutAUB,
             childSickNoteWithAUB, inactiveSickNote, inactiveChildSickNote);
 
         final SickDaysSummaryDto sickDaysOverview = new SickDaysSummaryDto(sickNotes, workDaysCountService,
-            LocalDate.of(2014, 10, 10), LocalDate.of(2014, 10, 18));
+            LocalDate.of(2014, OCTOBER, 10), LocalDate.of(2014, OCTOBER, 18));
 
         final SickDaysDto sickDays = sickDaysOverview.getSickDays();
         assertThat(sickDays.getDays())

--- a/src/test/java/org/synyx/urlaubsverwaltung/person/PersonRepositoryIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/person/PersonRepositoryIT.java
@@ -17,6 +17,8 @@ import java.time.LocalDate;
 import java.time.Year;
 import java.util.List;
 
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.synyx.urlaubsverwaltung.person.MailNotification.NOTIFICATION_EMAIL_APPLICATION_MANAGEMENT_APPLIED;
 import static org.synyx.urlaubsverwaltung.person.Role.INACTIVE;
@@ -217,8 +219,8 @@ class PersonRepositoryIT extends SingleTenantTestContainersBase {
 
         final Account previousYearAccount = new Account();
         previousYearAccount.setPerson(person);
-        previousYearAccount.setValidFrom(LocalDate.of(currentYear.minusYears(1).getValue(), 1, 1));
-        previousYearAccount.setValidTo(LocalDate.of(currentYear.minusYears(1).getValue(), 12, 31));
+        previousYearAccount.setValidFrom(LocalDate.of(currentYear.minusYears(1).getValue(), JANUARY, 1));
+        previousYearAccount.setValidTo(LocalDate.of(currentYear.minusYears(1).getValue(), DECEMBER, 31));
         accountService.save(previousYearAccount);
 
         assertThat(sut.findAllWithAccountByYear(currentYear.getValue())).hasSize(3);

--- a/src/test/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayApiControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/publicholiday/PublicHolidayApiControllerTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.time.Month.MAY;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -65,8 +66,8 @@ class PublicHolidayApiControllerTest {
 
         when(settingsService.getSettings()).thenReturn(settings);
 
-        final LocalDate from = LocalDate.of(2016, 5, 19);
-        final LocalDate to = LocalDate.of(2016, 5, 20);
+        final LocalDate from = LocalDate.of(2016, MAY, 19);
+        final LocalDate to = LocalDate.of(2016, MAY, 20);
         final PublicHoliday fromHoliday = new PublicHoliday(from, MORNING, "");
         final PublicHoliday toHoliday = new PublicHoliday(to, NOON, "");
         when(publicHolidaysService.getPublicHolidays(from, to, GERMANY_BADEN_WUERTTEMBERG)).thenReturn(List.of(fromHoliday, toHoliday));
@@ -137,8 +138,8 @@ class PublicHolidayApiControllerTest {
 
         when(personService.getPersonByID(1L)).thenReturn(Optional.of(person));
 
-        final LocalDate from = LocalDate.of(2016, 5, 19);
-        final LocalDate to = LocalDate.of(2016, 5, 20);
+        final LocalDate from = LocalDate.of(2016, MAY, 19);
+        final LocalDate to = LocalDate.of(2016, MAY, 20);
 
         when(workingTimeService.getFederalStatesByPersonAndDateRange(person, new DateRange(from, to)))
             .thenReturn(Map.of(

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/me/SickNotesViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/me/SickNotesViewControllerTest.java
@@ -34,6 +34,9 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.math.BigDecimal.ONE;
+import static java.time.Month.JANUARY;
+import static java.time.Month.JUNE;
+import static java.time.Month.MARCH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -76,7 +79,7 @@ class SickNotesViewControllerTest {
     @Mock
     private PersonSearchUiFragmentSupplier personSearchUiFragmentSupplier;
 
-    private final Clock clock = Clock.fixed(ZonedDateTime.of(LocalDate.of(2022, 6, 15).atStartOfDay(), ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
+    private final Clock clock = Clock.fixed(ZonedDateTime.of(LocalDate.of(2022, JUNE, 15).atStartOfDay(), ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
 
     @BeforeEach
     void setUp() {
@@ -193,8 +196,8 @@ class SickNotesViewControllerTest {
         final SickNote sickNote = SickNote.builder()
             .id(42L)
             .person(person)
-            .startDate(LocalDate.of(2022, 1, 2))
-            .endDate(LocalDate.of(2022, 1, 4))
+            .startDate(LocalDate.of(2022, JANUARY, 2))
+            .endDate(LocalDate.of(2022, JANUARY, 4))
             .dayLength(FULL)
             .sickNoteType(sickNoteType)
             .status(ACTIVE)
@@ -468,8 +471,8 @@ class SickNotesViewControllerTest {
         final SickNote sickNote = SickNote.builder()
             .id(1L)
             .person(person)
-            .startDate(LocalDate.of(2022, 1, 2))
-            .endDate(LocalDate.of(2022, 1, 4))
+            .startDate(LocalDate.of(2022, JANUARY, 2))
+            .endDate(LocalDate.of(2022, JANUARY, 4))
             .dayLength(FULL)
             .sickNoteType(sickNoteType)
             .status(SUBMITTED)
@@ -503,8 +506,8 @@ class SickNotesViewControllerTest {
         final SickNote sickNote = SickNote.builder()
             .id(1L)
             .person(person)
-            .startDate(LocalDate.of(2022, 1, 2))
-            .endDate(LocalDate.of(2022, 1, 4))
+            .startDate(LocalDate.of(2022, JANUARY, 2))
+            .endDate(LocalDate.of(2022, JANUARY, 4))
             .dayLength(FULL)
             .sickNoteType(sickNoteType)
             .status(ACTIVE)
@@ -542,8 +545,8 @@ class SickNotesViewControllerTest {
         final SickNote sickNote = SickNote.builder()
             .id(1L)
             .person(person)
-            .startDate(LocalDate.of(2022, 1, 2))
-            .endDate(LocalDate.of(2022, 1, 4))
+            .startDate(LocalDate.of(2022, JANUARY, 2))
+            .endDate(LocalDate.of(2022, JANUARY, 4))
             .dayLength(FULL)
             .sickNoteType(sickNoteType)
             .status(ACTIVE)
@@ -581,8 +584,8 @@ class SickNotesViewControllerTest {
         final SickNote sickNote = SickNote.builder()
             .id(1L)
             .person(person)
-            .startDate(LocalDate.of(2022, 1, 2))
-            .endDate(LocalDate.of(2022, 1, 4))
+            .startDate(LocalDate.of(2022, JANUARY, 2))
+            .endDate(LocalDate.of(2022, JANUARY, 4))
             .dayLength(FULL)
             .sickNoteType(sickNoteType)
             .status(ACTIVE)
@@ -620,8 +623,8 @@ class SickNotesViewControllerTest {
         final SickNote sickNote = SickNote.builder()
             .id(1L)
             .person(person)
-            .startDate(LocalDate.of(2022, 1, 2))
-            .endDate(LocalDate.of(2022, 1, 4))
+            .startDate(LocalDate.of(2022, JANUARY, 2))
+            .endDate(LocalDate.of(2022, JANUARY, 4))
             .dayLength(FULL)
             .sickNoteType(sickNoteType)
             .status(ACTIVE)
@@ -659,8 +662,8 @@ class SickNotesViewControllerTest {
         final SickNote sickNote = SickNote.builder()
             .id(1L)
             .person(person)
-            .startDate(LocalDate.of(2022, 1, 2))
-            .endDate(LocalDate.of(2022, 1, 4))
+            .startDate(LocalDate.of(2022, JANUARY, 2))
+            .endDate(LocalDate.of(2022, JANUARY, 4))
             .dayLength(FULL)
             .sickNoteType(sickNoteType)
             .status(ACTIVE)
@@ -695,8 +698,8 @@ class SickNotesViewControllerTest {
         final SickNote sickNote = SickNote.builder()
             .id(1L)
             .person(person)
-            .startDate(LocalDate.of(2022, 1, 2))
-            .endDate(LocalDate.of(2022, 1, 4))
+            .startDate(LocalDate.of(2022, JANUARY, 2))
+            .endDate(LocalDate.of(2022, JANUARY, 4))
             .dayLength(FULL)
             .sickNoteType(sickNoteType)
             .status(ACTIVE)
@@ -730,8 +733,8 @@ class SickNotesViewControllerTest {
         final SickNote sickNote1 = SickNote.builder()
             .id(1L)
             .person(person)
-            .startDate(LocalDate.of(2022, 3, 1))
-            .endDate(LocalDate.of(2022, 3, 3))
+            .startDate(LocalDate.of(2022, MARCH, 1))
+            .endDate(LocalDate.of(2022, MARCH, 3))
             .dayLength(FULL)
             .sickNoteType(sickNoteType)
             .status(ACTIVE)
@@ -740,8 +743,8 @@ class SickNotesViewControllerTest {
         final SickNote sickNote2 = SickNote.builder()
             .id(2L)
             .person(person)
-            .startDate(LocalDate.of(2022, 1, 1))
-            .endDate(LocalDate.of(2022, 1, 3))
+            .startDate(LocalDate.of(2022, JANUARY, 1))
+            .endDate(LocalDate.of(2022, JANUARY, 3))
             .dayLength(FULL)
             .sickNoteType(sickNoteType)
             .status(ACTIVE)
@@ -779,8 +782,8 @@ class SickNotesViewControllerTest {
         final SickNote sickNote = SickNote.builder()
             .id(1L)
             .person(person)
-            .startDate(LocalDate.of(2022, 1, 2))
-            .endDate(LocalDate.of(2022, 1, 4))
+            .startDate(LocalDate.of(2022, JANUARY, 2))
+            .endDate(LocalDate.of(2022, JANUARY, 4))
             .dayLength(FULL)
             .sickNoteType(sickNoteType)
             .status(ACTIVE)
@@ -800,8 +803,8 @@ class SickNotesViewControllerTest {
             .andExpect(model().attribute("sickNotes",
                 hasItems(
                     hasProperty("id", is(1L)),
-                    hasProperty("startDate", is(LocalDate.of(2022, 1, 2))),
-                    hasProperty("endDate", is(LocalDate.of(2022, 1, 4))),
+                    hasProperty("startDate", is(LocalDate.of(2022, JANUARY, 2))),
+                    hasProperty("endDate", is(LocalDate.of(2022, JANUARY, 4))),
                     hasProperty("dayLength", is(FULL)),
                     hasProperty("status", is(ACTIVE)),
                     hasProperty("allowedToEdit", is(true)),

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/me/YearlySickDaysSummaryTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/me/YearlySickDaysSummaryTest.java
@@ -12,6 +12,11 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static java.math.BigDecimal.ONE;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
+import static java.time.Month.JUNE;
+import static java.time.Month.MAY;
+import static java.time.Month.OCTOBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -33,10 +38,10 @@ class YearlySickDaysSummaryTest {
         sickNoteType.setCategory(SICK_NOTE);
         sickNoteType.setMessageKey("Krankmeldung");
 
-        final LocalDate startDate = LocalDate.of(2016, 1, 1);
-        final LocalDate endDate = LocalDate.of(2016, 12, 31);
-        final LocalDate aubStartDate = LocalDate.of(2016, 5, 5);
-        final LocalDate aubEndDate = LocalDate.of(2016, 6, 6);
+        final LocalDate startDate = LocalDate.of(2016, JANUARY, 1);
+        final LocalDate endDate = LocalDate.of(2016, DECEMBER, 31);
+        final LocalDate aubStartDate = LocalDate.of(2016, MAY, 5);
+        final LocalDate aubEndDate = LocalDate.of(2016, JUNE, 6);
 
         final SickNote sickNote = SickNote.builder()
             .person(person)
@@ -57,8 +62,8 @@ class YearlySickDaysSummaryTest {
         final BigDecimal workingDaysAub = BigDecimal.valueOf(100);
         when(workDaysCountService.getWorkDaysCount(FULL, aubStartDate, aubEndDate, person)).thenReturn(workingDaysAub);
 
-        final LocalDate from = LocalDate.of(2015, 1, 1);
-        final LocalDate to = LocalDate.of(2017, 12, 31);
+        final LocalDate from = LocalDate.of(2015, JANUARY, 1);
+        final LocalDate to = LocalDate.of(2017, DECEMBER, 31);
         final YearlySickDaysSummary sickDaysOverview = new YearlySickDaysSummary(List.of(sickNote), workDaysCountService, from, to);
         final SickDays sickDays = sickDaysOverview.getSickDays();
         assertThat(sickDays.getDays())
@@ -76,10 +81,10 @@ class YearlySickDaysSummaryTest {
         sickNoteType.setCategory(SICK_NOTE);
         sickNoteType.setMessageKey("Krankmeldung");
 
-        final LocalDate intervalStart = LocalDate.of(2026, 1, 1);
+        final LocalDate intervalStart = LocalDate.of(2026, JANUARY, 1);
 
-        final LocalDate sickNoteStartDate = LocalDate.of(2025, 12, 29);
-        final LocalDate sickNoteEndDate = LocalDate.of(2026, 1, 9);
+        final LocalDate sickNoteStartDate = LocalDate.of(2025, DECEMBER, 29);
+        final LocalDate sickNoteEndDate = LocalDate.of(2026, JANUARY, 9);
 
         final SickNote sickNote = SickNote.builder()
             .person(person)
@@ -91,7 +96,7 @@ class YearlySickDaysSummaryTest {
             .endDate(sickNoteEndDate)
             // aub must end before the start of the requested interval below
             .aubStartDate(sickNoteStartDate)
-            .aubEndDate(LocalDate.of(2025, 12,  31))
+            .aubEndDate(LocalDate.of(2025, DECEMBER,  31))
             .build();
 
         final WorkDaysCountService workDaysCountService = mock(WorkDaysCountService.class);
@@ -99,8 +104,8 @@ class YearlySickDaysSummaryTest {
         final BigDecimal sickNoteWorkingDays = BigDecimal.valueOf(42);
         when(workDaysCountService.getWorkDaysCount(FULL, intervalStart, sickNoteEndDate, person)).thenReturn(sickNoteWorkingDays);
 
-        final LocalDate from = LocalDate.of(2026, 1, 1);
-        final LocalDate to = LocalDate.of(2026, 12, 31);
+        final LocalDate from = LocalDate.of(2026, JANUARY, 1);
+        final LocalDate to = LocalDate.of(2026, DECEMBER, 31);
         final YearlySickDaysSummary sut = new YearlySickDaysSummary(List.of(sickNote), workDaysCountService, from, to);
 
         final SickDays actual = sut.getSickDays();
@@ -131,10 +136,10 @@ class YearlySickDaysSummaryTest {
             .dayLength(FULL)
             .sickNoteType(sickNoteType)
             .status(ACTIVE)
-            .startDate(LocalDate.of(2014, 10, 13))
-            .endDate(LocalDate.of(2014, 10, 13))
+            .startDate(LocalDate.of(2014, OCTOBER, 13))
+            .endDate(LocalDate.of(2014, OCTOBER, 13))
             .build();
-        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, 10, 13), LocalDate.of(2014, 10, 13), person))
+        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, OCTOBER, 13), LocalDate.of(2014, OCTOBER, 13), person))
             .thenReturn(ONE);
 
         final SickNote sickNoteWithAUB = SickNote.builder()
@@ -142,14 +147,14 @@ class YearlySickDaysSummaryTest {
             .dayLength(FULL)
             .sickNoteType(sickNoteType)
             .status(ACTIVE)
-            .startDate(LocalDate.of(2014, 10, 14))
-            .endDate(LocalDate.of(2014, 10, 16))
-            .aubStartDate(LocalDate.of(2014, 10, 15))
-            .aubEndDate(LocalDate.of(2014, 10, 15))
+            .startDate(LocalDate.of(2014, OCTOBER, 14))
+            .endDate(LocalDate.of(2014, OCTOBER, 16))
+            .aubStartDate(LocalDate.of(2014, OCTOBER, 15))
+            .aubEndDate(LocalDate.of(2014, OCTOBER, 15))
             .build();
-        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, 10, 14), LocalDate.of(2014, 10, 16), person))
+        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, OCTOBER, 14), LocalDate.of(2014, OCTOBER, 16), person))
             .thenReturn(BigDecimal.valueOf(3));
-        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, 10, 15), LocalDate.of(2014, 10, 15), person))
+        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, OCTOBER, 15), LocalDate.of(2014, OCTOBER, 15), person))
             .thenReturn(ONE);
 
         final SickNote childSickNoteWithoutAUB = SickNote.builder()
@@ -157,10 +162,10 @@ class YearlySickDaysSummaryTest {
             .dayLength(FULL)
             .sickNoteType(sickNoteTypeChild)
             .status(ACTIVE)
-            .startDate(LocalDate.of(2014, 10, 15))
-            .endDate(LocalDate.of(2014, 10, 15))
+            .startDate(LocalDate.of(2014, OCTOBER, 15))
+            .endDate(LocalDate.of(2014, OCTOBER, 15))
             .build();
-        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, 10, 15), LocalDate.of(2014, 10, 15), person))
+        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, OCTOBER, 15), LocalDate.of(2014, OCTOBER, 15), person))
             .thenReturn(ONE);
 
         final SickNote childSickNoteWithAUB = SickNote.builder()
@@ -168,14 +173,14 @@ class YearlySickDaysSummaryTest {
             .dayLength(FULL)
             .sickNoteType(sickNoteTypeChild)
             .status(ACTIVE)
-            .startDate(LocalDate.of(2014, 10, 16))
-            .endDate(LocalDate.of(2014, 10, 18))
-            .aubStartDate(LocalDate.of(2014, 10, 16))
-            .aubEndDate(LocalDate.of(2014, 10, 17))
+            .startDate(LocalDate.of(2014, OCTOBER, 16))
+            .endDate(LocalDate.of(2014, OCTOBER, 18))
+            .aubStartDate(LocalDate.of(2014, OCTOBER, 16))
+            .aubEndDate(LocalDate.of(2014, OCTOBER, 17))
             .build();
-        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, 10, 16), LocalDate.of(2014, 10, 18), person))
+        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, OCTOBER, 16), LocalDate.of(2014, OCTOBER, 18), person))
             .thenReturn(BigDecimal.valueOf(3));
-        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, 10, 16), LocalDate.of(2014, 10, 17), person))
+        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, OCTOBER, 16), LocalDate.of(2014, OCTOBER, 17), person))
             .thenReturn(BigDecimal.valueOf(2));
 
         final SickNote inactiveSickNote = SickNote.builder()
@@ -183,27 +188,27 @@ class YearlySickDaysSummaryTest {
             .dayLength(FULL)
             .sickNoteType(sickNoteTypeChild)
             .status(CANCELLED)
-            .startDate(LocalDate.of(2014, 10, 17))
-            .endDate(LocalDate.of(2014, 10, 17))
+            .startDate(LocalDate.of(2014, OCTOBER, 17))
+            .endDate(LocalDate.of(2014, OCTOBER, 17))
             .build();
-        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, 10, 17), LocalDate.of(2014, 10, 17), person))
+        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, OCTOBER, 17), LocalDate.of(2014, OCTOBER, 17), person))
             .thenReturn(ONE);
 
         final SickNote inactiveChildSickNote = SickNote.builder()
             .person(person)
             .sickNoteType(sickNoteTypeChild)
             .status(CANCELLED)
-            .startDate(LocalDate.of(2014, 10, 18))
-            .endDate(LocalDate.of(2014, 10, 18))
+            .startDate(LocalDate.of(2014, OCTOBER, 18))
+            .endDate(LocalDate.of(2014, OCTOBER, 18))
             .build();
-        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, 10, 18), LocalDate.of(2014, 10, 18), person))
+        when(workDaysCountService.getWorkDaysCount(FULL, LocalDate.of(2014, OCTOBER, 18), LocalDate.of(2014, OCTOBER, 18), person))
             .thenReturn(ONE);
 
         final List<SickNote> sickNotes = List.of(sickNoteWithoutAUB, sickNoteWithAUB, childSickNoteWithoutAUB,
             childSickNoteWithAUB, inactiveSickNote, inactiveChildSickNote);
 
         final YearlySickDaysSummary sickDaysOverview = new YearlySickDaysSummary(sickNotes, workDaysCountService,
-            LocalDate.of(2014, 10, 10), LocalDate.of(2014, 10, 18));
+            LocalDate.of(2014, OCTOBER, 10), LocalDate.of(2014, OCTOBER, 18));
 
         final SickDays sickDays = sickDaysOverview.getSickDays();
         assertThat(sickDays.getDays())

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sickdays/SickDaysDetailedStatisticsTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sickdays/SickDaysDetailedStatisticsTest.java
@@ -10,6 +10,8 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
 import static java.util.Calendar.JUNE;
 import static java.util.Calendar.NOVEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,8 +35,8 @@ class SickDaysDetailedStatisticsTest {
         sickNoteType.setCategory(SICK_NOTE);
 
         final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(
-            LocalDate.of(2022, 1, 1),
-            LocalDate.of(2022, 12, 31)
+            LocalDate.of(2022, JANUARY, 1),
+            LocalDate.of(2022, DECEMBER, 31)
         );
 
         final SickNote sickNoteOne = SickNote.builder()
@@ -64,7 +66,7 @@ class SickDaysDetailedStatisticsTest {
         final SickDaysDetailedStatistics sut =
             new SickDaysDetailedStatistics("0000001337", person, List.of(sickNoteOne, sickNoteTwo), List.of());
 
-        final SickDays actual = sut.getSickDays(LocalDate.of(2022, 1, 1), LocalDate.of(2022, 12, 31));
+        final SickDays actual = sut.getSickDays(LocalDate.of(2022, JANUARY, 1), LocalDate.of(2022, DECEMBER, 31));
 
         assertThat(actual.getDays()).containsEntry(TOTAL.name(), BigDecimal.valueOf(17)); // 3 * 5days + 2weekend
         assertThat(actual.getDays()).containsEntry(WITH_AUB.name(), BigDecimal.valueOf(5));
@@ -90,7 +92,7 @@ class SickDaysDetailedStatisticsTest {
         final SickDaysDetailedStatistics sut =
             new SickDaysDetailedStatistics("0000001337", person, List.of(sickNote), List.of());
 
-        final SickDays actual = sut.getSickDays(LocalDate.of(2022, 12, 1), LocalDate.of(2022, 12, 31));
+        final SickDays actual = sut.getSickDays(LocalDate.of(2022, DECEMBER, 1), LocalDate.of(2022, DECEMBER, 31));
 
         assertThat(actual.getDays()).containsEntry(TOTAL.name(), BigDecimal.ZERO);
         assertThat(actual.getDays()).containsEntry(WITH_AUB.name(), BigDecimal.ZERO);
@@ -116,7 +118,7 @@ class SickDaysDetailedStatisticsTest {
         final SickDaysDetailedStatistics sut =
             new SickDaysDetailedStatistics("0000001337", person, List.of(childSickNote), List.of());
 
-        final SickDays actual = sut.getSickDays(LocalDate.of(2022, 1, 1), LocalDate.of(2022, 12, 31));
+        final SickDays actual = sut.getSickDays(LocalDate.of(2022, JANUARY, 1), LocalDate.of(2022, DECEMBER, 31));
 
         assertThat(actual.getDays()).containsEntry(TOTAL.name(), BigDecimal.ZERO);
         assertThat(actual.getDays()).containsEntry(WITH_AUB.name(), BigDecimal.ZERO);
@@ -133,8 +135,8 @@ class SickDaysDetailedStatisticsTest {
         childSickNoteType.setCategory(SICK_NOTE_CHILD);
 
         final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(
-            LocalDate.of(2022, 1, 1),
-            LocalDate.of(2022, 12, 31)
+            LocalDate.of(2022, JANUARY, 1),
+            LocalDate.of(2022, DECEMBER, 31)
         );
 
         final SickNote childSickNoteOne = SickNote.builder()
@@ -164,7 +166,7 @@ class SickDaysDetailedStatisticsTest {
         final SickDaysDetailedStatistics sut =
             new SickDaysDetailedStatistics("0000001337", person, List.of(childSickNoteOne, childSickNoteTwo), List.of());
 
-        final SickDays actual = sut.getChildSickDays(LocalDate.of(2022, 1, 1), LocalDate.of(2022, 12, 31));
+        final SickDays actual = sut.getChildSickDays(LocalDate.of(2022, JANUARY, 1), LocalDate.of(2022, DECEMBER, 31));
 
         assertThat(actual.getDays()).containsEntry(TOTAL.name(), BigDecimal.valueOf(17)); // 3 * 5days + 2weekend
         assertThat(actual.getDays()).containsEntry(WITH_AUB.name(), BigDecimal.valueOf(5));
@@ -190,7 +192,7 @@ class SickDaysDetailedStatisticsTest {
         final SickDaysDetailedStatistics sut =
             new SickDaysDetailedStatistics("0000001337", person, List.of(childSickNote), List.of());
 
-        final SickDays actual = sut.getChildSickDays(LocalDate.of(2022, 12, 1), LocalDate.of(2022, 12, 31));
+        final SickDays actual = sut.getChildSickDays(LocalDate.of(2022, DECEMBER, 1), LocalDate.of(2022, DECEMBER, 31));
 
         assertThat(actual.getDays()).containsEntry(TOTAL.name(), BigDecimal.ZERO);
         assertThat(actual.getDays()).containsEntry(WITH_AUB.name(), BigDecimal.ZERO);
@@ -216,7 +218,7 @@ class SickDaysDetailedStatisticsTest {
         final SickDaysDetailedStatistics sut =
             new SickDaysDetailedStatistics("0000001337", person, List.of(sickNote), List.of());
 
-        final SickDays actual = sut.getChildSickDays(LocalDate.of(2022, 1, 1), LocalDate.of(2022, 12, 31));
+        final SickDays actual = sut.getChildSickDays(LocalDate.of(2022, JANUARY, 1), LocalDate.of(2022, DECEMBER, 31));
 
         assertThat(actual.getDays()).containsEntry(TOTAL.name(), BigDecimal.ZERO);
         assertThat(actual.getDays()).containsEntry(WITH_AUB.name(), BigDecimal.ZERO);

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sickdays/SickDaysOverviewViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sickdays/SickDaysOverviewViewControllerTest.java
@@ -48,6 +48,12 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.math.BigDecimal.ZERO;
+import static java.time.Month.APRIL;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.FEBRUARY;
+import static java.time.Month.JANUARY;
+import static java.time.Month.MARCH;
+import static java.time.Month.MAY;
 import static java.time.temporal.TemporalAdjusters.firstDayOfYear;
 import static java.time.temporal.TemporalAdjusters.lastDayOfYear;
 import static org.assertj.core.api.Assertions.as;
@@ -127,11 +133,11 @@ class SickDaysOverviewViewControllerTest {
     private static Stream<Arguments> dateInputAndIsoDateTuple() {
         final int year = clockYear();
         return Stream.of(
-            Arguments.of("25.03.%s".formatted(year), LocalDate.of(year, 3, 25)),
-            Arguments.of("25.03.%s".formatted(year - 2000), LocalDate.of(year, 3, 25)),
-            Arguments.of("25.3.%s".formatted(year), LocalDate.of(year, 3, 25)),
-            Arguments.of("25.3.%s".formatted(year - 2000), LocalDate.of(year, 3, 25)),
-            Arguments.of("1.4.%s".formatted(year - 2000), LocalDate.of(year, 4, 1))
+            Arguments.of("25.03.%s".formatted(year), LocalDate.of(year, MARCH, 25)),
+            Arguments.of("25.03.%s".formatted(year - 2000), LocalDate.of(year, MARCH, 25)),
+            Arguments.of("25.3.%s".formatted(year), LocalDate.of(year, MARCH, 25)),
+            Arguments.of("25.3.%s".formatted(year - 2000), LocalDate.of(year, MARCH, 25)),
+            Arguments.of("1.4.%s".formatted(year - 2000), LocalDate.of(year, APRIL, 1))
         );
     }
 
@@ -196,7 +202,7 @@ class SickDaysOverviewViewControllerTest {
             .model()
             .containsEntry("today", LocalDate.now(clock))
             .containsEntry("from", givenDate)
-            .containsEntry("to", LocalDate.of(year, 12, 31))
+            .containsEntry("to", LocalDate.of(year, DECEMBER, 31))
             .containsEntry("sortSelect", expectedPersonSortSelect());
     }
 
@@ -207,7 +213,7 @@ class SickDaysOverviewViewControllerTest {
         final Locale locale = Locale.GERMAN;
 
         final int year = clockYear();
-        final LocalDate fromDate = LocalDate.of(year, 1, 1);
+        final LocalDate fromDate = LocalDate.of(year, JANUARY, 1);
 
         when(sickDaysStatisticsService.getAll(any(), any(), any(), any())).thenReturn(new PageImpl<>(List.of()));
 
@@ -246,8 +252,8 @@ class SickDaysOverviewViewControllerTest {
             .hasViewName("sicknote/sick_days")
             .model()
             .containsEntry("today", LocalDate.now(clock))
-            .containsEntry("from", LocalDate.of(year, 1, 1))
-            .containsEntry("to", LocalDate.of(year, 12, 31))
+            .containsEntry("from", LocalDate.of(year, JANUARY, 1))
+            .containsEntry("to", LocalDate.of(year, DECEMBER, 31))
             .containsEntry("sortSelect", expectedPersonSortSelect());
     }
 
@@ -280,22 +286,22 @@ class SickDaysOverviewViewControllerTest {
         person3.setPermissions(List.of(USER));
 
         final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(
-            LocalDate.of(2019, 1, 1),
-            LocalDate.of(2019, 12, 31)
+            LocalDate.of(2019, JANUARY, 1),
+            LocalDate.of(2019, DECEMBER, 31)
         );
 
         final SickNoteType childSickType = new SickNoteType();
         childSickType.setCategory(SICK_NOTE_CHILD);
 
         final SickNote childSickNote = SickNote.builder()
-            .startDate(LocalDate.of(2019, 2, 1))
-            .endDate(LocalDate.of(2019, 3, 1))
+            .startDate(LocalDate.of(2019, FEBRUARY, 1))
+            .endDate(LocalDate.of(2019, MARCH, 1))
             .dayLength(FULL)
             .status(ACTIVE)
             .sickNoteType(childSickType)
             .person(person)
-            .aubStartDate(LocalDate.of(2019, 2, 10))
-            .aubEndDate(LocalDate.of(2019, 2, 15))
+            .aubStartDate(LocalDate.of(2019, FEBRUARY, 10))
+            .aubEndDate(LocalDate.of(2019, FEBRUARY, 15))
             .workingTimeCalendar(workingTimeCalendar)
             .build();
 
@@ -303,19 +309,19 @@ class SickDaysOverviewViewControllerTest {
         sickType.setCategory(SICK_NOTE);
 
         final SickNote sickNote = SickNote.builder()
-            .startDate(LocalDate.of(2019, 4, 1))
-            .endDate(LocalDate.of(2019, 5, 1))
+            .startDate(LocalDate.of(2019, APRIL, 1))
+            .endDate(LocalDate.of(2019, MAY, 1))
             .dayLength(FULL)
             .status(ACTIVE)
             .sickNoteType(sickType)
             .person(person2)
-            .aubStartDate(LocalDate.of(2019, 4, 10))
-            .aubEndDate(LocalDate.of(2019, 4, 20))
+            .aubStartDate(LocalDate.of(2019, APRIL, 10))
+            .aubEndDate(LocalDate.of(2019, APRIL, 20))
             .workingTimeCalendar(workingTimeCalendar)
             .build();
 
-        final LocalDate requestStartDate = LocalDate.of(2019, 2, 11);
-        final LocalDate requestEndDate = LocalDate.of(2019, 4, 15);
+        final LocalDate requestStartDate = LocalDate.of(2019, FEBRUARY, 11);
+        final LocalDate requestEndDate = LocalDate.of(2019, APRIL, 15);
 
         final PageableSearchQuery pageableSearchQuery =
             new PageableSearchQuery(PageRequest.of(2, 50, Sort.by(ASC, "person.firstName")), "");
@@ -403,8 +409,8 @@ class SickDaysOverviewViewControllerTest {
         signedInUser.setPermissions(List.of(USER));
         when(personService.getSignedInUser()).thenReturn(signedInUser);
 
-        final LocalDate requestStartDate = LocalDate.of(2019, 2, 11);
-        final LocalDate requestEndDate = LocalDate.of(2019, 4, 15);
+        final LocalDate requestStartDate = LocalDate.of(2019, FEBRUARY, 11);
+        final LocalDate requestEndDate = LocalDate.of(2019, APRIL, 15);
 
         final PageableSearchQuery pageableSearchQuery =
             new PageableSearchQuery(PageRequest.of(2, 50, Sort.by(ASC, "person.firstName")), "");

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteApiControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteApiControllerTest.java
@@ -21,6 +21,9 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
+import static java.time.Month.MAY;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -64,12 +67,12 @@ class SickNoteApiControllerTest {
         when(personService.getSignedInUser()).thenReturn(signedInUser);
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        final LocalDate from = LocalDate.of(2016, 5, 19);
-        final LocalDate to = LocalDate.of(2016, 5, 20);
+        final LocalDate from = LocalDate.of(2016, MAY, 19);
+        final LocalDate to = LocalDate.of(2016, MAY, 20);
         final SickNote sickNote1 = createSickNote(person, from, to, FULL);
         final SickNote sickNote2 = createSickNote(person);
         final SickNote sickNote3 = createSickNote(person);
-        when(sickNoteService.getForStatesAndPerson(List.of(ACTIVE), List.of(person), LocalDate.of(2016, 1, 1), LocalDate.of(2016, 12, 31)))
+        when(sickNoteService.getForStatesAndPerson(List.of(ACTIVE), List.of(person), LocalDate.of(2016, JANUARY, 1), LocalDate.of(2016, DECEMBER, 31)))
             .thenReturn(List.of(sickNote1, sickNote2, sickNote3));
 
         when(personService.getActivePersons()).thenReturn(List.of(person));
@@ -94,12 +97,12 @@ class SickNoteApiControllerTest {
         when(personService.getSignedInUser()).thenReturn(signedInUser);
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        final LocalDate from = LocalDate.of(2016, 5, 19);
-        final LocalDate to = LocalDate.of(2016, 5, 20);
+        final LocalDate from = LocalDate.of(2016, MAY, 19);
+        final LocalDate to = LocalDate.of(2016, MAY, 20);
         final SickNote sickNote1 = createSickNote(person, from, to, FULL);
         final SickNote sickNote2 = createSickNote(person);
         final SickNote sickNote3 = createSickNote(person);
-        when(sickNoteService.getForStatesAndPerson(List.of(ACTIVE), List.of(person), LocalDate.of(2016, 1, 1), LocalDate.of(2016, 12, 31)))
+        when(sickNoteService.getForStatesAndPerson(List.of(ACTIVE), List.of(person), LocalDate.of(2016, JANUARY, 1), LocalDate.of(2016, DECEMBER, 31)))
             .thenReturn(List.of(sickNote1, sickNote2, sickNote3));
 
         when(departmentService.getMembersForDepartmentHead(signedInUser)).thenReturn(List.of(person));
@@ -124,12 +127,12 @@ class SickNoteApiControllerTest {
         when(personService.getSignedInUser()).thenReturn(signedInUser);
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        final LocalDate from = LocalDate.of(2016, 5, 19);
-        final LocalDate to = LocalDate.of(2016, 5, 20);
+        final LocalDate from = LocalDate.of(2016, MAY, 19);
+        final LocalDate to = LocalDate.of(2016, MAY, 20);
         final SickNote sickNote1 = createSickNote(person, from, to, FULL);
         final SickNote sickNote2 = createSickNote(person);
         final SickNote sickNote3 = createSickNote(person);
-        when(sickNoteService.getForStatesAndPerson(List.of(ACTIVE), List.of(person), LocalDate.of(2016, 1, 1), LocalDate.of(2016, 12, 31)))
+        when(sickNoteService.getForStatesAndPerson(List.of(ACTIVE), List.of(person), LocalDate.of(2016, JANUARY, 1), LocalDate.of(2016, DECEMBER, 31)))
             .thenReturn(List.of(sickNote1, sickNote2, sickNote3));
 
         when(departmentService.getMembersForSecondStageAuthority(signedInUser)).thenReturn(List.of(person));
@@ -221,12 +224,12 @@ class SickNoteApiControllerTest {
         person.setId(23L);
         when(personService.getPersonByID(23L)).thenReturn(Optional.of(person));
 
-        final LocalDate from = LocalDate.of(2016, 5, 19);
-        final LocalDate to = LocalDate.of(2016, 5, 20);
+        final LocalDate from = LocalDate.of(2016, MAY, 19);
+        final LocalDate to = LocalDate.of(2016, MAY, 20);
         final SickNote sickNote1 = createSickNote(person, from, to, FULL);
         final SickNote sickNote2 = createSickNote(person);
         final SickNote sickNote3 = createSickNote(person);
-        when(sickNoteService.getForStatesAndPerson(List.of(ACTIVE), List.of(person), LocalDate.of(2016, 1, 1), LocalDate.of(2016, 12, 31)))
+        when(sickNoteService.getForStatesAndPerson(List.of(ACTIVE), List.of(person), LocalDate.of(2016, JANUARY, 1), LocalDate.of(2016, DECEMBER, 31)))
             .thenReturn(List.of(sickNote1, sickNote2, sickNote3));
 
         perform(get("/api/persons/23/sicknotes")
@@ -253,12 +256,12 @@ class SickNoteApiControllerTest {
         person.setId(23L);
         when(personService.getPersonByID(23L)).thenReturn(Optional.of(person));
 
-        final LocalDate from = LocalDate.of(2016, 5, 19);
-        final LocalDate to = LocalDate.of(2016, 5, 20);
+        final LocalDate from = LocalDate.of(2016, MAY, 19);
+        final LocalDate to = LocalDate.of(2016, MAY, 20);
         final SickNote sickNote1 = createSickNote(person, from, to, FULL);
         final SickNote sickNote2 = createSickNote(person);
         final SickNote sickNote3 = createSickNote(person);
-        when(sickNoteService.getForStatesAndPerson(List.of(ACTIVE), List.of(person), LocalDate.of(2016, 1, 1), LocalDate.of(2016, 12, 31)))
+        when(sickNoteService.getForStatesAndPerson(List.of(ACTIVE), List.of(person), LocalDate.of(2016, JANUARY, 1), LocalDate.of(2016, DECEMBER, 31)))
             .thenReturn(List.of(sickNote1, sickNote2, sickNote3));
 
         when(departmentService.isSecondStageAuthorityAllowedToManagePerson(signedInUser, person)).thenReturn(true);
@@ -286,12 +289,12 @@ class SickNoteApiControllerTest {
         person.setId(23L);
         when(personService.getPersonByID(23L)).thenReturn(Optional.of(person));
 
-        final LocalDate from = LocalDate.of(2016, 5, 19);
-        final LocalDate to = LocalDate.of(2016, 5, 20);
+        final LocalDate from = LocalDate.of(2016, MAY, 19);
+        final LocalDate to = LocalDate.of(2016, MAY, 20);
         final SickNote sickNote1 = createSickNote(person, from, to, FULL);
         final SickNote sickNote2 = createSickNote(person);
         final SickNote sickNote3 = createSickNote(person);
-        when(sickNoteService.getForStatesAndPerson(List.of(ACTIVE), List.of(person), LocalDate.of(2016, 1, 1), LocalDate.of(2016, 12, 31)))
+        when(sickNoteService.getForStatesAndPerson(List.of(ACTIVE), List.of(person), LocalDate.of(2016, JANUARY, 1), LocalDate.of(2016, DECEMBER, 31)))
             .thenReturn(List.of(sickNote1, sickNote2, sickNote3));
 
         when(departmentService.isDepartmentHeadAllowedToManagePerson(signedInUser, person)).thenReturn(true);

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteConvertFormTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteConvertFormTest.java
@@ -6,6 +6,7 @@ import org.synyx.urlaubsverwaltung.person.Person;
 
 import java.time.LocalDate;
 
+import static java.time.Month.JANUARY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.synyx.urlaubsverwaltung.TestDataCreator.createSickNote;
 
@@ -19,8 +20,8 @@ class SickNoteConvertFormTest {
     void ensureCorrectProvidedValuesFromSickNote() {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        final LocalDate startDate = LocalDate.of(2014, 1, 1);
-        final LocalDate endDate = LocalDate.of(2014, 1, 10);
+        final LocalDate startDate = LocalDate.of(2014, JANUARY, 1);
+        final LocalDate endDate = LocalDate.of(2014, JANUARY, 10);
         final SickNote sickNote = createSickNote(person, startDate, endDate, DayLength.NOON);
 
         final SickNoteConvertForm sut = new SickNoteConvertForm(sickNote);

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteFormDtoTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteFormDtoTest.java
@@ -7,11 +7,12 @@ import org.synyx.urlaubsverwaltung.sicknote.sicknotetype.SickNoteType;
 
 import java.time.LocalDate;
 
+import static java.time.Month.APRIL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SickNoteFormDtoTest {
 
-    private final LocalDate day2019_04_16 = LocalDate.of(2019, 4, 16);
+    private final LocalDate day2019_04_16 = LocalDate.of(2019, APRIL, 16);
     private final Long id = 1L;
     private final Person person = new Person();
     private final SickNoteType type = new SickNoteType();

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteMailServiceIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteMailServiceIT.java
@@ -28,6 +28,8 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 
+import static java.time.Month.APRIL;
+import static java.time.Month.FEBRUARY;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.verify;
@@ -77,8 +79,8 @@ class SickNoteMailServiceIT extends SingleTenantTestContainersBase {
         final SickNote sickNote = SickNote.builder()
             .id(1L)
             .person(person)
-            .startDate(LocalDate.of(2022, 2, 1))
-            .endDate(LocalDate.of(2022, 4, 1))
+            .startDate(LocalDate.of(2022, FEBRUARY, 1))
+            .endDate(LocalDate.of(2022, APRIL, 1))
             .dayLength(DayLength.FULL)
             .build();
 
@@ -159,8 +161,8 @@ class SickNoteMailServiceIT extends SingleTenantTestContainersBase {
             .id(1L)
             .person(person)
             .applier(management)
-            .startDate(LocalDate.of(2022, 2, 1))
-            .endDate(LocalDate.of(2022, 4, 1))
+            .startDate(LocalDate.of(2022, FEBRUARY, 1))
+            .endDate(LocalDate.of(2022, APRIL, 1))
             .dayLength(DayLength.FULL)
             .sickNoteType(sickNoteTypeChild)
             .build();
@@ -206,8 +208,8 @@ class SickNoteMailServiceIT extends SingleTenantTestContainersBase {
             .id(1L)
             .person(person)
             .applier(management)
-            .startDate(LocalDate.of(2022, 2, 1))
-            .endDate(LocalDate.of(2022, 4, 1))
+            .startDate(LocalDate.of(2022, FEBRUARY, 1))
+            .endDate(LocalDate.of(2022, APRIL, 1))
             .dayLength(DayLength.FULL)
             .sickNoteType(sickNoteTypeChild)
             .build();
@@ -248,8 +250,8 @@ class SickNoteMailServiceIT extends SingleTenantTestContainersBase {
         final SickNote sickNote = SickNote.builder()
             .id(1L)
             .person(person)
-            .startDate(LocalDate.of(2022, 2, 1))
-            .endDate(LocalDate.of(2022, 4, 1))
+            .startDate(LocalDate.of(2022, FEBRUARY, 1))
+            .endDate(LocalDate.of(2022, APRIL, 1))
             .dayLength(DayLength.FULL)
             .build();
 
@@ -297,8 +299,8 @@ class SickNoteMailServiceIT extends SingleTenantTestContainersBase {
             .id(1L)
             .person(person)
             .applier(editor)
-            .startDate(LocalDate.of(2022, 2, 1))
-            .endDate(LocalDate.of(2022, 4, 1))
+            .startDate(LocalDate.of(2022, FEBRUARY, 1))
+            .endDate(LocalDate.of(2022, APRIL, 1))
             .dayLength(DayLength.FULL)
             .sickNoteType(sickNoteTypeChild)
             .build();
@@ -353,8 +355,8 @@ class SickNoteMailServiceIT extends SingleTenantTestContainersBase {
             .id(1L)
             .person(person)
             .applier(management)
-            .startDate(LocalDate.of(2022, 2, 1))
-            .endDate(LocalDate.of(2022, 4, 1))
+            .startDate(LocalDate.of(2022, FEBRUARY, 1))
+            .endDate(LocalDate.of(2022, APRIL, 1))
             .dayLength(DayLength.FULL)
             .sickNoteType(sickNoteTypeChild)
             .build();
@@ -395,8 +397,8 @@ class SickNoteMailServiceIT extends SingleTenantTestContainersBase {
         final SickNote sickNote = SickNote.builder()
             .id(1L)
             .person(person)
-            .startDate(LocalDate.of(2022, 2, 1))
-            .endDate(LocalDate.of(2022, 4, 1))
+            .startDate(LocalDate.of(2022, FEBRUARY, 1))
+            .endDate(LocalDate.of(2022, APRIL, 1))
             .dayLength(DayLength.FULL)
             .build();
 
@@ -443,10 +445,10 @@ class SickNoteMailServiceIT extends SingleTenantTestContainersBase {
             .id(1L)
             .person(person)
             .applier(office1)
-            .startDate(LocalDate.of(2022, 2, 1))
-            .endDate(LocalDate.of(2022, 4, 1))
-            .aubStartDate(LocalDate.of(2022, 2, 2))
-            .aubEndDate(LocalDate.of(2022, 4, 1))
+            .startDate(LocalDate.of(2022, FEBRUARY, 1))
+            .endDate(LocalDate.of(2022, APRIL, 1))
+            .aubStartDate(LocalDate.of(2022, FEBRUARY, 2))
+            .aubEndDate(LocalDate.of(2022, APRIL, 1))
             .dayLength(DayLength.FULL)
             .sickNoteType(sickNoteType)
             .build();
@@ -495,8 +497,8 @@ class SickNoteMailServiceIT extends SingleTenantTestContainersBase {
             .id(1L)
             .person(person)
             .applier(person)
-            .startDate(LocalDate.of(2022, 2, 1))
-            .endDate(LocalDate.of(2022, 4, 1))
+            .startDate(LocalDate.of(2022, FEBRUARY, 1))
+            .endDate(LocalDate.of(2022, APRIL, 1))
             .dayLength(DayLength.FULL)
             .sickNoteType(sickNoteTypeChild)
             .build();
@@ -543,8 +545,8 @@ class SickNoteMailServiceIT extends SingleTenantTestContainersBase {
             .id(1L)
             .person(person)
             .applier(person)
-            .startDate(LocalDate.of(2022, 2, 1))
-            .endDate(LocalDate.of(2022, 4, 1))
+            .startDate(LocalDate.of(2022, FEBRUARY, 1))
+            .endDate(LocalDate.of(2022, APRIL, 1))
             .dayLength(DayLength.FULL)
             .sickNoteType(sickNoteTypeChild)
             .build();
@@ -590,8 +592,8 @@ class SickNoteMailServiceIT extends SingleTenantTestContainersBase {
             .id(1L)
             .person(person)
             .applier(person)
-            .startDate(LocalDate.of(2022, 2, 1))
-            .endDate(LocalDate.of(2022, 4, 1))
+            .startDate(LocalDate.of(2022, FEBRUARY, 1))
+            .endDate(LocalDate.of(2022, APRIL, 1))
             .dayLength(DayLength.FULL)
             .sickNoteType(sickNoteTypeChild)
             .build();
@@ -640,8 +642,8 @@ class SickNoteMailServiceIT extends SingleTenantTestContainersBase {
             .id(1L)
             .person(person)
             .applier(person)
-            .startDate(LocalDate.of(2022, 2, 1))
-            .endDate(LocalDate.of(2022, 4, 1))
+            .startDate(LocalDate.of(2022, FEBRUARY, 1))
+            .endDate(LocalDate.of(2022, APRIL, 1))
             .dayLength(DayLength.FULL)
             .sickNoteType(sickNoteTypeChild)
             .build();

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteMailServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteMailServiceTest.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static java.time.Month.APRIL;
+import static java.time.Month.MARCH;
 import static java.util.Arrays.asList;
 import static java.util.Locale.GERMAN;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -88,15 +90,15 @@ class SickNoteMailServiceTest {
         final SickNote sickNoteA = SickNote.builder()
             .id(1L)
             .person(person)
-            .startDate(LocalDate.of(2022, 4, 1))
-            .endDate(LocalDate.of(2022, 4, 13))
+            .startDate(LocalDate.of(2022, APRIL, 1))
+            .endDate(LocalDate.of(2022, APRIL, 13))
             .build();
 
         final SickNote sickNoteB = SickNote.builder()
             .id(2L)
             .person(person)
-            .startDate(LocalDate.of(2022, 4, 10))
-            .endDate(LocalDate.of(2022, 4, 20))
+            .startDate(LocalDate.of(2022, APRIL, 10))
+            .endDate(LocalDate.of(2022, APRIL, 20))
             .build();
 
         when(sickNoteService.getSickNotesReachingEndOfSickPay()).thenReturn(asList(sickNoteA, sickNoteB));
@@ -105,18 +107,18 @@ class SickNoteMailServiceTest {
 
         final Map<String, Object> modelA = new HashMap<>();
         modelA.put("maximumSickPayDays", 5);
-        modelA.put("endOfSickPayDays", LocalDate.of(2022, 4, 5));
+        modelA.put("endOfSickPayDays", LocalDate.of(2022, APRIL, 5));
         modelA.put("sickPayDaysEndedDaysAgo", 4L);
         modelA.put("sickNotePayFrom", sickNoteA.getStartDate());
-        modelA.put("sickNotePayTo", LocalDate.of(2022, 4, 5));
+        modelA.put("sickNotePayTo", LocalDate.of(2022, APRIL, 5));
         modelA.put("sickNote", sickNoteA);
 
         final Map<String, Object> modelB = new HashMap<>();
         modelB.put("maximumSickPayDays", 5);
-        modelB.put("endOfSickPayDays", LocalDate.of(2022, 4, 14));
+        modelB.put("endOfSickPayDays", LocalDate.of(2022, APRIL, 14));
         modelB.put("sickPayDaysEndedDaysAgo", 13L);
         modelB.put("sickNotePayFrom", sickNoteB.getStartDate());
-        modelB.put("sickNotePayTo", LocalDate.of(2022, 4, 14));
+        modelB.put("sickNotePayTo", LocalDate.of(2022, APRIL, 14));
         modelB.put("sickNote", sickNoteB);
 
         sut.sendEndOfSickPayNotification();
@@ -171,8 +173,8 @@ class SickNoteMailServiceTest {
             .id(2L)
             .person(person)
             .applier(management)
-            .startDate(LocalDate.of(2022, 3, 10))
-            .endDate(LocalDate.of(2022, 4, 20))
+            .startDate(LocalDate.of(2022, MARCH, 10))
+            .endDate(LocalDate.of(2022, APRIL, 20))
             .build();
 
         sut.sendCreatedToSickPerson(sickNote);
@@ -203,8 +205,8 @@ class SickNoteMailServiceTest {
         final SickNote sickNote = SickNote.builder()
             .id(2L)
             .person(person)
-            .startDate(LocalDate.of(2022, 4, 10))
-            .endDate(LocalDate.of(2022, 4, 20))
+            .startDate(LocalDate.of(2022, APRIL, 10))
+            .endDate(LocalDate.of(2022, APRIL, 20))
             .dayLength(DayLength.FULL)
             .build();
 
@@ -243,8 +245,8 @@ class SickNoteMailServiceTest {
             .id(2L)
             .person(person)
             .applier(management)
-            .startDate(LocalDate.of(2022, 3, 10))
-            .endDate(LocalDate.of(2022, 4, 20))
+            .startDate(LocalDate.of(2022, MARCH, 10))
+            .endDate(LocalDate.of(2022, APRIL, 20))
             .build();
 
         sut.sendEditedToSickPerson(sickNote, management);
@@ -277,8 +279,8 @@ class SickNoteMailServiceTest {
             .id(2L)
             .person(person)
             .applier(management)
-            .startDate(LocalDate.of(2022, 3, 10))
-            .endDate(LocalDate.of(2022, 4, 20))
+            .startDate(LocalDate.of(2022, MARCH, 10))
+            .endDate(LocalDate.of(2022, APRIL, 20))
             .build();
 
         when(mailRecipientService.getRecipientsOfInterest(person, NOTIFICATION_EMAIL_SICK_NOTE_EDITED_BY_MANAGEMENT_TO_MANAGEMENT))
@@ -312,8 +314,8 @@ class SickNoteMailServiceTest {
             .id(2L)
             .person(person)
             .applier(management)
-            .startDate(LocalDate.of(2022, 3, 10))
-            .endDate(LocalDate.of(2022, 4, 20))
+            .startDate(LocalDate.of(2022, MARCH, 10))
+            .endDate(LocalDate.of(2022, APRIL, 20))
             .build();
 
         sut.sendCancelledToSickPerson(sickNote, management);
@@ -337,8 +339,8 @@ class SickNoteMailServiceTest {
         final SickNote sickNote = SickNote.builder()
             .id(2L)
             .person(person)
-            .startDate(LocalDate.of(2022, 4, 10))
-            .endDate(LocalDate.of(2022, 4, 20))
+            .startDate(LocalDate.of(2022, APRIL, 10))
+            .endDate(LocalDate.of(2022, APRIL, 20))
             .build();
 
         final Person colleague = new Person("muster", "Muster", "Marlene", "muster@example.org");
@@ -381,8 +383,8 @@ class SickNoteMailServiceTest {
             .id(2L)
             .person(person)
             .applier(management1)
-            .startDate(LocalDate.of(2022, 3, 10))
-            .endDate(LocalDate.of(2022, 4, 20))
+            .startDate(LocalDate.of(2022, MARCH, 10))
+            .endDate(LocalDate.of(2022, APRIL, 20))
             .build();
 
         final String comment = "Some comment";
@@ -409,8 +411,8 @@ class SickNoteMailServiceTest {
         final SickNote sickNote = SickNote.builder()
             .id(2L)
             .person(person)
-            .startDate(LocalDate.of(2022, 3, 10))
-            .endDate(LocalDate.of(2022, 4, 20))
+            .startDate(LocalDate.of(2022, MARCH, 10))
+            .endDate(LocalDate.of(2022, APRIL, 20))
             .build();
 
         sut.sendSickNoteSubmittedNotificationToSickPerson(sickNote);
@@ -439,8 +441,8 @@ class SickNoteMailServiceTest {
         final SickNote sickNote = SickNote.builder()
             .id(2L)
             .person(person)
-            .startDate(LocalDate.of(2022, 3, 10))
-            .endDate(LocalDate.of(2022, 4, 20))
+            .startDate(LocalDate.of(2022, MARCH, 10))
+            .endDate(LocalDate.of(2022, APRIL, 20))
             .build();
 
         sut.sendSickNoteAcceptedNotificationToSickPerson(sickNote, management);
@@ -472,8 +474,8 @@ class SickNoteMailServiceTest {
         final SickNote sickNote = SickNote.builder()
             .id(2L)
             .person(person)
-            .startDate(LocalDate.of(2022, 3, 10))
-            .endDate(LocalDate.of(2022, 4, 20))
+            .startDate(LocalDate.of(2022, MARCH, 10))
+            .endDate(LocalDate.of(2022, APRIL, 20))
             .build();
 
         sut.sendSickNoteSubmittedNotificationToOfficeAndResponsibleManagement(sickNote);
@@ -510,8 +512,8 @@ class SickNoteMailServiceTest {
             .id(2L)
             .person(person)
 
-            .startDate(LocalDate.of(2022, 3, 10))
-            .endDate(LocalDate.of(2022, 4, 20))
+            .startDate(LocalDate.of(2022, MARCH, 10))
+            .endDate(LocalDate.of(2022, APRIL, 20))
             .build();
 
         sut.sendSickNoteAcceptedNotificationToOfficeAndResponsibleManagement(sickNote, management1);

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteMapperTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteMapperTest.java
@@ -18,6 +18,8 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
+import static java.time.Month.AUGUST;
+import static java.time.Month.JANUARY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -46,12 +48,12 @@ class SickNoteMapperTest {
             applier.setId(2L);
 
             final SickNoteType sickNoteType = new SickNoteType();
-            final LocalDate startDate = LocalDate.of(2024, 8, 19);
-            final LocalDate endDate = LocalDate.of(2024, 8, 23);
-            final LocalDate aubStartDate = LocalDate.of(2024, 8, 20);
-            final LocalDate aubEndDate = LocalDate.of(2024, 8, 23);
-            final LocalDate lastEdited = LocalDate.of(2024, 8, 20);
-            final LocalDate endOfSickPauNotificationSend = LocalDate.of(2025, 1, 1);
+            final LocalDate startDate = LocalDate.of(2024, AUGUST, 19);
+            final LocalDate endDate = LocalDate.of(2024, AUGUST, 23);
+            final LocalDate aubStartDate = LocalDate.of(2024, AUGUST, 20);
+            final LocalDate aubEndDate = LocalDate.of(2024, AUGUST, 23);
+            final LocalDate lastEdited = LocalDate.of(2024, AUGUST, 20);
+            final LocalDate endOfSickPauNotificationSend = LocalDate.of(2025, JANUARY, 1);
 
             final SickNoteEntity entity = new SickNoteEntity();
             entity.setId(1L);
@@ -96,12 +98,12 @@ class SickNoteMapperTest {
             applier.setId(2L);
 
             final SickNoteType sickNoteType = new SickNoteType();
-            final LocalDate startDate = LocalDate.of(2024, 8, 19);
-            final LocalDate endDate = LocalDate.of(2024, 8, 23);
-            final LocalDate aubStartDate = LocalDate.of(2024, 8, 20);
-            final LocalDate aubEndDate = LocalDate.of(2024, 8, 23);
-            final LocalDate lastEdited = LocalDate.of(2024, 8, 20);
-            final LocalDate endOfSickPauNotificationSend = LocalDate.of(2025, 1, 1);
+            final LocalDate startDate = LocalDate.of(2024, AUGUST, 19);
+            final LocalDate endDate = LocalDate.of(2024, AUGUST, 23);
+            final LocalDate aubStartDate = LocalDate.of(2024, AUGUST, 20);
+            final LocalDate aubEndDate = LocalDate.of(2024, AUGUST, 23);
+            final LocalDate lastEdited = LocalDate.of(2024, AUGUST, 20);
+            final LocalDate endOfSickPauNotificationSend = LocalDate.of(2025, JANUARY, 1);
 
             final SickNoteEntity entity = new SickNoteEntity();
             entity.setId(1L);
@@ -153,8 +155,8 @@ class SickNoteMapperTest {
         @Test
         void ensureWithEmptyEntities() {
 
-            final LocalDate startDate = LocalDate.of(2024, 8, 19);
-            final LocalDate endDate = LocalDate.of(2024, 8, 23);
+            final LocalDate startDate = LocalDate.of(2024, AUGUST, 19);
+            final LocalDate endDate = LocalDate.of(2024, AUGUST, 23);
 
             final List<SickNote> actual = sut.toSickNoteWithWorkDays(List.of(), new DateRange(startDate, endDate));
             assertThat(actual).isEmpty();
@@ -175,12 +177,12 @@ class SickNoteMapperTest {
             applier.setId(3L);
 
             final SickNoteType sickNoteType = new SickNoteType();
-            final LocalDate startDate = LocalDate.of(2024, 8, 19);
-            final LocalDate endDate = LocalDate.of(2024, 8, 23);
-            final LocalDate aubStartDate = LocalDate.of(2024, 8, 20);
-            final LocalDate aubEndDate = LocalDate.of(2024, 8, 23);
-            final LocalDate lastEdited = LocalDate.of(2024, 8, 20);
-            final LocalDate endOfSickPauNotificationSend = LocalDate.of(2025, 1, 1);
+            final LocalDate startDate = LocalDate.of(2024, AUGUST, 19);
+            final LocalDate endDate = LocalDate.of(2024, AUGUST, 23);
+            final LocalDate aubStartDate = LocalDate.of(2024, AUGUST, 20);
+            final LocalDate aubEndDate = LocalDate.of(2024, AUGUST, 23);
+            final LocalDate lastEdited = LocalDate.of(2024, AUGUST, 20);
+            final LocalDate endOfSickPauNotificationSend = LocalDate.of(2025, JANUARY, 1);
 
             final SickNoteEntity entity1 = new SickNoteEntity();
             entity1.setId(1L);
@@ -261,12 +263,12 @@ class SickNoteMapperTest {
             applier.setId(3L);
 
             final SickNoteType sickNoteType = new SickNoteType();
-            final LocalDate startDate = LocalDate.of(2024, 8, 19);
-            final LocalDate endDate = LocalDate.of(2024, 8, 23);
-            final LocalDate aubStartDate = LocalDate.of(2024, 8, 20);
-            final LocalDate aubEndDate = LocalDate.of(2024, 8, 23);
-            final LocalDate lastEdited = LocalDate.of(2024, 8, 20);
-            final LocalDate endOfSickPauNotificationSend = LocalDate.of(2025, 1, 1);
+            final LocalDate startDate = LocalDate.of(2024, AUGUST, 19);
+            final LocalDate endDate = LocalDate.of(2024, AUGUST, 23);
+            final LocalDate aubStartDate = LocalDate.of(2024, AUGUST, 20);
+            final LocalDate aubEndDate = LocalDate.of(2024, AUGUST, 23);
+            final LocalDate lastEdited = LocalDate.of(2024, AUGUST, 20);
+            final LocalDate endOfSickPauNotificationSend = LocalDate.of(2025, JANUARY, 1);
 
             final SickNoteEntity entity1 = new SickNoteEntity();
             entity1.setId(1L);

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteRepositoryIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteRepositoryIT.java
@@ -11,6 +11,8 @@ import org.synyx.urlaubsverwaltung.person.PersonService;
 import java.time.LocalDate;
 import java.util.List;
 
+import static java.time.Month.FEBRUARY;
+import static java.time.Month.MARCH;
 import static java.time.ZoneOffset.UTC;
 import static java.time.temporal.TemporalAdjusters.firstDayOfMonth;
 import static java.time.temporal.TemporalAdjusters.lastDayOfMonth;
@@ -34,15 +36,15 @@ class SickNoteRepositoryIT extends SingleTenantTestContainersBase {
         // lohnfortzahlung from 01.02.2022 until 14.03.2022
         // 7 days before notification on 07.03.2022
         // --> SickNote will be found
-        final LocalDate startDate = LocalDate.of(2022, 2, 1);
-        final LocalDate endDate = LocalDate.of(2022, 3, 30);
+        final LocalDate startDate = LocalDate.of(2022, FEBRUARY, 1);
+        final LocalDate endDate = LocalDate.of(2022, MARCH, 30);
 
         final SickNoteEntity activeSickNote = createSickNote(null, startDate, endDate, ACTIVE);
         sickNoteRepository.save(activeSickNote);
 
         final int maximumSickPayDays = 42;
         final int daysBeforeEndOfSickPayNotification = 7;
-        final LocalDate today = LocalDate.of(2022, 3, 7);
+        final LocalDate today = LocalDate.of(2022, MARCH, 7);
 
         final List<SickNoteEntity> sickNotes = sickNoteRepository.findSickNotesToNotifyForSickPayEnd(maximumSickPayDays, daysBeforeEndOfSickPayNotification, today);
         assertThat(sickNotes)
@@ -56,15 +58,15 @@ class SickNoteRepositoryIT extends SingleTenantTestContainersBase {
         // 7 days before notification on 07.03.2022
         // but asks on 06.03.2022
         // --> No SickNote will be found
-        final LocalDate startDate = LocalDate.of(2022, 2, 1);
-        final LocalDate endDate = LocalDate.of(2022, 3, 30);
+        final LocalDate startDate = LocalDate.of(2022, FEBRUARY, 1);
+        final LocalDate endDate = LocalDate.of(2022, MARCH, 30);
 
         final SickNoteEntity activeSickNote = createSickNote(null, startDate, endDate, ACTIVE);
         sickNoteRepository.save(activeSickNote);
 
         final int maximumSickPayDays = 42;
         final int daysBeforeEndOfSickPayNotification = 7;
-        final LocalDate today = LocalDate.of(2022, 3, 6);
+        final LocalDate today = LocalDate.of(2022, MARCH, 6);
 
         final List<SickNoteEntity> sickNotes = sickNoteRepository.findSickNotesToNotifyForSickPayEnd(maximumSickPayDays, daysBeforeEndOfSickPayNotification, today);
         assertThat(sickNotes).isEmpty();
@@ -77,15 +79,15 @@ class SickNoteRepositoryIT extends SingleTenantTestContainersBase {
         // 7 days before notification on 07.03.2022
         // and asks on 08.03.2022
         // --> SickNote will be found
-        final LocalDate startDate = LocalDate.of(2022, 2, 1);
-        final LocalDate endDate = LocalDate.of(2022, 3, 30);
+        final LocalDate startDate = LocalDate.of(2022, FEBRUARY, 1);
+        final LocalDate endDate = LocalDate.of(2022, MARCH, 30);
 
         final SickNoteEntity activeSickNote = createSickNote(null, startDate, endDate, ACTIVE);
         sickNoteRepository.save(activeSickNote);
 
         final int maximumSickPayDays = 42;
         final int daysBeforeEndOfSickPayNotification = 7;
-        final LocalDate today = LocalDate.of(2022, 3, 8);
+        final LocalDate today = LocalDate.of(2022, MARCH, 8);
 
         final List<SickNoteEntity> sickNotes = sickNoteRepository.findSickNotesToNotifyForSickPayEnd(maximumSickPayDays, daysBeforeEndOfSickPayNotification, today);
         assertThat(sickNotes)
@@ -99,15 +101,15 @@ class SickNoteRepositoryIT extends SingleTenantTestContainersBase {
         // 7 days before notification on 07.03.2022
         // but sick note period only until 14.03.2022
         // --> No sick note will be found
-        final LocalDate startDate = LocalDate.of(2022, 2, 1);
-        final LocalDate endDate = LocalDate.of(2022, 3, 14);
+        final LocalDate startDate = LocalDate.of(2022, FEBRUARY, 1);
+        final LocalDate endDate = LocalDate.of(2022, MARCH, 14);
 
         final SickNoteEntity activeSickNote = createSickNote(null, startDate, endDate, ACTIVE);
         sickNoteRepository.save(activeSickNote);
 
         final int maximumSickPayDays = 42;
         final int daysBeforeEndOfSickPayNotification = 7;
-        final LocalDate today = LocalDate.of(2022, 3, 7);
+        final LocalDate today = LocalDate.of(2022, MARCH, 7);
 
         final List<SickNoteEntity> sickNotes = sickNoteRepository.findSickNotesToNotifyForSickPayEnd(maximumSickPayDays, daysBeforeEndOfSickPayNotification, today);
         assertThat(sickNotes).isEmpty();
@@ -120,8 +122,8 @@ class SickNoteRepositoryIT extends SingleTenantTestContainersBase {
         // 7 days before notification on 07.03.2022
         // but sick notes not of type active
         // --> No sick note will be found
-        final LocalDate startDate = LocalDate.of(2022, 2, 1);
-        final LocalDate endDate = LocalDate.of(2022, 3, 15);
+        final LocalDate startDate = LocalDate.of(2022, FEBRUARY, 1);
+        final LocalDate endDate = LocalDate.of(2022, MARCH, 15);
 
         final SickNoteEntity activeSickNote = createSickNote(null, startDate, endDate, ACTIVE);
         sickNoteRepository.save(activeSickNote);
@@ -131,7 +133,7 @@ class SickNoteRepositoryIT extends SingleTenantTestContainersBase {
 
         final int maximumSickPayDays = 42;
         final int daysBeforeEndOfSickPayNotification = 7;
-        final LocalDate today = LocalDate.of(2022, 3, 7);
+        final LocalDate today = LocalDate.of(2022, MARCH, 7);
 
         final List<SickNoteEntity> sickNotes = sickNoteRepository.findSickNotesToNotifyForSickPayEnd(maximumSickPayDays, daysBeforeEndOfSickPayNotification, today);
         assertThat(sickNotes)
@@ -148,8 +150,8 @@ class SickNoteRepositoryIT extends SingleTenantTestContainersBase {
         // 7 days before notification on 07.03.2022
         // but already notified is after last edit
         // --> No sick note will be found
-        final LocalDate startDate = LocalDate.of(2022, 2, 1);
-        final LocalDate endDate = LocalDate.of(2022, 3, 15);
+        final LocalDate startDate = LocalDate.of(2022, FEBRUARY, 1);
+        final LocalDate endDate = LocalDate.of(2022, MARCH, 15);
 
         final SickNoteEntity sickNote = createSickNote(null, startDate, endDate, ACTIVE);
         sickNote.setLastEdited(startDate);
@@ -158,7 +160,7 @@ class SickNoteRepositoryIT extends SingleTenantTestContainersBase {
 
         final int maximumSickPayDays = 42;
         final int daysBeforeEndOfSickPayNotification = 7;
-        final LocalDate today = LocalDate.of(2022, 3, 7);
+        final LocalDate today = LocalDate.of(2022, MARCH, 7);
 
         final List<SickNoteEntity> sickNotes = sickNoteRepository.findSickNotesToNotifyForSickPayEnd(maximumSickPayDays, daysBeforeEndOfSickPayNotification, today);
         assertThat(sickNotes).isEmpty();
@@ -171,8 +173,8 @@ class SickNoteRepositoryIT extends SingleTenantTestContainersBase {
         // 7 days before notification on 07.03.2022
         // and was not already sent
         // --> sick note will be found
-        final LocalDate startDate = LocalDate.of(2022, 2, 1);
-        final LocalDate endDate = LocalDate.of(2022, 3, 15);
+        final LocalDate startDate = LocalDate.of(2022, FEBRUARY, 1);
+        final LocalDate endDate = LocalDate.of(2022, MARCH, 15);
 
         final SickNoteEntity sickNote = createSickNote(null, startDate, endDate, ACTIVE);
         sickNote.setLastEdited(startDate);
@@ -180,7 +182,7 @@ class SickNoteRepositoryIT extends SingleTenantTestContainersBase {
 
         final int maximumSickPayDays = 42;
         final int daysBeforeEndOfSickPayNotification = 7;
-        final LocalDate today = LocalDate.of(2022, 3, 7);
+        final LocalDate today = LocalDate.of(2022, MARCH, 7);
 
         final List<SickNoteEntity> sickNotes = sickNoteRepository.findSickNotesToNotifyForSickPayEnd(maximumSickPayDays, daysBeforeEndOfSickPayNotification, today);
         assertThat(sickNotes)
@@ -191,8 +193,8 @@ class SickNoteRepositoryIT extends SingleTenantTestContainersBase {
     @Test
     void ensureNotToSendMailIfSickNoteIsEditedButMailWasSent() {
 
-        final LocalDate startDate = LocalDate.of(2022, 2, 1);
-        final LocalDate endDate = LocalDate.of(2022, 3, 15);
+        final LocalDate startDate = LocalDate.of(2022, FEBRUARY, 1);
+        final LocalDate endDate = LocalDate.of(2022, MARCH, 15);
 
         final SickNoteEntity sickNote = createSickNote(null, startDate, endDate, ACTIVE);
         sickNote.setLastEdited(endDate);
@@ -201,7 +203,7 @@ class SickNoteRepositoryIT extends SingleTenantTestContainersBase {
 
         final int maximumSickPayDays = 42;
         final int daysBeforeEndOfSickPayNotification = 7;
-        final LocalDate today = LocalDate.of(2022, 3, 7);
+        final LocalDate today = LocalDate.of(2022, MARCH, 7);
 
         final List<SickNoteEntity> sickNotes = sickNoteRepository.findSickNotesToNotifyForSickPayEnd(maximumSickPayDays, daysBeforeEndOfSickPayNotification, today);
         assertThat(sickNotes).isEmpty();

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteServiceImplTest.java
@@ -23,6 +23,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JUNE;
+import static java.time.Month.OCTOBER;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
@@ -61,9 +64,9 @@ class SickNoteServiceImplTest {
         final Person person = new Person();
         final Person applier = new Person();
         final SickNoteType sickNoteType = new SickNoteType();
-        final LocalDate startDate = LocalDate.of(2022, 12, 5);
-        final LocalDate endDate = LocalDate.of(2022, 12, 9);
-        final LocalDate aubStartDate = LocalDate.of(2022, 12, 7);
+        final LocalDate startDate = LocalDate.of(2022, DECEMBER, 5);
+        final LocalDate endDate = LocalDate.of(2022, DECEMBER, 9);
+        final LocalDate aubStartDate = LocalDate.of(2022, DECEMBER, 7);
 
         when(sickNoteRepository.save(any(SickNoteEntity.class))).thenAnswer(returnsFirstArg());
 
@@ -77,7 +80,7 @@ class SickNoteServiceImplTest {
             .dayLength(DayLength.FULL)
             .aubStartDate(aubStartDate)
             .aubEndDate(endDate)
-            .lastEdited(LocalDate.of(2022, 12, 5))
+            .lastEdited(LocalDate.of(2022, DECEMBER, 5))
             .endOfSickPayNotificationSend(endDate)
             .status(ACTIVE)
             .build();
@@ -303,8 +306,8 @@ class SickNoteServiceImplTest {
     void getSickNotesReachingEndOfSickPay() {
 
         final Person person = new Person();
-        final LocalDate startDate = LocalDate.of(2022, 12, 5);
-        final LocalDate endDate = LocalDate.of(2022, 12, 9);
+        final LocalDate startDate = LocalDate.of(2022, DECEMBER, 5);
+        final LocalDate endDate = LocalDate.of(2022, DECEMBER, 9);
 
         final SickNoteEntity entity = new SickNoteEntity();
         entity.setId(1L);
@@ -321,7 +324,7 @@ class SickNoteServiceImplTest {
         settings.setSickNoteSettings(sickNoteSettings);
         when(settingsService.getSettings()).thenReturn(settings);
 
-        when(sickNoteRepository.findSickNotesToNotifyForSickPayEnd(5, 2, LocalDate.of(2021, 6, 28)))
+        when(sickNoteRepository.findSickNotesToNotifyForSickPayEnd(5, 2, LocalDate.of(2021, JUNE, 28)))
             .thenReturn(List.of(entity));
 
         final SickNote sickNote = SickNote.builder().build();
@@ -409,7 +412,7 @@ class SickNoteServiceImplTest {
 
         final List<Person> persons = List.of(person);
         final List<SickNoteStatus> openSickNoteStatuses = List.of(ACTIVE);
-        final LocalDate since = LocalDate.of(2020, 10, 3);
+        final LocalDate since = LocalDate.of(2020, OCTOBER, 3);
 
         when(sickNoteRepository.findByStatusInAndPersonInAndEndDateIsGreaterThanEqual(openSickNoteStatuses, persons, since))
             .thenReturn(List.of(entity));

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewControllerTest.java
@@ -49,6 +49,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 
+import static java.time.Month.FEBRUARY;
+import static java.time.Month.JANUARY;
 import static java.util.List.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -815,8 +817,8 @@ class SickNoteViewControllerTest {
         final Person somePerson = new Person();
         when(personService.getSignedInUser()).thenReturn(somePerson);
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
-            .startDate(LocalDate.of(2025, 2, 10))
-            .endDate(LocalDate.of(2025, 2, 20)).person(somePerson).build()));
+            .startDate(LocalDate.of(2025, FEBRUARY, 10))
+            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(somePerson).build()));
         perform(get("/web/sicknote/15")).andExpect(status().isOk());
     }
 
@@ -828,8 +830,8 @@ class SickNoteViewControllerTest {
         final Person officePerson = personWithRole(OFFICE);
         when(personService.getSignedInUser()).thenReturn(officePerson);
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
-            .startDate(LocalDate.of(2025, 2, 10))
-            .endDate(LocalDate.of(2025, 2, 20))
+            .startDate(LocalDate.of(2025, FEBRUARY, 10))
+            .endDate(LocalDate.of(2025, FEBRUARY, 20))
             .person(new Person()).build()));
 
         perform(get("/web/sicknote/15")).andExpect(status().isOk());
@@ -861,8 +863,8 @@ class SickNoteViewControllerTest {
         person.setPermissions(List.of(USER, DEPARTMENT_HEAD));
         person.setId(2L);
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
-            .startDate(LocalDate.of(2025, 2, 10))
-            .endDate(LocalDate.of(2025, 2, 20)).person(person).build()));
+            .startDate(LocalDate.of(2025, FEBRUARY, 10))
+            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).build()));
 
         perform(get("/web/sicknote/15")).andExpect(status().isOk());
     }
@@ -881,8 +883,8 @@ class SickNoteViewControllerTest {
         person.setPermissions(List.of(USER, DEPARTMENT_HEAD));
         person.setId(2L);
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
-            .startDate(LocalDate.of(2025, 2, 10))
-            .endDate(LocalDate.of(2025, 2, 20)).person(person).build()));
+            .startDate(LocalDate.of(2025, FEBRUARY, 10))
+            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).build()));
         when(departmentService.isDepartmentHeadAllowedToManagePerson(departmentHeadPerson, person)).thenReturn(true);
 
         perform(get("/web/sicknote/15")).andExpect(status().isOk());
@@ -902,8 +904,8 @@ class SickNoteViewControllerTest {
         person.setPermissions(List.of(USER, DEPARTMENT_HEAD));
         person.setId(2L);
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
-            .startDate(LocalDate.of(2025, 2, 10))
-            .endDate(LocalDate.of(2025, 2, 20)).person(person).build()));
+            .startDate(LocalDate.of(2025, FEBRUARY, 10))
+            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).build()));
         when(departmentService.isDepartmentHeadAllowedToManagePerson(departmentHeadPerson, person)).thenReturn(true);
 
         perform(get("/web/sicknote/15")).andExpect(status().isOk());
@@ -936,8 +938,8 @@ class SickNoteViewControllerTest {
         final Person person = personWithRole(USER);
         person.setId(2L);
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
-            .startDate(LocalDate.of(2025, 2, 10))
-            .endDate(LocalDate.of(2025, 2, 20)).person(person).build()));
+            .startDate(LocalDate.of(2025, FEBRUARY, 10))
+            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).build()));
         when(departmentService.isSecondStageAuthorityAllowedToManagePerson(secondStageAuthority, person)).thenReturn(true);
 
         perform(get("/web/sicknote/15")).andExpect(status().isOk());
@@ -954,8 +956,8 @@ class SickNoteViewControllerTest {
         final Person person = personWithRole(USER);
         person.setId(2L);
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
-            .startDate(LocalDate.of(2025, 2, 10))
-            .endDate(LocalDate.of(2025, 2, 20)).person(person).build()));
+            .startDate(LocalDate.of(2025, FEBRUARY, 10))
+            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).build()));
         when(departmentService.isSecondStageAuthorityAllowedToManagePerson(secondStageAuthority, person)).thenReturn(true);
 
         perform(get("/web/sicknote/15")).andExpect(status().isOk());
@@ -1005,8 +1007,8 @@ class SickNoteViewControllerTest {
 
         final Person person = new Person();
         final SickNote sickNote = SickNote.builder()
-            .startDate(LocalDate.of(2019, 1, 1))
-            .endDate(LocalDate.of(2019, 2, 24))
+            .startDate(LocalDate.of(2019, JANUARY, 1))
+            .endDate(LocalDate.of(2019, FEBRUARY, 24))
             .person(person)
             .status(ACTIVE)
             .build();
@@ -1022,7 +1024,7 @@ class SickNoteViewControllerTest {
 
         perform(get("/web/sicknote/15"))
             .andExpect(model().attribute("sickNote", instanceOf(SickNote.class)))
-            .andExpect(model().attribute("sickPayDaysEndDate", LocalDate.of(2019, 2, 11)))
+            .andExpect(model().attribute("sickPayDaysEndDate", LocalDate.of(2019, FEBRUARY, 11)))
             .andExpect(model().attribute("doesSickPayDaysEnd", true))
             .andExpect(model().attribute("numberSickPayDaysSinceEnd", ChronoUnit.DAYS.between(sickPayDaysEndDate, LocalDate.now()) + 1))
             .andExpect(view().name("sicknote/sick_note_detail"));
@@ -1036,8 +1038,8 @@ class SickNoteViewControllerTest {
 
         final Person person = new Person();
         final SickNote sickNote = SickNote.builder()
-            .startDate(LocalDate.of(2025, 2, 10))
-            .endDate(LocalDate.of(2025, 2, 20))
+            .startDate(LocalDate.of(2025, FEBRUARY, 10))
+            .endDate(LocalDate.of(2025, FEBRUARY, 20))
             .person(person)
             .status(ACTIVE)
             .build();
@@ -1065,8 +1067,8 @@ class SickNoteViewControllerTest {
 
         when(personService.getSignedInUser()).thenReturn(personWithRole(role, SICK_NOTE_VIEW, SICK_NOTE_EDIT));
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
-            .startDate(LocalDate.of(2025, 2, 10))
-            .endDate(LocalDate.of(2025, 2, 20)).person(new Person()).status(ACTIVE).build()));
+            .startDate(LocalDate.of(2025, FEBRUARY, 10))
+            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(new Person()).status(ACTIVE).build()));
         when(sickNoteCommentService.getCommentsBySickNote(any(SickNote.class))).thenReturn(List.of());
 
         perform(get("/web/sicknote/15"))
@@ -1085,8 +1087,8 @@ class SickNoteViewControllerTest {
 
         final Person person = new Person();
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
-            .startDate(LocalDate.of(2025, 2, 10))
-            .endDate(LocalDate.of(2025, 2, 20)).person(person).build()));
+            .startDate(LocalDate.of(2025, FEBRUARY, 10))
+            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).build()));
         when(sickNoteCommentService.getCommentsBySickNote(any(SickNote.class))).thenReturn(List.of());
         when(departmentService.isDepartmentHeadAllowedToManagePerson(departmentHead, person)).thenReturn(true);
 
@@ -1122,8 +1124,8 @@ class SickNoteViewControllerTest {
 
         final Person person = new Person();
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
-            .startDate(LocalDate.of(2025, 2, 10))
-            .endDate(LocalDate.of(2025, 2, 20)).person(person).build()));
+            .startDate(LocalDate.of(2025, FEBRUARY, 10))
+            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).build()));
         when(sickNoteCommentService.getCommentsBySickNote(any(SickNote.class))).thenReturn(List.of());
         when(departmentService.isSecondStageAuthorityAllowedToManagePerson(ssa, person)).thenReturn(true);
 
@@ -1156,8 +1158,8 @@ class SickNoteViewControllerTest {
         when(settingsService.getSettings()).thenReturn(new Settings());
         when(personService.getSignedInUser()).thenReturn(personWithRole(OFFICE));
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
-            .startDate(LocalDate.of(2025, 2, 10))
-            .endDate(LocalDate.of(2025, 2, 20)).person(new Person()).status(ACTIVE).build()));
+            .startDate(LocalDate.of(2025, FEBRUARY, 10))
+            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(new Person()).status(ACTIVE).build()));
         when(sickNoteCommentService.getCommentsBySickNote(any(SickNote.class))).thenReturn(List.of());
 
         perform(get("/web/sicknote/15"))

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendValidatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendValidatorTest.java
@@ -17,6 +17,7 @@ import java.time.LocalDate;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static java.time.Month.AUGUST;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -64,8 +65,8 @@ class SickNoteExtendValidatorTest {
 
     static Stream<Arguments> endDateTuples() {
         return Stream.of(
-            Arguments.of(LocalDate.of(2024, 8, 8), LocalDate.of(2024, 8, 7)),
-            Arguments.of(LocalDate.of(2024, 8, 8), LocalDate.of(2024, 8, 8))
+            Arguments.of(LocalDate.of(2024, AUGUST, 8), LocalDate.of(2024, AUGUST, 7)),
+            Arguments.of(LocalDate.of(2024, AUGUST, 8), LocalDate.of(2024, AUGUST, 8))
         );
     }
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendViewControllerTest.java
@@ -26,6 +26,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import static java.time.Month.SEPTEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -124,7 +125,7 @@ class SickNoteExtendViewControllerTest {
 
         when(personService.getSignedInUser()).thenReturn(person);
 
-        final LocalDate endDate = LocalDate.of(2024, 9, 27);
+        final LocalDate endDate = LocalDate.of(2024, SEPTEMBER, 27);
 
         final SickNote currentActiveSickNote = SickNote.builder()
             .id(1L)
@@ -156,7 +157,7 @@ class SickNoteExtendViewControllerTest {
 
         when(personService.getSignedInUser()).thenReturn(person);
 
-        final LocalDate endDate = LocalDate.of(2024, 9, 27);
+        final LocalDate endDate = LocalDate.of(2024, SEPTEMBER, 27);
 
         final SickNote currentActiveSickNote = SickNote.builder()
             .id(1L)

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtensionServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtensionServiceImplTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.time.Month.AUGUST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
@@ -97,7 +98,7 @@ class SickNoteExtensionServiceImplTest {
             final SickNoteExtensionEntity entity = new SickNoteExtensionEntity();
             entity.setId(1L);
             entity.setSickNoteId(1L);
-            entity.setNewEndDate(LocalDate.of(2024, 8, 23));
+            entity.setNewEndDate(LocalDate.of(2024, AUGUST, 23));
             entity.setStatus(SUBMITTED);
 
             when(repository.findAllBySickNoteIdOrderByCreatedAtDesc(1L)).thenReturn(List.of(entity));
@@ -105,8 +106,8 @@ class SickNoteExtensionServiceImplTest {
             final SickNote sickNote = SickNote.builder()
                 .id(1L)
                 .person(person)
-                .startDate(LocalDate.of(2024, 8, 21))
-                .endDate(LocalDate.of(2024, 8, 22))
+                .startDate(LocalDate.of(2024, AUGUST, 21))
+                .endDate(LocalDate.of(2024, AUGUST, 22))
                 .build();
 
             final DateRange dateRange = new DateRange(sickNote.getStartDate(), entity.getNewEndDate());
@@ -126,7 +127,7 @@ class SickNoteExtensionServiceImplTest {
             final SickNoteExtensionEntity entity = new SickNoteExtensionEntity();
             entity.setId(1L);
             entity.setSickNoteId(1L);
-            entity.setNewEndDate(LocalDate.of(2024, 8, 23));
+            entity.setNewEndDate(LocalDate.of(2024, AUGUST, 23));
             entity.setStatus(SUBMITTED);
 
             when(repository.findAllBySickNoteIdOrderByCreatedAtDesc(1L)).thenReturn(List.of(entity));
@@ -134,14 +135,14 @@ class SickNoteExtensionServiceImplTest {
             final SickNote sickNote = SickNote.builder()
                 .id(1L)
                 .person(person)
-                .startDate(LocalDate.of(2024, 8, 21))
-                .endDate(LocalDate.of(2024, 8, 22))
+                .startDate(LocalDate.of(2024, AUGUST, 21))
+                .endDate(LocalDate.of(2024, AUGUST, 22))
                 .build();
 
             final WorkingTimeCalendar workingTimeCalendar = new WorkingTimeCalendar(Map.of(
-                LocalDate.of(2024, 8, 21), new WorkingTimeCalendar.WorkingDayInformation(DayLength.FULL, WORKDAY, WORKDAY),
-                LocalDate.of(2024, 8, 22), new WorkingTimeCalendar.WorkingDayInformation(DayLength.FULL, WORKDAY, WORKDAY),
-                LocalDate.of(2024, 8, 23), new WorkingTimeCalendar.WorkingDayInformation(DayLength.FULL, WORKDAY, WORKDAY)
+                LocalDate.of(2024, AUGUST, 21), new WorkingTimeCalendar.WorkingDayInformation(DayLength.FULL, WORKDAY, WORKDAY),
+                LocalDate.of(2024, AUGUST, 22), new WorkingTimeCalendar.WorkingDayInformation(DayLength.FULL, WORKDAY, WORKDAY),
+                LocalDate.of(2024, AUGUST, 23), new WorkingTimeCalendar.WorkingDayInformation(DayLength.FULL, WORKDAY, WORKDAY)
             ));
 
             final DateRange dateRange = new DateRange(sickNote.getStartDate(), entity.getNewEndDate());
@@ -151,7 +152,7 @@ class SickNoteExtensionServiceImplTest {
             final Optional<SickNoteExtension> actual = sut.findSubmittedExtensionOfSickNote(sickNote);
             assertThat(actual).hasValueSatisfying(extension -> {
                 assertThat(extension.id()).isEqualTo(1L);
-                assertThat(extension.nextEndDate()).isEqualTo(LocalDate.of(2024, 8, 23));
+                assertThat(extension.nextEndDate()).isEqualTo(LocalDate.of(2024, AUGUST, 23));
                 assertThat(extension.status()).isEqualTo(SUBMITTED);
                 assertThat(extension.additionalWorkdays()).isEqualTo(BigDecimal.ONE);
             });
@@ -257,9 +258,9 @@ class SickNoteExtensionServiceImplTest {
             final Person person = new Person();
             person.setId(1L);
 
-            final LocalDate startDate = LocalDate.of(2024, 8, 21);
-            final LocalDate endDate = LocalDate.of(2024, 8, 22);
-            final LocalDate nextEndDate = LocalDate.of(2024, 8, 23);
+            final LocalDate startDate = LocalDate.of(2024, AUGUST, 21);
+            final LocalDate endDate = LocalDate.of(2024, AUGUST, 22);
+            final LocalDate nextEndDate = LocalDate.of(2024, AUGUST, 23);
 
             final SickNoteExtensionEntity existingEntity = new SickNoteExtensionEntity();
             existingEntity.setId(1L);
@@ -297,9 +298,9 @@ class SickNoteExtensionServiceImplTest {
             final Person person = new Person();
             person.setId(1L);
 
-            final LocalDate startDate = LocalDate.of(2024, 8, 21);
-            final LocalDate endDate = LocalDate.of(2024, 8, 22);
-            final LocalDate nextEndDate = LocalDate.of(2024, 8, 23);
+            final LocalDate startDate = LocalDate.of(2024, AUGUST, 21);
+            final LocalDate endDate = LocalDate.of(2024, AUGUST, 22);
+            final LocalDate nextEndDate = LocalDate.of(2024, AUGUST, 23);
 
             final SickNoteExtensionEntity existingEntity = new SickNoteExtensionEntity();
             existingEntity.setId(1L);
@@ -334,9 +335,9 @@ class SickNoteExtensionServiceImplTest {
             final Person submitter = new Person();
             submitter.setId(1L);
 
-            final LocalDate startDate = LocalDate.of(2024, 8, 21);
-            final LocalDate endDate = LocalDate.of(2024, 8, 22);
-            final LocalDate nextEndDate = LocalDate.of(2024, 8, 23);
+            final LocalDate startDate = LocalDate.of(2024, AUGUST, 21);
+            final LocalDate endDate = LocalDate.of(2024, AUGUST, 22);
+            final LocalDate nextEndDate = LocalDate.of(2024, AUGUST, 23);
 
             final SickNote sickNote = SickNote.builder()
                 .id(1L)
@@ -413,9 +414,9 @@ class SickNoteExtensionServiceImplTest {
             final Person person = new Person();
             person.setId(1L);
 
-            final LocalDate startDate = LocalDate.of(2024, 8, 21);
-            final LocalDate endDate = LocalDate.of(2024, 8, 22);
-            final LocalDate nextEndDate = LocalDate.of(2024, 8, 23);
+            final LocalDate startDate = LocalDate.of(2024, AUGUST, 21);
+            final LocalDate endDate = LocalDate.of(2024, AUGUST, 22);
+            final LocalDate nextEndDate = LocalDate.of(2024, AUGUST, 23);
 
             final SickNote sickNote = SickNote.builder()
                 .id(1L)

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SubmittedSickNoteServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SubmittedSickNoteServiceImplTest.java
@@ -23,6 +23,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
+import static java.time.Month.AUGUST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -91,9 +92,9 @@ class SubmittedSickNoteServiceImplTest {
             final Person person = new Person();
             person.setId(1L);
 
-            final LocalDate startDate = LocalDate.of(2024, 8, 21);
-            final LocalDate endDate = LocalDate.of(2024, 8, 22);
-            final LocalDate nextEndDate = LocalDate.of(2024, 8, 23);
+            final LocalDate startDate = LocalDate.of(2024, AUGUST, 21);
+            final LocalDate endDate = LocalDate.of(2024, AUGUST, 22);
+            final LocalDate nextEndDate = LocalDate.of(2024, AUGUST, 23);
 
             when(sickNoteService.getForStatesAndPerson(List.of(SickNoteStatus.SUBMITTED), List.of(person)))
                 .thenReturn(List.of());
@@ -143,9 +144,9 @@ class SubmittedSickNoteServiceImplTest {
             final Person person = new Person();
             person.setId(1L);
 
-            final LocalDate startDate = LocalDate.of(2024, 8, 21);
-            final LocalDate endDate = LocalDate.of(2024, 8, 22);
-            final LocalDate nextEndDate = LocalDate.of(2024, 8, 23);
+            final LocalDate startDate = LocalDate.of(2024, AUGUST, 21);
+            final LocalDate endDate = LocalDate.of(2024, AUGUST, 22);
+            final LocalDate nextEndDate = LocalDate.of(2024, AUGUST, 23);
 
             when(sickNoteService.getForStatesAndPerson(List.of(SickNoteStatus.SUBMITTED), List.of(person)))
                 .thenReturn(List.of());
@@ -196,9 +197,9 @@ class SubmittedSickNoteServiceImplTest {
             final Person person = new Person();
             person.setId(1L);
 
-            final LocalDate startDate = LocalDate.of(2024, 8, 21);
-            final LocalDate endDate = LocalDate.of(2024, 8, 22);
-            final LocalDate nextEndDate = LocalDate.of(2024, 8, 23);
+            final LocalDate startDate = LocalDate.of(2024, AUGUST, 21);
+            final LocalDate endDate = LocalDate.of(2024, AUGUST, 22);
+            final LocalDate nextEndDate = LocalDate.of(2024, AUGUST, 23);
 
             final SickNote sickNote = SickNote.builder()
                 .id(1L)

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/statistics/SickNoteStatisticsServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/statistics/SickNoteStatisticsServiceTest.java
@@ -22,6 +22,9 @@ import java.util.List;
 import java.util.Map;
 
 import static java.math.BigDecimal.valueOf;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
+import static java.time.Month.OCTOBER;
 import static java.time.temporal.TemporalAdjusters.lastDayOfYear;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -76,7 +79,7 @@ class SickNoteStatisticsServiceTest {
         final List<Person> members = List.of(member1, member2);
         when(departmentService.getManagedMembersOfPerson(departmentHead, year)).thenReturn(members);
 
-        final LocalDate date = LocalDate.of(year.getValue(), 10, 10);
+        final LocalDate date = LocalDate.of(year.getValue(), OCTOBER, 10);
 
         final LocalDate firstDayOfYear = year.atDay(1);
         final LocalDate lastDayOfYear = firstDayOfYear.with(lastDayOfYear());
@@ -133,7 +136,7 @@ class SickNoteStatisticsServiceTest {
         final List<Person> members = List.of(member1, member2);
         when(departmentService.getManagedMembersOfPerson(secondStageAuthPerson, year)).thenReturn(members);
 
-        final LocalDate date = LocalDate.of(year.getValue(), 10, 10);
+        final LocalDate date = LocalDate.of(year.getValue(), OCTOBER, 10);
 
         final LocalDate firstDayOfYear = year.atDay(1);
         final LocalDate lastDayOfYear = firstDayOfYear.with(lastDayOfYear());
@@ -188,9 +191,9 @@ class SickNoteStatisticsServiceTest {
 
         when(personService.getAllPersonsHavingAccountInYear(year)).thenReturn(List.of(personWithRole, person));
 
-        final LocalDate from = LocalDate.of(year.getValue(), 1, 1);
-        final LocalDate to = LocalDate.of(year.getValue(), 12, 31);
-        final LocalDate date = LocalDate.of(year.getValue(), 10, 10);
+        final LocalDate from = LocalDate.of(year.getValue(), JANUARY, 1);
+        final LocalDate to = LocalDate.of(year.getValue(), DECEMBER, 31);
+        final LocalDate date = LocalDate.of(year.getValue(), OCTOBER, 10);
 
         final SickNote sickNote = SickNote.builder()
             .person(person)
@@ -242,14 +245,14 @@ class SickNoteStatisticsServiceTest {
 
         when(personService.getAllPersonsHavingAccountInYear(year)).thenReturn(List.of(office, person));
 
-        final LocalDate from = LocalDate.of(2022, 1, 1);
-        final LocalDate to = LocalDate.of(2022, 12, 31);
+        final LocalDate from = LocalDate.of(2022, JANUARY, 1);
+        final LocalDate to = LocalDate.of(2022, DECEMBER, 31);
 
         final SickNote sickNote = SickNote.builder()
             .person(person)
             .sickNoteType(sickNoteType(SickNoteCategory.SICK_NOTE))
-            .startDate(LocalDate.of(year.getValue(), 10, 10))
-            .endDate(LocalDate.of(year.getValue(), 10, 10))
+            .startDate(LocalDate.of(year.getValue(), OCTOBER, 10))
+            .endDate(LocalDate.of(year.getValue(), OCTOBER, 10))
             .dayLength(FULL)
             .workingTimeCalendar(workingTimeCalendarMondayToSunday(from, to))
             .build();
@@ -278,14 +281,14 @@ class SickNoteStatisticsServiceTest {
         user.setId(1L);
         user.setPermissions(List.of(USER, SICK_NOTE_VIEW));
 
-        final LocalDate from = LocalDate.of(2022, 1, 1);
-        final LocalDate to = LocalDate.of(2022, 12, 31);
+        final LocalDate from = LocalDate.of(2022, JANUARY, 1);
+        final LocalDate to = LocalDate.of(2022, DECEMBER, 31);
 
         final SickNote sickNote = SickNote.builder()
             .person(user)
             .sickNoteType(sickNoteType(SickNoteCategory.SICK_NOTE))
-            .startDate(LocalDate.of(year.getValue(), 10, 10))
-            .endDate(LocalDate.of(year.getValue(), 10, 10))
+            .startDate(LocalDate.of(year.getValue(), OCTOBER, 10))
+            .endDate(LocalDate.of(year.getValue(), OCTOBER, 10))
             .dayLength(FULL)
             .workingTimeCalendar(workingTimeCalendarMondayToSunday(from, to))
             .build();
@@ -333,10 +336,10 @@ class SickNoteStatisticsServiceTest {
 
         when(personService.getAllPersonsHavingAccountInYear(year)).thenReturn(List.of(office, person));
 
-        final LocalDate from = LocalDate.of(2022, 1, 1);
-        final LocalDate to = LocalDate.of(2022, 12, 31);
-        final LocalDate sickNoteStart = LocalDate.of(2022, 1, 10);
-        final LocalDate sickNoteEnd = LocalDate.of(2022, 1, 11);
+        final LocalDate from = LocalDate.of(2022, JANUARY, 1);
+        final LocalDate to = LocalDate.of(2022, DECEMBER, 31);
+        final LocalDate sickNoteStart = LocalDate.of(2022, JANUARY, 10);
+        final LocalDate sickNoteEnd = LocalDate.of(2022, JANUARY, 11);
 
         // only the two sick note dates are target work days for `person`, `office` has none at all
         // --> target work days in January == sick days in January

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/statistics/SickNoteStatisticsTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/statistics/SickNoteStatisticsTest.java
@@ -24,6 +24,7 @@ import static java.math.RoundingMode.HALF_UP;
 import static java.time.LocalDate.of;
 import static java.time.Month.DECEMBER;
 import static java.time.Month.JANUARY;
+import static java.time.Month.JULY;
 import static java.time.Month.OCTOBER;
 import static java.util.Arrays.stream;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,7 +65,7 @@ class SickNoteStatisticsTest {
                 .build();
 
             final Year year = Year.of(2022);
-            final LocalDate asOfDate = LocalDate.of(2022, 10, 17);
+            final LocalDate asOfDate = LocalDate.of(2022, OCTOBER, 17);
             final SickNoteStatistics sut = new SickNoteStatistics(year, asOfDate, List.of(sickNote1, sickNote2), List.of());
 
             assertThat(sut.getTotalNumberOfAllSickNotes()).isEqualTo(2);
@@ -97,7 +98,7 @@ class SickNoteStatisticsTest {
             .build();
 
         final Year year = Year.of(2022);
-        final LocalDate asOfDate = LocalDate.of(2022, 10, 17);
+        final LocalDate asOfDate = LocalDate.of(2022, OCTOBER, 17);
         final SickNoteStatistics sut = new SickNoteStatistics(year, asOfDate, List.of(sickNote1, sickNote2), List.of());
 
         assertThat(sut.getTotalNumberOfSickNotes()).isEqualTo(BigDecimal.valueOf(2));
@@ -136,7 +137,7 @@ class SickNoteStatisticsTest {
                 .build();
 
             final Year year = Year.of(2022);
-            final LocalDate asOfDate = LocalDate.of(2022, 10, 17);
+            final LocalDate asOfDate = LocalDate.of(2022, OCTOBER, 17);
             final SickNoteStatistics sut = new SickNoteStatistics(year, asOfDate, List.of(sickNote1, sickNote2), List.of(person));
 
             assertThat(sut.getAverageDurationOfAllSickNotes()).isEqualTo(valueOf(6.50).setScale(2, HALF_UP));
@@ -175,7 +176,7 @@ class SickNoteStatisticsTest {
             .build();
 
         final Year year = Year.of(2022);
-        final LocalDate asOfDate = LocalDate.of(2022, 10, 17);
+        final LocalDate asOfDate = LocalDate.of(2022, OCTOBER, 17);
         final SickNoteStatistics sut = new SickNoteStatistics(year, asOfDate, List.of(sickNote, sickNoteChild), List.of());
 
         assertThat(sut.getTotalNumberOfSickDaysAllCategories()).isEqualTo(BigDecimal.valueOf(13));
@@ -216,7 +217,7 @@ class SickNoteStatisticsTest {
                 .build();
 
             final Year year = Year.of(2022);
-            final LocalDate asOfDate = LocalDate.of(2022, 10, 17);
+            final LocalDate asOfDate = LocalDate.of(2022, OCTOBER, 17);
             final SickNoteStatistics sut = new SickNoteStatistics(year, asOfDate, List.of(sickNote1, sickNote2), List.of(person, person2));
 
             // 2 sick notes: 1st with 3 workdays and 2nd with 10 workdays in year of statistic --> sum = 13 workdays
@@ -228,7 +229,7 @@ class SickNoteStatisticsTest {
         @Test
         void testGetAverageDurationOfDiseasePerPersonDivisionByZero() {
             final Year year = Year.of(2022);
-            final LocalDate asOfDate = LocalDate.of(2022, 10, 17);
+            final LocalDate asOfDate = LocalDate.of(2022, OCTOBER, 17);
             final SickNoteStatistics sut = new SickNoteStatistics(year, asOfDate, List.of(), List.of());
 
             final BigDecimal averageDurationOfDiseasePerPerson = sut.getAverageDurationOfDiseasePerPerson();
@@ -255,7 +256,7 @@ class SickNoteStatisticsTest {
                 .build();
 
             final Year year = Year.of(2015);
-            final LocalDate asOfDate = LocalDate.of(2015, 10, 17);
+            final LocalDate asOfDate = LocalDate.of(2015, OCTOBER, 17);
             final SickNoteStatistics sut = new SickNoteStatistics(year, asOfDate, List.of(sickNote), List.of(person));
 
             // 2015 has 261 monday to friday workdays
@@ -294,7 +295,7 @@ class SickNoteStatisticsTest {
                 .build();
 
             final Year year = Year.of(2022);
-            final LocalDate asOfDate = LocalDate.of(2022, 10, 17);
+            final LocalDate asOfDate = LocalDate.of(2022, OCTOBER, 17);
             final SickNoteStatistics sut = new SickNoteStatistics(year, asOfDate, List.of(sickNote1, sickNote2), List.of(person, person2));
 
             assertThat(sut.getAverageDurationOfDiseasePerPerson()).isEqualByComparingTo(valueOf(6.5));
@@ -339,7 +340,7 @@ class SickNoteStatisticsTest {
                 .build();
 
             final Year year = Year.of(2022);
-            final LocalDate asOfDate = LocalDate.of(2022, 10, 17);
+            final LocalDate asOfDate = LocalDate.of(2022, OCTOBER, 17);
             final SickNoteStatistics sut = new SickNoteStatistics(year, asOfDate, List.of(sickNote1, sickNote2), List.of(person, person2, person3));
 
             assertThat(sut.getNumberOfPersonsWithMinimumOneSickNote()).isEqualTo(2L);
@@ -383,7 +384,7 @@ class SickNoteStatisticsTest {
                 .build();
 
             final Year year = Year.of(2022);
-            final LocalDate asOfDate = LocalDate.of(2022, 10, 17);
+            final LocalDate asOfDate = LocalDate.of(2022, OCTOBER, 17);
             final SickNoteStatistics sut = new SickNoteStatistics(year, asOfDate, List.of(sickNote1, sickNote2), List.of(person, person2));
 
             assertThat(sut.getTotalNumberOfSickDaysAllCategories()).isEqualTo(valueOf(13));
@@ -433,7 +434,7 @@ class SickNoteStatisticsTest {
                 .build();
 
             final Year year = Year.of(2025);
-            final LocalDate asOfDate = LocalDate.of(2022, 7, 4);
+            final LocalDate asOfDate = LocalDate.of(2022, JULY, 4);
             final SickNoteStatistics sut = new SickNoteStatistics(year, asOfDate, List.of(sickNote, sickNote2, childSickNote), List.of());
             assertThat(sut.getNumberOfSickDaysByMonth()).isEqualTo(stream(Month.values()).map(month -> month.equals(givenMonth) ? valueOf(2) : ZERO).toList());
         }
@@ -444,15 +445,15 @@ class SickNoteStatisticsTest {
 
             final SickNote childSickNote = SickNote.builder(SickNote.builder()
                 .person(person)
-                .startDate(of(2025, 1, 1))
-                .endDate(of(2025, 1, 2))
+                .startDate(of(2025, JANUARY, 1))
+                .endDate(of(2025, JANUARY, 2))
                 .dayLength(FULL)
                 .sickNoteType(sickNoteType())
                 .status(ACTIVE)
                 .build()).sickNoteType(childSickNoteType()).build();
 
             final Year year = Year.of(2025);
-            final LocalDate asOfDate = LocalDate.of(2025, 7, 4);
+            final LocalDate asOfDate = LocalDate.of(2025, JULY, 4);
 
             final SickNoteStatistics sut = new SickNoteStatistics(year, asOfDate, List.of(childSickNote), List.of());
             assertThat(sut.getNumberOfSickDaysByMonth()).isEqualTo(List.of(ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO));
@@ -478,7 +479,7 @@ class SickNoteStatisticsTest {
                 .build();
 
             final Year year = Year.of(2025);
-            final LocalDate asOfDate = LocalDate.of(2025, 7, 4);
+            final LocalDate asOfDate = LocalDate.of(2025, JULY, 4);
             final SickNoteStatistics sut = new SickNoteStatistics(year, asOfDate, List.of(sickNote), List.of());
             assertThat(sut.getNumberOfSickDaysByMonth()).isEqualTo(List.of(valueOf(1), valueOf(2), ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO));
         }
@@ -511,7 +512,7 @@ class SickNoteStatisticsTest {
                 .build();
 
             final Year year = Year.of(2025);
-            final LocalDate asOfDate = LocalDate.of(2025, 7, 4);
+            final LocalDate asOfDate = LocalDate.of(2025, JULY, 4);
             final SickNoteStatistics sut = new SickNoteStatistics(year, asOfDate, List.of(sickNote), List.of(person), Map.of(person, workingTimeCalendar));
 
             // two sick days and two target work days in givenMonth --> (2 / 2) * 100 = 100%, zero elsewhere
@@ -527,15 +528,15 @@ class SickNoteStatisticsTest {
             // person only has target work days on Jan 1-2, person2 only on Jan 3-5
             final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(
                 LocalDate.parse("2025-01-01"), LocalDate.parse("2025-12-31"),
-                date -> !date.isBefore(of(2025, 1, 1)) && !date.isAfter(of(2025, 1, 2)));
+                date -> !date.isBefore(of(2025, JANUARY, 1)) && !date.isAfter(of(2025, JANUARY, 2)));
             final WorkingTimeCalendar workingTimeCalendar2 = workingTimeCalendarMondayToSunday(
                 LocalDate.parse("2025-01-01"), LocalDate.parse("2025-12-31"),
-                date -> !date.isBefore(of(2025, 1, 3)) && !date.isAfter(of(2025, 1, 5)));
+                date -> !date.isBefore(of(2025, JANUARY, 3)) && !date.isAfter(of(2025, JANUARY, 5)));
 
             final SickNote sickNote = SickNote.builder()
                 .person(person)
-                .startDate(of(2025, 1, 1))
-                .endDate(of(2025, 1, 2))
+                .startDate(of(2025, JANUARY, 1))
+                .endDate(of(2025, JANUARY, 2))
                 .dayLength(FULL)
                 .sickNoteType(sickNoteType())
                 .status(ACTIVE)
@@ -544,8 +545,8 @@ class SickNoteStatisticsTest {
 
             final SickNote childSickNote = SickNote.builder()
                 .person(person2)
-                .startDate(of(2025, 1, 3))
-                .endDate(of(2025, 1, 5))
+                .startDate(of(2025, JANUARY, 3))
+                .endDate(of(2025, JANUARY, 5))
                 .dayLength(FULL)
                 .sickNoteType(childSickNoteType())
                 .status(ACTIVE)
@@ -553,7 +554,7 @@ class SickNoteStatisticsTest {
                 .build();
 
             final Year year = Year.of(2025);
-            final LocalDate asOfDate = LocalDate.of(2025, 7, 4);
+            final LocalDate asOfDate = LocalDate.of(2025, JULY, 4);
             final Map<Person, WorkingTimeCalendar> workingTimeCalendarsByPerson = Map.of(person, workingTimeCalendar, person2, workingTimeCalendar2);
             final SickNoteStatistics sut = new SickNoteStatistics(year, asOfDate, List.of(sickNote, childSickNote), List.of(person, person2), workingTimeCalendarsByPerson);
 
@@ -569,12 +570,12 @@ class SickNoteStatisticsTest {
             // only person has target work days on Jan 1-2, personWithoutCalendar has no entry in the map at all
             final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(
                 LocalDate.parse("2025-01-01"), LocalDate.parse("2025-12-31"),
-                date -> !date.isBefore(of(2025, 1, 1)) && !date.isAfter(of(2025, 1, 2)));
+                date -> !date.isBefore(of(2025, JANUARY, 1)) && !date.isAfter(of(2025, JANUARY, 2)));
 
             final SickNote sickNote = SickNote.builder()
                 .person(person)
-                .startDate(of(2025, 1, 1))
-                .endDate(of(2025, 1, 2))
+                .startDate(of(2025, JANUARY, 1))
+                .endDate(of(2025, JANUARY, 2))
                 .dayLength(FULL)
                 .sickNoteType(sickNoteType())
                 .status(ACTIVE)
@@ -582,7 +583,7 @@ class SickNoteStatisticsTest {
                 .build();
 
             final Year year = Year.of(2025);
-            final LocalDate asOfDate = LocalDate.of(2025, 7, 4);
+            final LocalDate asOfDate = LocalDate.of(2025, JULY, 4);
             final Map<Person, WorkingTimeCalendar> workingTimeCalendarsByPerson = Map.of(person, workingTimeCalendar);
             final SickNoteStatistics sut = new SickNoteStatistics(year, asOfDate, List.of(sickNote), List.of(person, personWithoutCalendar), workingTimeCalendarsByPerson);
 
@@ -598,8 +599,8 @@ class SickNoteStatisticsTest {
 
             final SickNote sickNote = SickNote.builder()
                 .person(person)
-                .startDate(of(2025, 1, 1))
-                .endDate(of(2025, 1, 2))
+                .startDate(of(2025, JANUARY, 1))
+                .endDate(of(2025, JANUARY, 2))
                 .dayLength(FULL)
                 .sickNoteType(sickNoteType())
                 .status(ACTIVE)
@@ -607,7 +608,7 @@ class SickNoteStatisticsTest {
                 .build();
 
             final Year year = Year.of(2025);
-            final LocalDate asOfDate = LocalDate.of(2025, 7, 4);
+            final LocalDate asOfDate = LocalDate.of(2025, JULY, 4);
             final SickNoteStatistics sut = new SickNoteStatistics(year, asOfDate, List.of(sickNote), List.of());
 
             assertThat(sut.getSickRateByMonth()).allMatch(rate -> rate.compareTo(ZERO) == 0);

--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/OverviewCalendarUIIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/OverviewCalendarUIIT.java
@@ -52,6 +52,8 @@ import static java.time.DayOfWeek.TUESDAY;
 import static java.time.DayOfWeek.WEDNESDAY;
 import static java.time.Month.APRIL;
 import static java.time.Month.DECEMBER;
+import static java.time.Month.FEBRUARY;
+import static java.time.Month.MARCH;
 import static java.util.Locale.GERMAN;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.util.StringUtils.trimAllWhitespace;
@@ -78,7 +80,7 @@ class OverviewCalendarUIIT {
         keycloak.configureSpringDataSource(registry);
     }
 
-    private static final LocalDate FIXED_DATE = LocalDate.of(2022, 2, 5);
+    private static final LocalDate FIXED_DATE = LocalDate.of(2022, FEBRUARY, 5);
 
     @TestConfiguration
     static class Configuration {
@@ -125,7 +127,7 @@ class OverviewCalendarUIIT {
         assertThat(page).hasTitle(overviewPage.getExpectedPageTitle(officePerson.getNiceName(), FIXED_DATE.getYear()));
 
         // Click on a day in the next month
-        final LocalDate date = LocalDate.of(2022, 3, 15);
+        final LocalDate date = LocalDate.of(2022, MARCH, 15);
         overviewPage.clickDay(date);
 
         // Ensure navigation to ApplicationPage
@@ -154,8 +156,8 @@ class OverviewCalendarUIIT {
         assertThat(page).hasTitle(overviewPage.getExpectedPageTitle(officePerson.getNiceName(), FIXED_DATE.getYear()));
 
         // Select a range of 3 days (Tuesday to Thursday) in the next month
-        final LocalDate startDate = LocalDate.of(2022, 3, 8);
-        final LocalDate endDate = LocalDate.of(2022, 3, 10);
+        final LocalDate startDate = LocalDate.of(2022, MARCH, 8);
+        final LocalDate endDate = LocalDate.of(2022, MARCH, 10);
 
         overviewPage.selectDateRange(startDate, endDate);
         overviewPage.clickDay(endDate);

--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/PersonsUIIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/PersonsUIIT.java
@@ -147,7 +147,7 @@ class PersonsUIIT {
         final String userId = keycloak.createUser(email, firstName, lastName, email, email);
         final Person savedPerson = personService.create(userId, firstName, lastName, email, List.of(), roles);
 
-        final LocalDate validFrom = LocalDate.of(2022, 1, 1);
+        final LocalDate validFrom = LocalDate.of(2022, JANUARY, 1);
         final List<Integer> workingDays = Stream.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY).map(DayOfWeek::getValue).toList();
         workingTimeWriteService.touch(workingDays, validFrom, savedPerson);
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/SickNoteUIIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/SickNoteUIIT.java
@@ -324,7 +324,7 @@ class SickNoteUIIT {
         final String userId = keycloak.createUser(email, firstName, lastName, email, email);
         final Person savedPerson = personService.create(userId, firstName, lastName, email, List.of(), roles);
 
-        final LocalDate validFrom = LocalDate.of(2022, 1, 1);
+        final LocalDate validFrom = LocalDate.of(2022, JANUARY, 1);
         final List<Integer> workingDays = Stream.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY).map(DayOfWeek::getValue).toList();
         workingTimeWriteService.touch(workingDays, validFrom, savedPerson);
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/util/DateUtilTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/util/DateUtilTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 
+import static java.time.Month.DECEMBER;
+import static java.time.Month.NOVEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
@@ -16,7 +18,7 @@ class DateUtilTest {
     void ensureReturnsTrueIfGivenDayIsAWorkDay() {
 
         // Monday
-        LocalDate date = LocalDate.of(2011, 12, 26);
+        LocalDate date = LocalDate.of(2011, DECEMBER, 26);
 
         boolean returnValue = DateUtil.isWorkDay(date);
 
@@ -27,7 +29,7 @@ class DateUtilTest {
     void ensureReturnsFalseIfGivenDayIsNotAWorkDay() {
 
         // Sunday
-        LocalDate date = LocalDate.of(2014, 11, 23);
+        LocalDate date = LocalDate.of(2014, NOVEMBER, 23);
 
         boolean returnValue = DateUtil.isWorkDay(date);
 
@@ -37,7 +39,7 @@ class DateUtilTest {
     @Test
     void ensureReturnsTrueForChristmasEve() {
 
-        LocalDate date = LocalDate.of(2011, 12, 24);
+        LocalDate date = LocalDate.of(2011, DECEMBER, 24);
 
         boolean returnValue = DateUtil.isChristmasEve(date);
 
@@ -47,7 +49,7 @@ class DateUtilTest {
     @Test
     void ensureReturnsFalseForNotChristmasEve() {
 
-        LocalDate date = LocalDate.of(2011, 12, 25);
+        LocalDate date = LocalDate.of(2011, DECEMBER, 25);
 
         boolean returnValue = DateUtil.isChristmasEve(date);
 
@@ -57,7 +59,7 @@ class DateUtilTest {
     @Test
     void ensureReturnsTrueForNewYearsEve() {
 
-        LocalDate date = LocalDate.of(2014, 12, 31);
+        LocalDate date = LocalDate.of(2014, DECEMBER, 31);
 
         boolean returnValue = DateUtil.isNewYearsEve(date);
 
@@ -67,7 +69,7 @@ class DateUtilTest {
     @Test
     void ensureReturnsFalseForNotNewYearsEve() {
 
-        LocalDate date = LocalDate.of(2011, 12, 25);
+        LocalDate date = LocalDate.of(2011, DECEMBER, 25);
 
         boolean returnValue = DateUtil.isNewYearsEve(date);
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/vacations/VacationApiControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/vacations/VacationApiControllerTest.java
@@ -23,6 +23,10 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.time.LocalDate.of;
+import static java.time.Month.APRIL;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JANUARY;
+import static java.time.Month.MAY;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -60,14 +64,14 @@ class VacationApiControllerTest {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         final Application allowedVacation = createApplication(person,
-            LocalDate.of(2016, 5, 19), LocalDate.of(2016, 5, 20), FULL, new StaticMessageSource());
+            LocalDate.of(2016, MAY, 19), LocalDate.of(2016, MAY, 20), FULL, new StaticMessageSource());
         allowedVacation.setStatus(ALLOWED);
 
         final Application cancellationRequestedVacation = createApplication(person,
-            LocalDate.of(2016, 4, 5), LocalDate.of(2016, 4, 10), FULL, new StaticMessageSource());
+            LocalDate.of(2016, APRIL, 5), LocalDate.of(2016, APRIL, 10), FULL, new StaticMessageSource());
         cancellationRequestedVacation.setStatus(ALLOWED_CANCELLATION_REQUESTED);
 
-        when(applicationService.getForStatesAndPerson(ApplicationStatus.activeStatuses(), List.of(person), LocalDate.of(2016, 1, 1), LocalDate.of(2016, 12, 31)))
+        when(applicationService.getForStatesAndPerson(ApplicationStatus.activeStatuses(), List.of(person), LocalDate.of(2016, JANUARY, 1), LocalDate.of(2016, DECEMBER, 31)))
             .thenReturn(List.of(allowedVacation, cancellationRequestedVacation));
 
         when(personService.getPersonByID(23L)).thenReturn(Optional.of(person));
@@ -165,13 +169,13 @@ class VacationApiControllerTest {
         when(personService.getPersonByID(23L)).thenReturn(Optional.of(person));
 
         final Application vacationAllowed = createApplication(new Person("muster", "Muster", "Marlene", "muster@example.org"),
-            of(2016, 5, 19), of(2016, 5, 20), FULL, new StaticMessageSource());
+            of(2016, MAY, 19), of(2016, MAY, 20), FULL, new StaticMessageSource());
         vacationAllowed.setStatus(ALLOWED);
         final Application vacationAllowedCancelRequested = createApplication(new Person("muster", "Muster", "Marlene", "muster@example.org"),
-            of(2016, 5, 19), of(2016, 5, 20), FULL, new StaticMessageSource());
+            of(2016, MAY, 19), of(2016, MAY, 20), FULL, new StaticMessageSource());
         vacationAllowed.setStatus(ALLOWED_CANCELLATION_REQUESTED);
 
-        when(departmentService.getApplicationsFromColleaguesOf(person, LocalDate.of(2016, 1, 1), LocalDate.of(2016, 12, 31)))
+        when(departmentService.getApplicationsFromColleaguesOf(person, LocalDate.of(2016, JANUARY, 1), LocalDate.of(2016, DECEMBER, 31)))
             .thenReturn(List.of(vacationAllowedCancelRequested, vacationAllowed));
 
         perform(get("/api/persons/23/vacations")

--- a/src/test/java/org/synyx/urlaubsverwaltung/web/DateAndTimeFormatAwareTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/web/DateAndTimeFormatAwareTest.java
@@ -20,6 +20,7 @@ import java.time.LocalDate;
 import java.time.format.FormatStyle;
 import java.util.Locale;
 
+import static java.time.Month.OCTOBER;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.GERMAN;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,12 +50,12 @@ class DateAndTimeFormatAwareTest {
 
     @Test
     void ensureParseForIsoDateString() {
-        assertThat(sut.parse("2020-10-30", locale)).hasValue(LocalDate.of(2020, 10, 30));
+        assertThat(sut.parse("2020-10-30", locale)).hasValue(LocalDate.of(2020, OCTOBER, 30));
     }
 
     @Test
     void ensureParseForGermanDateString() {
-        assertThat(sut.parse("30.10.2020", locale)).hasValue(LocalDate.of(2020, 10, 30));
+        assertThat(sut.parse("30.10.2020", locale)).hasValue(LocalDate.of(2020, OCTOBER, 30));
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkDaysCountServiceTest.java
@@ -30,8 +30,10 @@ import static java.time.DayOfWeek.SATURDAY;
 import static java.time.DayOfWeek.THURSDAY;
 import static java.time.DayOfWeek.TUESDAY;
 import static java.time.DayOfWeek.WEDNESDAY;
+import static java.time.Month.APRIL;
 import static java.time.Month.DECEMBER;
 import static java.time.Month.JANUARY;
+import static java.time.Month.MAY;
 import static java.time.Month.NOVEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
@@ -69,8 +71,8 @@ class WorkDaysCountServiceTest {
         when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        final LocalDate startDate = LocalDate.of(2010, 12, 17);
-        final LocalDate endDate = LocalDate.of(2010, 12, 31);
+        final LocalDate startDate = LocalDate.of(2010, DECEMBER, 17);
+        final LocalDate endDate = LocalDate.of(2010, DECEMBER, 31);
 
         final WorkingTime workingTime = createWorkingTime(person, startDate, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
@@ -91,8 +93,8 @@ class WorkDaysCountServiceTest {
         when(settingsService.getSettings()).thenReturn(new Settings());
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        final LocalDate startDate = LocalDate.of(2009, 12, 17);
-        final LocalDate endDate = LocalDate.of(2009, 12, 31);
+        final LocalDate startDate = LocalDate.of(2009, DECEMBER, 17);
+        final LocalDate endDate = LocalDate.of(2009, DECEMBER, 31);
 
         final WorkingTime workingTime = createWorkingTime(person, startDate, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
@@ -112,15 +114,15 @@ class WorkDaysCountServiceTest {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         // Mon Jan 8 to Fri Jan 12, 2024
-        final LocalDate startDate = LocalDate.of(2024, 1, 8);
-        final LocalDate endDate = LocalDate.of(2024, 1, 12);
+        final LocalDate startDate = LocalDate.of(2024, JANUARY, 8);
+        final LocalDate endDate = LocalDate.of(2024, JANUARY, 12);
 
         final WorkingTime workingTime = createWorkingTime(person, startDate, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
         // Wed Jan 10 intentionally not covered by any DateRange
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class)))
             .thenReturn(Map.of(
-                new DateRange(startDate, LocalDate.of(2024, 1, 9)), workingTime,
-                new DateRange(LocalDate.of(2024, 1, 11), endDate), workingTime
+                new DateRange(startDate, LocalDate.of(2024, JANUARY, 9)), workingTime,
+                new DateRange(LocalDate.of(2024, JANUARY, 11), endDate), workingTime
             ));
 
         // Mon, Tue, (Wed skipped — no WorkingTime), Thu, Fri = 4
@@ -132,9 +134,9 @@ class WorkDaysCountServiceTest {
     void getWorkDaysWithMultipleWorkingTimesOverOneAbsence() {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        final LocalDate startDate = LocalDate.of(2022, 1, 10);
-        final LocalDate midDate = LocalDate.of(2022, 1, 17);
-        final LocalDate endDate = LocalDate.of(2022, 1, 23);
+        final LocalDate startDate = LocalDate.of(2022, JANUARY, 10);
+        final LocalDate midDate = LocalDate.of(2022, JANUARY, 17);
+        final LocalDate endDate = LocalDate.of(2022, JANUARY, 23);
 
         final WorkingTime workingTimeFullWeek = createWorkingTime(person, startDate, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
         final WorkingTime workingTimeHalfWeek = createWorkingTime(person, midDate, MONDAY, TUESDAY, WEDNESDAY);
@@ -155,9 +157,9 @@ class WorkDaysCountServiceTest {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         // Period: Dec 20, 2023 (Wednesday) - Jan 5, 2024 (Friday)
-        final LocalDate startDate = LocalDate.of(2023, 12, 20);
-        final LocalDate midDate = LocalDate.of(2024, 1, 1);
-        final LocalDate endDate = LocalDate.of(2024, 1, 5);
+        final LocalDate startDate = LocalDate.of(2023, DECEMBER, 20);
+        final LocalDate midDate = LocalDate.of(2024, JANUARY, 1);
+        final LocalDate endDate = LocalDate.of(2024, JANUARY, 5);
 
         // First period: Baden-Wuerttemberg (Dec 20, 2023 - Dec 31, 2023)
         final WorkingTime workingTimeBW = new WorkingTime(person, startDate, GERMANY_BADEN_WUERTTEMBERG, false);
@@ -206,8 +208,8 @@ class WorkDaysCountServiceTest {
     void getWorkDaysWithHalfDayMorning() {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        final LocalDate startDate = LocalDate.of(2011, 1, 4);
-        final LocalDate endDate = LocalDate.of(2011, 1, 4);
+        final LocalDate startDate = LocalDate.of(2011, JANUARY, 4);
+        final LocalDate endDate = LocalDate.of(2011, JANUARY, 4);
 
         final WorkingTime workingTime = createWorkingTime(person, startDate, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
@@ -220,8 +222,8 @@ class WorkDaysCountServiceTest {
     void getWorkDaysWithHalfDaysMorning() {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        final LocalDate startDate = LocalDate.of(2011, 1, 4);
-        final LocalDate endDate = LocalDate.of(2011, 1, 8);
+        final LocalDate startDate = LocalDate.of(2011, JANUARY, 4);
+        final LocalDate endDate = LocalDate.of(2011, JANUARY, 8);
 
         final WorkingTime workingTime = createWorkingTime(person, startDate, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
@@ -234,8 +236,8 @@ class WorkDaysCountServiceTest {
     void getWorkDaysWithHalfDayNoon() {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        final LocalDate startDate = LocalDate.of(2011, 1, 4);
-        final LocalDate endDate = LocalDate.of(2011, 1, 4);
+        final LocalDate startDate = LocalDate.of(2011, JANUARY, 4);
+        final LocalDate endDate = LocalDate.of(2011, JANUARY, 4);
 
         final WorkingTime workingTime = createWorkingTime(person, startDate, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
@@ -248,8 +250,8 @@ class WorkDaysCountServiceTest {
     void getWorkDaysWithHalfDaysNoon() {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
-        final LocalDate startDate = LocalDate.of(2011, 1, 4);
-        final LocalDate endDate = LocalDate.of(2011, 1, 8);
+        final LocalDate startDate = LocalDate.of(2011, JANUARY, 4);
+        final LocalDate endDate = LocalDate.of(2011, JANUARY, 8);
 
         final WorkingTime workingTime = createWorkingTime(person, startDate, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
@@ -264,8 +266,8 @@ class WorkDaysCountServiceTest {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         // start date is Sunday, end date Saturday
-        final LocalDate startDate = LocalDate.of(2011, 1, 2);
-        final LocalDate endDate = LocalDate.of(2011, 1, 8);
+        final LocalDate startDate = LocalDate.of(2011, JANUARY, 2);
+        final LocalDate endDate = LocalDate.of(2011, JANUARY, 8);
 
         final WorkingTime workingTime = createWorkingTime(person, startDate, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
@@ -279,8 +281,8 @@ class WorkDaysCountServiceTest {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         // Labour Day (1st May)
-        final LocalDate startDate = LocalDate.of(2009, 4, 27);
-        final LocalDate endDate = LocalDate.of(2009, 5, 2);
+        final LocalDate startDate = LocalDate.of(2009, APRIL, 27);
+        final LocalDate endDate = LocalDate.of(2009, MAY, 2);
 
         final WorkingTime workingTime = createWorkingTime(person, startDate, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));
@@ -296,8 +298,8 @@ class WorkDaysCountServiceTest {
 
         final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
         // start date and end date are not in the same year
-        final LocalDate startDate = LocalDate.of(2011, 12, 26);
-        final LocalDate endDate = LocalDate.of(2012, 1, 15);
+        final LocalDate startDate = LocalDate.of(2011, DECEMBER, 26);
+        final LocalDate endDate = LocalDate.of(2012, JANUARY, 15);
 
         final WorkingTime workingTime = createWorkingTime(person, startDate, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY);
         when(workingTimeService.getWorkingTimesByPersonAndDateRange(eq(person), any(DateRange.class))).thenReturn(Map.of(new DateRange(startDate, endDate), workingTime));

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeCalendarApiControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeCalendarApiControllerTest.java
@@ -67,7 +67,7 @@ class WorkingTimeCalendarApiControllerTest {
             .andExpect(jsonPath("$.workDays", is("1")));
 
         verify(personService).getPersonByID(23L);
-        verify(workDaysCountService).getWorkDaysCount(FULL, LocalDate.of(2016, 1, 4), LocalDate.of(2016, 1, 4), person);
+        verify(workDaysCountService).getWorkDaysCount(FULL, LocalDate.of(2016, JANUARY, 4), LocalDate.of(2016, JANUARY, 4), person);
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeCalendarServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeCalendarServiceImplTest.java
@@ -75,20 +75,20 @@ class WorkingTimeCalendarServiceImplTest {
             date -> sut.getNextWorkingDayFollowingTo(person, date);
 
         // first day of valid(From) workingTime
-        assertThat(get.apply(LocalDate.of(2024, 1, 1))).hasValue(LocalDate.of(2024, 1, 2));
+        assertThat(get.apply(LocalDate.of(2024, JANUARY, 1))).hasValue(LocalDate.of(2024, JANUARY, 2));
 
         // within valid working time
-        assertThat(get.apply(LocalDate.of(2024, 7, 15))).hasValue(LocalDate.of(2024, 7, 16));
-        assertThat(get.apply(LocalDate.of(2024, 7, 16))).hasValue(LocalDate.of(2024, 7, 18));
-        assertThat(get.apply(LocalDate.of(2024, 7, 17))).hasValue(LocalDate.of(2024, 7, 18));
-        assertThat(get.apply(LocalDate.of(2024, 7, 18))).hasValue(LocalDate.of(2024, 7, 19));
-        assertThat(get.apply(LocalDate.of(2024, 7, 19))).hasValue(LocalDate.of(2024, 7, 22));
-        assertThat(get.apply(LocalDate.of(2024, 7, 20))).hasValue(LocalDate.of(2024, 7, 22));
-        assertThat(get.apply(LocalDate.of(2024, 7, 21))).hasValue(LocalDate.of(2024, 7, 22));
+        assertThat(get.apply(LocalDate.of(2024, JULY, 15))).hasValue(LocalDate.of(2024, JULY, 16));
+        assertThat(get.apply(LocalDate.of(2024, JULY, 16))).hasValue(LocalDate.of(2024, JULY, 18));
+        assertThat(get.apply(LocalDate.of(2024, JULY, 17))).hasValue(LocalDate.of(2024, JULY, 18));
+        assertThat(get.apply(LocalDate.of(2024, JULY, 18))).hasValue(LocalDate.of(2024, JULY, 19));
+        assertThat(get.apply(LocalDate.of(2024, JULY, 19))).hasValue(LocalDate.of(2024, JULY, 22));
+        assertThat(get.apply(LocalDate.of(2024, JULY, 20))).hasValue(LocalDate.of(2024, JULY, 22));
+        assertThat(get.apply(LocalDate.of(2024, JULY, 21))).hasValue(LocalDate.of(2024, JULY, 22));
 
         // future
-        assertThat(get.apply(LocalDate.of(2024, 12, 31))).hasValue(LocalDate.of(2025, 1, 2));
-        assertThat(get.apply(LocalDate.of(2025, 1, 1))).hasValue(LocalDate.of(2025, 1, 2));
+        assertThat(get.apply(LocalDate.of(2024, DECEMBER, 31))).hasValue(LocalDate.of(2025, JANUARY, 2));
+        assertThat(get.apply(LocalDate.of(2025, JANUARY, 1))).hasValue(LocalDate.of(2025, JANUARY, 2));
     }
 
     @Test
@@ -111,16 +111,16 @@ class WorkingTimeCalendarServiceImplTest {
             date -> sut.getNextWorkingDayFollowingTo(person, date);
 
         // outside of future workingTime, but next working day is within future workingTime
-        assertThat(get.apply(LocalDate.of(2024, 6, 30))).hasValue(LocalDate.of(2024, 7, 5));
+        assertThat(get.apply(LocalDate.of(2024, JUNE, 30))).hasValue(LocalDate.of(2024, JULY, 5));
 
         // within valid working time
-        assertThat(get.apply(LocalDate.of(2024, 7, 1))).hasValue(LocalDate.of(2024, 7, 5));
-        assertThat(get.apply(LocalDate.of(2024, 7, 2))).hasValue(LocalDate.of(2024, 7, 5));
-        assertThat(get.apply(LocalDate.of(2024, 7, 3))).hasValue(LocalDate.of(2024, 7, 5));
-        assertThat(get.apply(LocalDate.of(2024, 7, 4))).hasValue(LocalDate.of(2024, 7, 5));
-        assertThat(get.apply(LocalDate.of(2024, 7, 5))).hasValue(LocalDate.of(2024, 7, 6));
-        assertThat(get.apply(LocalDate.of(2024, 7, 6))).hasValue(LocalDate.of(2024, 7, 7));
-        assertThat(get.apply(LocalDate.of(2024, 7, 7))).hasValue(LocalDate.of(2024, 7, 12));
+        assertThat(get.apply(LocalDate.of(2024, JULY, 1))).hasValue(LocalDate.of(2024, JULY, 5));
+        assertThat(get.apply(LocalDate.of(2024, JULY, 2))).hasValue(LocalDate.of(2024, JULY, 5));
+        assertThat(get.apply(LocalDate.of(2024, JULY, 3))).hasValue(LocalDate.of(2024, JULY, 5));
+        assertThat(get.apply(LocalDate.of(2024, JULY, 4))).hasValue(LocalDate.of(2024, JULY, 5));
+        assertThat(get.apply(LocalDate.of(2024, JULY, 5))).hasValue(LocalDate.of(2024, JULY, 6));
+        assertThat(get.apply(LocalDate.of(2024, JULY, 6))).hasValue(LocalDate.of(2024, JULY, 7));
+        assertThat(get.apply(LocalDate.of(2024, JULY, 7))).hasValue(LocalDate.of(2024, JULY, 12));
     }
 
     @Test
@@ -132,7 +132,7 @@ class WorkingTimeCalendarServiceImplTest {
         when(workingTimeRepository.findByPersonIsInOrderByValidFromDesc(List.of(person)))
             .thenReturn(List.of());
 
-        final Optional<LocalDate> actual = sut.getNextWorkingDayFollowingTo(person, LocalDate.of(2024, 7, 21));
+        final Optional<LocalDate> actual = sut.getNextWorkingDayFollowingTo(person, LocalDate.of(2024, JULY, 21));
         assertThat(actual).isEmpty();
     }
 
@@ -151,10 +151,10 @@ class WorkingTimeCalendarServiceImplTest {
         final Function<LocalDate, Optional<LocalDate>> get =
             date -> sut.getNextWorkingDayFollowingTo(person, date);
 
-        assertThat(get.apply(LocalDate.of(2023, 12, 30))).isEmpty();
+        assertThat(get.apply(LocalDate.of(2023, DECEMBER, 30))).isEmpty();
 
         // is present because the next day matches a workingTime
-        assertThat(get.apply(LocalDate.of(2023, 12, 31))).isPresent();
+        assertThat(get.apply(LocalDate.of(2023, DECEMBER, 31))).isPresent();
     }
 
     @Test
@@ -169,7 +169,7 @@ class WorkingTimeCalendarServiceImplTest {
         when(workingTimeRepository.findByPersonIsInOrderByValidFromDesc(List.of(person)))
             .thenReturn(List.of(workingTimeEntity));
 
-        assertThat(sut.getNextWorkingDayFollowingTo(person, LocalDate.of(2024, 7, 21))).isEmpty();
+        assertThat(sut.getNextWorkingDayFollowingTo(person, LocalDate.of(2024, JULY, 21))).isEmpty();
     }
 
     @Test
@@ -407,7 +407,7 @@ class WorkingTimeCalendarServiceImplTest {
             return Optional.empty();
         });
 
-        final Map<Person, WorkingTimeCalendar> actual = sut.getWorkingTimesByPersons(persons, new DateRange(LocalDate.of(2024, 12, 24), LocalDate.of(2024, 12, 24)));
+        final Map<Person, WorkingTimeCalendar> actual = sut.getWorkingTimesByPersons(persons, new DateRange(LocalDate.of(2024, DECEMBER, 24), LocalDate.of(2024, DECEMBER, 24)));
         assertThat(actual)
             .hasSize(1)
             .containsKeys(person);

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeCalendarTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeCalendarTest.java
@@ -22,6 +22,13 @@ import java.util.stream.Stream;
 import static java.time.DayOfWeek.SATURDAY;
 import static java.time.DayOfWeek.SUNDAY;
 import static java.time.DayOfWeek.WEDNESDAY;
+import static java.time.Month.APRIL;
+import static java.time.Month.AUGUST;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.JULY;
+import static java.time.Month.JUNE;
+import static java.time.Month.MARCH;
+import static java.time.Month.SEPTEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.synyx.urlaubsverwaltung.period.DayLength.MORNING;
@@ -44,8 +51,8 @@ class WorkingTimeCalendarTest {
         @Test
         void ensureNextWorkingFollowingTo() {
 
-            final LocalDate from = LocalDate.of(2024, 7, 1);
-            final LocalDate to = LocalDate.of(2024, 7, 31);
+            final LocalDate from = LocalDate.of(2024, JULY, 1);
+            final LocalDate to = LocalDate.of(2024, JULY, 31);
 
             final WorkingTimeCalendar sut = workingTimeCalendar(from, to, date -> {
                 if (List.of(WEDNESDAY, SATURDAY, SUNDAY).contains(date.getDayOfWeek())) {
@@ -55,27 +62,27 @@ class WorkingTimeCalendarTest {
                 }
             });
 
-            assertThat(sut.nextWorkingFollowingTo(LocalDate.of(2024, 6, 30))).hasValue(LocalDate.of(2024, 7, 1));
-            assertThat(sut.nextWorkingFollowingTo(LocalDate.of(2024, 7, 15))).hasValue(LocalDate.of(2024, 7, 16));
-            assertThat(sut.nextWorkingFollowingTo(LocalDate.of(2024, 7, 16))).hasValue(LocalDate.of(2024, 7, 18));
-            assertThat(sut.nextWorkingFollowingTo(LocalDate.of(2024, 7, 17))).hasValue(LocalDate.of(2024, 7, 18));
-            assertThat(sut.nextWorkingFollowingTo(LocalDate.of(2024, 7, 18))).hasValue(LocalDate.of(2024, 7, 19));
-            assertThat(sut.nextWorkingFollowingTo(LocalDate.of(2024, 7, 19))).hasValue(LocalDate.of(2024, 7, 22));
-            assertThat(sut.nextWorkingFollowingTo(LocalDate.of(2024, 7, 20))).hasValue(LocalDate.of(2024, 7, 22));
-            assertThat(sut.nextWorkingFollowingTo(LocalDate.of(2024, 7, 21))).hasValue(LocalDate.of(2024, 7, 22));
+            assertThat(sut.nextWorkingFollowingTo(LocalDate.of(2024, JUNE, 30))).hasValue(LocalDate.of(2024, JULY, 1));
+            assertThat(sut.nextWorkingFollowingTo(LocalDate.of(2024, JULY, 15))).hasValue(LocalDate.of(2024, JULY, 16));
+            assertThat(sut.nextWorkingFollowingTo(LocalDate.of(2024, JULY, 16))).hasValue(LocalDate.of(2024, JULY, 18));
+            assertThat(sut.nextWorkingFollowingTo(LocalDate.of(2024, JULY, 17))).hasValue(LocalDate.of(2024, JULY, 18));
+            assertThat(sut.nextWorkingFollowingTo(LocalDate.of(2024, JULY, 18))).hasValue(LocalDate.of(2024, JULY, 19));
+            assertThat(sut.nextWorkingFollowingTo(LocalDate.of(2024, JULY, 19))).hasValue(LocalDate.of(2024, JULY, 22));
+            assertThat(sut.nextWorkingFollowingTo(LocalDate.of(2024, JULY, 20))).hasValue(LocalDate.of(2024, JULY, 22));
+            assertThat(sut.nextWorkingFollowingTo(LocalDate.of(2024, JULY, 21))).hasValue(LocalDate.of(2024, JULY, 22));
         }
 
         @Test
         void ensureNextWorkingFollowingToReturnsEmptyOptionalWhenNotInWorkingDays() {
 
-            final LocalDate from = LocalDate.of(2024, 7, 1);
-            final LocalDate to = LocalDate.of(2024, 7, 31);
+            final LocalDate from = LocalDate.of(2024, JULY, 1);
+            final LocalDate to = LocalDate.of(2024, JULY, 31);
 
             final WorkingTimeCalendar sut = workingTimeCalendarMondayToSunday(from, to);
 
             // 2024-06-30 would return 2024-07-01 -> use 2024-06-30 to assert empty value
-            assertThat(sut.nextWorkingFollowingTo(LocalDate.of(2024, 6, 29))).isEmpty();
-            assertThat(sut.nextWorkingFollowingTo(LocalDate.of(2024, 7, 31))).isEmpty();
+            assertThat(sut.nextWorkingFollowingTo(LocalDate.of(2024, JUNE, 29))).isEmpty();
+            assertThat(sut.nextWorkingFollowingTo(LocalDate.of(2024, JULY, 31))).isEmpty();
         }
     }
 
@@ -85,8 +92,8 @@ class WorkingTimeCalendarTest {
         @Test
         void ensureWorkingTimeForApplicationOverTwoDaysWhenWorkingFull() {
 
-            final LocalDate from = LocalDate.of(2022, 8, 1);
-            final LocalDate to = LocalDate.of(2022, 8, 31);
+            final LocalDate from = LocalDate.of(2022, AUGUST, 1);
+            final LocalDate to = LocalDate.of(2022, AUGUST, 31);
 
             final WorkingTimeCalendar sut = workingTimeCalendarMondayToSunday(from, to);
 
@@ -103,8 +110,8 @@ class WorkingTimeCalendarTest {
         @Test
         void ensureWorkingTimeForApplicationHalfDayWhenWorkingFull() {
 
-            final LocalDate from = LocalDate.of(2022, 8, 1);
-            final LocalDate to = LocalDate.of(2022, 8, 31);
+            final LocalDate from = LocalDate.of(2022, AUGUST, 1);
+            final LocalDate to = LocalDate.of(2022, AUGUST, 31);
 
             final WorkingTimeCalendar sut = workingTimeCalendarMondayToSunday(from, to);
 
@@ -122,8 +129,8 @@ class WorkingTimeCalendarTest {
         @MethodSource("morningAndNoonWorkingTimeInformation")
         void ensureWorkingTimeForApplicationFullDayWhenWorkingWith(WorkingDayInformation workingDayInformation) {
 
-            final LocalDate from = LocalDate.of(2022, 8, 1);
-            final LocalDate to = LocalDate.of(2022, 8, 31);
+            final LocalDate from = LocalDate.of(2022, AUGUST, 1);
+            final LocalDate to = LocalDate.of(2022, AUGUST, 31);
 
             final WorkingTimeCalendar sut = workingTimeCalendar(from, to, _ -> workingDayInformation);
 
@@ -137,31 +144,31 @@ class WorkingTimeCalendarTest {
 
         @Test
         void ensureWorkingTimeForLocalDateWhenWorkingFull() {
-            final LocalDate from = LocalDate.of(2022, 8, 1);
-            final LocalDate to = LocalDate.of(2022, 8, 31);
+            final LocalDate from = LocalDate.of(2022, AUGUST, 1);
+            final LocalDate to = LocalDate.of(2022, AUGUST, 31);
 
             final WorkingTimeCalendar sut = workingTimeCalendarMondayToSunday(from, to);
 
-            final Optional<BigDecimal> actual = sut.workingTime(LocalDate.of(2022, 8, 10));
+            final Optional<BigDecimal> actual = sut.workingTime(LocalDate.of(2022, AUGUST, 10));
 
             assertThat(actual).hasValue(BigDecimal.valueOf(1));
         }
 
         @Test
         void ensureWorkingTimeForLocalDateReturnsEmptyOptionalForDateOutOfRange() {
-            final LocalDate from = LocalDate.of(2022, 8, 1);
-            final LocalDate to = LocalDate.of(2022, 8, 31);
+            final LocalDate from = LocalDate.of(2022, AUGUST, 1);
+            final LocalDate to = LocalDate.of(2022, AUGUST, 31);
 
             final WorkingTimeCalendar sut = workingTimeCalendarMondayToSunday(from, to);
 
-            assertThat(sut.workingTime(LocalDate.of(2022, 7, 31))).isEmpty();
-            assertThat(sut.workingTime(LocalDate.of(2022, 9, 1))).isEmpty();
+            assertThat(sut.workingTime(LocalDate.of(2022, JULY, 31))).isEmpty();
+            assertThat(sut.workingTime(LocalDate.of(2022, SEPTEMBER, 1))).isEmpty();
         }
 
         @Test
         void ensureWorkingTimeForDateRangeWhenWorkingFull() {
-            final LocalDate from = LocalDate.of(2022, 8, 1);
-            final LocalDate to = LocalDate.of(2022, 8, 31);
+            final LocalDate from = LocalDate.of(2022, AUGUST, 1);
+            final LocalDate to = LocalDate.of(2022, AUGUST, 31);
 
             final WorkingTimeCalendar sut = workingTimeCalendarMondayToSunday(from, to);
 
@@ -171,8 +178,8 @@ class WorkingTimeCalendarTest {
 
         @Test
         void ensureWorkingTimeForDateRangeForFalsyDateRangeWhenWorkingFull() {
-            final LocalDate from = LocalDate.of(2022, 8, 1);
-            final LocalDate to = LocalDate.of(2022, 8, 31);
+            final LocalDate from = LocalDate.of(2022, AUGUST, 1);
+            final LocalDate to = LocalDate.of(2022, AUGUST, 31);
 
             final WorkingTimeCalendar sut = workingTimeCalendarMondayToSunday(from, to);
 
@@ -182,8 +189,8 @@ class WorkingTimeCalendarTest {
         @ParameterizedTest
         @MethodSource("morningAndNoonWorkingTimeInformation")
         void ensureWorkingTimeForDateRangeWhenWorkingNotFull(WorkingDayInformation workingDayInformation) {
-            final LocalDate from = LocalDate.of(2022, 8, 1);
-            final LocalDate to = LocalDate.of(2022, 8, 31);
+            final LocalDate from = LocalDate.of(2022, AUGUST, 1);
+            final LocalDate to = LocalDate.of(2022, AUGUST, 31);
 
             final WorkingTimeCalendar sut = workingTimeCalendar(from, to, _ -> workingDayInformation);
 
@@ -194,8 +201,8 @@ class WorkingTimeCalendarTest {
         @ParameterizedTest
         @MethodSource("morningAndNoonWorkingTimeInformation")
         void ensureWorkingTimeForDateRangeForFalsyDateRangeWhenWorkingNotFull(WorkingDayInformation workingDayInformation) {
-            final LocalDate from = LocalDate.of(2022, 8, 1);
-            final LocalDate to = LocalDate.of(2022, 8, 31);
+            final LocalDate from = LocalDate.of(2022, AUGUST, 1);
+            final LocalDate to = LocalDate.of(2022, AUGUST, 31);
 
             final WorkingTimeCalendar sut = workingTimeCalendar(from, to, _ -> workingDayInformation);
 
@@ -216,9 +223,9 @@ class WorkingTimeCalendarTest {
         @Test
         void ensureWorkingTimeForApplicationWithStartInDateRange() {
 
-            final LocalDate applicationFrom = LocalDate.of(2023, 3, 31);
-            final LocalDate applicationTo = LocalDate.of(2023, 4, 2);
-            final DateRange marchDateRange = new DateRange(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 3, 31));
+            final LocalDate applicationFrom = LocalDate.of(2023, MARCH, 31);
+            final LocalDate applicationTo = LocalDate.of(2023, APRIL, 2);
+            final DateRange marchDateRange = new DateRange(LocalDate.of(2023, MARCH, 1), LocalDate.of(2023, MARCH, 31));
 
             final WorkingTimeCalendar sut = workingTimeCalendarMondayToSunday(applicationFrom, applicationTo);
 
@@ -235,9 +242,9 @@ class WorkingTimeCalendarTest {
         @Test
         void ensureWorkingTimeForApplicationWithEndInDateRange() {
 
-            final LocalDate applicationFrom = LocalDate.of(2023, 3, 31);
-            final LocalDate applicationTo = LocalDate.of(2023, 4, 2);
-            final DateRange aprilDateRange = new DateRange(LocalDate.of(2023, 4, 1), LocalDate.of(2023, 4, 30));
+            final LocalDate applicationFrom = LocalDate.of(2023, MARCH, 31);
+            final LocalDate applicationTo = LocalDate.of(2023, APRIL, 2);
+            final DateRange aprilDateRange = new DateRange(LocalDate.of(2023, APRIL, 1), LocalDate.of(2023, APRIL, 30));
 
             final WorkingTimeCalendar sut = workingTimeCalendarMondayToSunday(applicationFrom, applicationTo);
 
@@ -254,8 +261,8 @@ class WorkingTimeCalendarTest {
         @Test
         void ensureWorkingTimeForApplicationWithoutWorkingDayInformation() {
 
-            final LocalDate applicationDate = LocalDate.of(2023, 3, 31);
-            final DateRange aprilDateRange = new DateRange(LocalDate.of(2023, 3, 1), LocalDate.of(2023, 4, 30));
+            final LocalDate applicationDate = LocalDate.of(2023, MARCH, 31);
+            final DateRange aprilDateRange = new DateRange(LocalDate.of(2023, MARCH, 1), LocalDate.of(2023, APRIL, 30));
 
             final WorkingTimeCalendar sut = new WorkingTimeCalendar(Map.of());
 
@@ -273,7 +280,7 @@ class WorkingTimeCalendarTest {
         @EnumSource(value = DayLength.class, names = {"MORNING", "NOON"})
         void ensureWorkingTimeForHalfDayApplicationAtHalfPublicHoliday(DayLength dayLength) {
 
-            final LocalDate christmas = LocalDate.of(2024, 12, 24);
+            final LocalDate christmas = LocalDate.of(2024, DECEMBER, 24);
 
             final Map<LocalDate, WorkingDayInformation> workingTimeByDate = Map.of(christmas, new WorkingDayInformation(MORNING, WORKDAY, PUBLIC_HOLIDAY));
             final WorkingTimeCalendar sut = new WorkingTimeCalendar(workingTimeByDate);
@@ -304,7 +311,7 @@ class WorkingTimeCalendarTest {
         @MethodSource("singleHalfDay")
         void ensureWorkingTimeForHalfDayApplicationAndWorkingDay(DayLength dayLength, WorkingDayInformation workingDayInformation, BigDecimal expectedWorkingTime) {
 
-            final LocalDate date = LocalDate.of(2024, 12, 24);
+            final LocalDate date = LocalDate.of(2024, DECEMBER, 24);
 
             final Map<LocalDate, WorkingDayInformation> workingTimeByDate = Map.of(date, workingDayInformation);
             final WorkingTimeCalendar sut = new WorkingTimeCalendar(workingTimeByDate);
@@ -345,7 +352,7 @@ class WorkingTimeCalendarTest {
         @ParameterizedTest
         @MethodSource("falsyHalfDayPublicHolidayTuples")
         void ensureHasHalfDayPublicHolidayReturnsFalse(WorkingTimeCalendarEntryType morning, WorkingTimeCalendarEntryType noon) {
-            final LocalDate date = LocalDate.of(2024, 12, 1);
+            final LocalDate date = LocalDate.of(2024, DECEMBER, 1);
 
             final Map<LocalDate, WorkingDayInformation> workingTimeByDate = Map.of(date, new WorkingDayInformation(null, morning, noon));
             final WorkingTimeCalendar sut = new WorkingTimeCalendar(workingTimeByDate);
@@ -357,7 +364,7 @@ class WorkingTimeCalendarTest {
         @ParameterizedTest
         @MethodSource("truthyHalfDayPublicHolidayTuples")
         void ensureHasHalfDayPublicHolidayReturnsTrue(WorkingTimeCalendarEntryType morning, WorkingTimeCalendarEntryType noon) {
-            final LocalDate date = LocalDate.of(2024, 12, 1);
+            final LocalDate date = LocalDate.of(2024, DECEMBER, 1);
 
             final Map<LocalDate, WorkingDayInformation> workingTimeByDate = Map.of(date, new WorkingDayInformation(null, morning, noon));
             final WorkingTimeCalendar sut = new WorkingTimeCalendar(workingTimeByDate);

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeServiceImplTest.java
@@ -23,7 +23,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.time.Month.AUGUST;
+import static java.time.Month.JANUARY;
 import static java.time.Month.JUNE;
+import static java.time.Month.NOVEMBER;
+import static java.time.Month.SEPTEMBER;
 import static java.time.ZoneOffset.UTC;
 import static java.time.temporal.TemporalAdjusters.firstDayOfYear;
 import static java.util.Collections.emptyList;
@@ -340,31 +344,31 @@ class WorkingTimeServiceImplTest {
         final WorkingTimeEntity workingTimeEntity = new WorkingTimeEntity();
         workingTimeEntity.setId(1L);
         workingTimeEntity.setPerson(person);
-        workingTimeEntity.setValidFrom(LocalDate.of(2020, 9, 1));
+        workingTimeEntity.setValidFrom(LocalDate.of(2020, SEPTEMBER, 1));
         workingTimeEntity.setFederalStateOverride(GERMANY_BADEN_WUERTTEMBERG);
 
         final WorkingTimeEntity workingTimeEntityChanged = new WorkingTimeEntity();
         workingTimeEntityChanged.setId(2L);
         workingTimeEntityChanged.setPerson(person);
-        workingTimeEntityChanged.setValidFrom(LocalDate.of(2021, 11, 15));
+        workingTimeEntityChanged.setValidFrom(LocalDate.of(2021, NOVEMBER, 15));
         workingTimeEntityChanged.setFederalStateOverride(GERMANY_RHEINLAND_PFALZ);
 
         final WorkingTimeEntity workingTimeEntityFuture = new WorkingTimeEntity();
         workingTimeEntityFuture.setId(3L);
         workingTimeEntityFuture.setPerson(person);
-        workingTimeEntityFuture.setValidFrom(LocalDate.of(2022, 1, 1));
+        workingTimeEntityFuture.setValidFrom(LocalDate.of(2022, JANUARY, 1));
         workingTimeEntityFuture.setFederalStateOverride(GERMANY_BERLIN);
 
         when(workingTimeRepository.findByPersonOrderByValidFromDesc(person)).thenReturn(List.of(workingTimeEntityFuture, workingTimeEntityChanged, workingTimeEntity));
 
-        final DateRange dateRange = new DateRange(LocalDate.of(2021, 11, 1), LocalDate.of(2021, 11, 30));
+        final DateRange dateRange = new DateRange(LocalDate.of(2021, NOVEMBER, 1), LocalDate.of(2021, NOVEMBER, 30));
         final Map<DateRange, FederalState> federalStatesByPersonAndDateRange = sut.getFederalStatesByPersonAndDateRange(person, dateRange);
         assertThat(federalStatesByPersonAndDateRange)
             .isNotEmpty()
             .hasSize(2)
             .containsExactly(
-                entry(new DateRange(LocalDate.of(2021, 11, 1), LocalDate.of(2021, 11, 14)), GERMANY_BADEN_WUERTTEMBERG),
-                entry(new DateRange(LocalDate.of(2021, 11, 15), LocalDate.of(2021, 11, 30)), GERMANY_RHEINLAND_PFALZ)
+                entry(new DateRange(LocalDate.of(2021, NOVEMBER, 1), LocalDate.of(2021, NOVEMBER, 14)), GERMANY_BADEN_WUERTTEMBERG),
+                entry(new DateRange(LocalDate.of(2021, NOVEMBER, 15), LocalDate.of(2021, NOVEMBER, 30)), GERMANY_RHEINLAND_PFALZ)
             );
     }
 
@@ -376,29 +380,29 @@ class WorkingTimeServiceImplTest {
         final WorkingTimeEntity workingTimeEntity = new WorkingTimeEntity();
         workingTimeEntity.setId(1L);
         workingTimeEntity.setPerson(person);
-        workingTimeEntity.setValidFrom(LocalDate.of(2020, 1, 1));
+        workingTimeEntity.setValidFrom(LocalDate.of(2020, JANUARY, 1));
         workingTimeEntity.setFederalStateOverride(GERMANY_BADEN_WUERTTEMBERG);
 
         final WorkingTimeEntity workingTimeEntityChanged = new WorkingTimeEntity();
         workingTimeEntityChanged.setId(2L);
         workingTimeEntityChanged.setPerson(person);
-        workingTimeEntityChanged.setValidFrom(LocalDate.of(2020, 9, 1));
+        workingTimeEntityChanged.setValidFrom(LocalDate.of(2020, SEPTEMBER, 1));
         workingTimeEntityChanged.setFederalStateOverride(GERMANY_RHEINLAND_PFALZ);
 
         final WorkingTimeEntity workingTimeEntityFuture = new WorkingTimeEntity();
         workingTimeEntityFuture.setId(3L);
         workingTimeEntityFuture.setPerson(person);
-        workingTimeEntityFuture.setValidFrom(LocalDate.of(2022, 1, 1));
+        workingTimeEntityFuture.setValidFrom(LocalDate.of(2022, JANUARY, 1));
         workingTimeEntityFuture.setFederalStateOverride(GERMANY_BERLIN);
 
         when(workingTimeRepository.findByPersonOrderByValidFromDesc(person)).thenReturn(List.of(workingTimeEntityFuture, workingTimeEntityChanged, workingTimeEntity));
 
-        final DateRange dateRange = new DateRange(LocalDate.of(2020, 9, 1), LocalDate.of(2020, 9, 10));
+        final DateRange dateRange = new DateRange(LocalDate.of(2020, SEPTEMBER, 1), LocalDate.of(2020, SEPTEMBER, 10));
         final Map<DateRange, FederalState> federalStatesByPersonAndDateRange = sut.getFederalStatesByPersonAndDateRange(person, dateRange);
         assertThat(federalStatesByPersonAndDateRange)
             .isNotEmpty()
             .hasSize(1)
-            .containsExactly(entry(new DateRange(LocalDate.of(2020, 9, 1), LocalDate.of(2020, 9, 10)), GERMANY_RHEINLAND_PFALZ));
+            .containsExactly(entry(new DateRange(LocalDate.of(2020, SEPTEMBER, 1), LocalDate.of(2020, SEPTEMBER, 10)), GERMANY_RHEINLAND_PFALZ));
     }
 
     @Test
@@ -409,31 +413,31 @@ class WorkingTimeServiceImplTest {
         final WorkingTimeEntity workingTimeEntity = new WorkingTimeEntity();
         workingTimeEntity.setId(1L);
         workingTimeEntity.setPerson(person);
-        workingTimeEntity.setValidFrom(LocalDate.of(2020, 1, 1));
+        workingTimeEntity.setValidFrom(LocalDate.of(2020, JANUARY, 1));
         workingTimeEntity.setFederalStateOverride(GERMANY_BADEN_WUERTTEMBERG);
 
         final WorkingTimeEntity workingTimeEntityChanged = new WorkingTimeEntity();
         workingTimeEntityChanged.setId(2L);
         workingTimeEntityChanged.setPerson(person);
-        workingTimeEntityChanged.setValidFrom(LocalDate.of(2020, 9, 1));
+        workingTimeEntityChanged.setValidFrom(LocalDate.of(2020, SEPTEMBER, 1));
         workingTimeEntityChanged.setFederalStateOverride(GERMANY_RHEINLAND_PFALZ);
 
         final WorkingTimeEntity workingTimeEntityFuture = new WorkingTimeEntity();
         workingTimeEntityFuture.setId(3L);
         workingTimeEntityFuture.setPerson(person);
-        workingTimeEntityFuture.setValidFrom(LocalDate.of(2022, 1, 1));
+        workingTimeEntityFuture.setValidFrom(LocalDate.of(2022, JANUARY, 1));
         workingTimeEntityFuture.setFederalStateOverride(GERMANY_BERLIN);
 
         when(workingTimeRepository.findByPersonOrderByValidFromDesc(person)).thenReturn(List.of(workingTimeEntityFuture, workingTimeEntityChanged, workingTimeEntity));
 
-        final DateRange dateRange = new DateRange(LocalDate.of(2020, 8, 1), LocalDate.of(2020, 9, 1));
+        final DateRange dateRange = new DateRange(LocalDate.of(2020, AUGUST, 1), LocalDate.of(2020, SEPTEMBER, 1));
         final Map<DateRange, FederalState> federalStatesByPersonAndDateRange = sut.getFederalStatesByPersonAndDateRange(person, dateRange);
         assertThat(federalStatesByPersonAndDateRange)
             .isNotEmpty()
             .hasSize(2)
             .containsExactly(
-                entry(new DateRange(LocalDate.of(2020, 9, 1), LocalDate.of(2020, 9, 1)), GERMANY_RHEINLAND_PFALZ),
-                entry(new DateRange(LocalDate.of(2020, 8, 1), LocalDate.of(2020, 8, 31)), GERMANY_BADEN_WUERTTEMBERG)
+                entry(new DateRange(LocalDate.of(2020, SEPTEMBER, 1), LocalDate.of(2020, SEPTEMBER, 1)), GERMANY_RHEINLAND_PFALZ),
+                entry(new DateRange(LocalDate.of(2020, AUGUST, 1), LocalDate.of(2020, AUGUST, 31)), GERMANY_BADEN_WUERTTEMBERG)
             );
     }
 
@@ -446,8 +450,8 @@ class WorkingTimeServiceImplTest {
 
         assertThat(sut.getFederalStatesByPersonAndDateRange(batman,
             new DateRange(
-                LocalDate.of(2021, 11, 1),
-                LocalDate.of(2021, 11, 30)))).isEmpty();
+                LocalDate.of(2021, NOVEMBER, 1),
+                LocalDate.of(2021, NOVEMBER, 30)))).isEmpty();
     }
 
     @Test
@@ -458,31 +462,31 @@ class WorkingTimeServiceImplTest {
         final WorkingTimeEntity workingTimeEntity = new WorkingTimeEntity();
         workingTimeEntity.setId(1L);
         workingTimeEntity.setPerson(person);
-        workingTimeEntity.setValidFrom(LocalDate.of(2020, 9, 1));
+        workingTimeEntity.setValidFrom(LocalDate.of(2020, SEPTEMBER, 1));
         workingTimeEntity.setFederalStateOverride(GERMANY_BADEN_WUERTTEMBERG);
 
         final WorkingTimeEntity workingTimeEntityChanged = new WorkingTimeEntity();
         workingTimeEntityChanged.setId(2L);
         workingTimeEntityChanged.setPerson(person);
-        workingTimeEntityChanged.setValidFrom(LocalDate.of(2021, 11, 15));
+        workingTimeEntityChanged.setValidFrom(LocalDate.of(2021, NOVEMBER, 15));
         workingTimeEntityChanged.setFederalStateOverride(GERMANY_RHEINLAND_PFALZ);
 
         final WorkingTimeEntity workingTimeEntityFuture = new WorkingTimeEntity();
         workingTimeEntityFuture.setId(3L);
         workingTimeEntityFuture.setPerson(person);
-        workingTimeEntityFuture.setValidFrom(LocalDate.of(2022, 1, 1));
+        workingTimeEntityFuture.setValidFrom(LocalDate.of(2022, JANUARY, 1));
         workingTimeEntityFuture.setFederalStateOverride(GERMANY_BERLIN);
 
         when(workingTimeRepository.findByPersonOrderByValidFromDesc(person)).thenReturn(List.of(workingTimeEntityFuture, workingTimeEntityChanged, workingTimeEntity));
 
-        final DateRange dateRange = new DateRange(LocalDate.of(2021, 11, 1), LocalDate.of(2021, 11, 30));
+        final DateRange dateRange = new DateRange(LocalDate.of(2021, NOVEMBER, 1), LocalDate.of(2021, NOVEMBER, 30));
         final Map<DateRange, WorkingTime> federalStatesByPersonAndDateRange = sut.getWorkingTimesByPersonAndDateRange(person, dateRange);
         assertThat(federalStatesByPersonAndDateRange)
             .isNotEmpty()
             .hasSize(2)
             .containsExactly(
-                entry(new DateRange(LocalDate.of(2021, 11, 1), LocalDate.of(2021, 11, 14)), new WorkingTime(person, LocalDate.of(2020, 9, 1), GERMANY_BADEN_WUERTTEMBERG, false)),
-                entry(new DateRange(LocalDate.of(2021, 11, 15), LocalDate.of(2021, 11, 30)), new WorkingTime(person, LocalDate.of(2021, 11, 15), GERMANY_RHEINLAND_PFALZ, false))
+                entry(new DateRange(LocalDate.of(2021, NOVEMBER, 1), LocalDate.of(2021, NOVEMBER, 14)), new WorkingTime(person, LocalDate.of(2020, SEPTEMBER, 1), GERMANY_BADEN_WUERTTEMBERG, false)),
+                entry(new DateRange(LocalDate.of(2021, NOVEMBER, 15), LocalDate.of(2021, NOVEMBER, 30)), new WorkingTime(person, LocalDate.of(2021, NOVEMBER, 15), GERMANY_RHEINLAND_PFALZ, false))
             );
     }
 
@@ -494,29 +498,29 @@ class WorkingTimeServiceImplTest {
         final WorkingTimeEntity workingTimeEntity = new WorkingTimeEntity();
         workingTimeEntity.setId(1L);
         workingTimeEntity.setPerson(person);
-        workingTimeEntity.setValidFrom(LocalDate.of(2020, 1, 1));
+        workingTimeEntity.setValidFrom(LocalDate.of(2020, JANUARY, 1));
         workingTimeEntity.setFederalStateOverride(GERMANY_BADEN_WUERTTEMBERG);
 
         final WorkingTimeEntity workingTimeEntityChanged = new WorkingTimeEntity();
         workingTimeEntityChanged.setId(2L);
         workingTimeEntityChanged.setPerson(person);
-        workingTimeEntityChanged.setValidFrom(LocalDate.of(2020, 9, 1));
+        workingTimeEntityChanged.setValidFrom(LocalDate.of(2020, SEPTEMBER, 1));
         workingTimeEntityChanged.setFederalStateOverride(GERMANY_RHEINLAND_PFALZ);
 
         final WorkingTimeEntity workingTimeEntityFuture = new WorkingTimeEntity();
         workingTimeEntityFuture.setId(3L);
         workingTimeEntityFuture.setPerson(person);
-        workingTimeEntityFuture.setValidFrom(LocalDate.of(2022, 1, 1));
+        workingTimeEntityFuture.setValidFrom(LocalDate.of(2022, JANUARY, 1));
         workingTimeEntityFuture.setFederalStateOverride(GERMANY_BERLIN);
 
         when(workingTimeRepository.findByPersonOrderByValidFromDesc(person)).thenReturn(List.of(workingTimeEntityFuture, workingTimeEntityChanged, workingTimeEntity));
 
-        final DateRange dateRange = new DateRange(LocalDate.of(2020, 9, 1), LocalDate.of(2020, 9, 10));
+        final DateRange dateRange = new DateRange(LocalDate.of(2020, SEPTEMBER, 1), LocalDate.of(2020, SEPTEMBER, 10));
         final Map<DateRange, WorkingTime> federalStatesByPersonAndDateRange = sut.getWorkingTimesByPersonAndDateRange(person, dateRange);
         assertThat(federalStatesByPersonAndDateRange)
             .isNotEmpty()
             .hasSize(1)
-            .containsExactly(entry(new DateRange(LocalDate.of(2020, 9, 1), LocalDate.of(2020, 9, 10)), new WorkingTime(person, LocalDate.of(2020, 9, 1), GERMANY_RHEINLAND_PFALZ, false)));
+            .containsExactly(entry(new DateRange(LocalDate.of(2020, SEPTEMBER, 1), LocalDate.of(2020, SEPTEMBER, 10)), new WorkingTime(person, LocalDate.of(2020, SEPTEMBER, 1), GERMANY_RHEINLAND_PFALZ, false)));
     }
 
     @Test
@@ -527,31 +531,31 @@ class WorkingTimeServiceImplTest {
         final WorkingTimeEntity workingTimeEntity = new WorkingTimeEntity();
         workingTimeEntity.setId(1L);
         workingTimeEntity.setPerson(person);
-        workingTimeEntity.setValidFrom(LocalDate.of(2020, 1, 1));
+        workingTimeEntity.setValidFrom(LocalDate.of(2020, JANUARY, 1));
         workingTimeEntity.setFederalStateOverride(GERMANY_BADEN_WUERTTEMBERG);
 
         final WorkingTimeEntity workingTimeEntityChanged = new WorkingTimeEntity();
         workingTimeEntityChanged.setId(2L);
         workingTimeEntityChanged.setPerson(person);
-        workingTimeEntityChanged.setValidFrom(LocalDate.of(2020, 9, 1));
+        workingTimeEntityChanged.setValidFrom(LocalDate.of(2020, SEPTEMBER, 1));
         workingTimeEntityChanged.setFederalStateOverride(GERMANY_RHEINLAND_PFALZ);
 
         final WorkingTimeEntity workingTimeEntityFuture = new WorkingTimeEntity();
         workingTimeEntityFuture.setId(3L);
         workingTimeEntityFuture.setPerson(person);
-        workingTimeEntityFuture.setValidFrom(LocalDate.of(2022, 1, 1));
+        workingTimeEntityFuture.setValidFrom(LocalDate.of(2022, JANUARY, 1));
         workingTimeEntityFuture.setFederalStateOverride(GERMANY_BERLIN);
 
         when(workingTimeRepository.findByPersonOrderByValidFromDesc(person)).thenReturn(List.of(workingTimeEntityFuture, workingTimeEntityChanged, workingTimeEntity));
 
-        final DateRange dateRange = new DateRange(LocalDate.of(2020, 8, 1), LocalDate.of(2020, 9, 1));
+        final DateRange dateRange = new DateRange(LocalDate.of(2020, AUGUST, 1), LocalDate.of(2020, SEPTEMBER, 1));
         final Map<DateRange, WorkingTime> federalStatesByPersonAndDateRange = sut.getWorkingTimesByPersonAndDateRange(person, dateRange);
         assertThat(federalStatesByPersonAndDateRange)
             .isNotEmpty()
             .hasSize(2)
             .containsExactly(
-                entry(new DateRange(LocalDate.of(2020, 9, 1), LocalDate.of(2020, 9, 1)), new WorkingTime(person, LocalDate.of(2020, 9, 1), GERMANY_RHEINLAND_PFALZ, false)),
-                entry(new DateRange(LocalDate.of(2020, 8, 1), LocalDate.of(2020, 8, 31)), new WorkingTime(person, LocalDate.of(2020, 1, 1), GERMANY_BADEN_WUERTTEMBERG, false))
+                entry(new DateRange(LocalDate.of(2020, SEPTEMBER, 1), LocalDate.of(2020, SEPTEMBER, 1)), new WorkingTime(person, LocalDate.of(2020, SEPTEMBER, 1), GERMANY_RHEINLAND_PFALZ, false)),
+                entry(new DateRange(LocalDate.of(2020, AUGUST, 1), LocalDate.of(2020, AUGUST, 31)), new WorkingTime(person, LocalDate.of(2020, JANUARY, 1), GERMANY_BADEN_WUERTTEMBERG, false))
             );
     }
 
@@ -563,8 +567,8 @@ class WorkingTimeServiceImplTest {
 
         assertThat(sut.getWorkingTimesByPersonAndDateRange(person,
             new DateRange(
-                LocalDate.of(2021, 11, 1),
-                LocalDate.of(2021, 11, 30)))).isEmpty();
+                LocalDate.of(2021, NOVEMBER, 1),
+                LocalDate.of(2021, NOVEMBER, 30)))).isEmpty();
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeViewControllerTest.java
@@ -34,6 +34,9 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.time.DayOfWeek.MONDAY;
+import static java.time.Month.APRIL;
+import static java.time.Month.MARCH;
+import static java.time.Month.OCTOBER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -121,7 +124,7 @@ class WorkingTimeViewControllerTest {
         final Person person = new Person();
         when(personService.getPersonByID(KNOWN_PERSON_ID)).thenReturn(Optional.of(person));
 
-        final WorkingTime workingTime = new WorkingTime(person, LocalDate.of(2020, 10, 2), GERMANY_BERLIN, false);
+        final WorkingTime workingTime = new WorkingTime(person, LocalDate.of(2020, OCTOBER, 2), GERMANY_BERLIN, false);
         workingTime.setWorkingDays(List.of(MONDAY), DayLength.FULL);
         when(workingTimeService.getWorkingTime(eq(person), any(LocalDate.class))).thenReturn(Optional.of(workingTime));
         when(workingTimeService.getByPerson(person)).thenReturn(List.of(workingTime));
@@ -132,7 +135,7 @@ class WorkingTimeViewControllerTest {
             .andExpect(model().attribute("workingTime", equalTo(new WorkingTimeForm(workingTime))))
             .andExpect(model().attribute("workingTimeHistories", hasItem(hasProperty("valid", equalTo(true)))))
             .andExpect(model().attribute("workingTimeHistories", hasItem(hasProperty("federalState", equalTo("GERMANY_BERLIN")))))
-            .andExpect(model().attribute("workingTimeHistories", hasItem(hasProperty("validFrom", equalTo(LocalDate.of(2020, 10, 2))))))
+            .andExpect(model().attribute("workingTimeHistories", hasItem(hasProperty("validFrom", equalTo(LocalDate.of(2020, OCTOBER, 2))))))
             .andExpect(model().attribute("workingTimeHistories", hasItem(hasProperty("validTo", equalTo(null)))))
             .andExpect(model().attribute("workingTimeHistories", hasItem(hasProperty("workingDays", hasItem("MONDAY")))))
             .andExpect(model().attribute("defaultFederalState", equalTo(GERMANY_BADEN_WUERTTEMBERG)))
@@ -148,7 +151,7 @@ class WorkingTimeViewControllerTest {
         final Person person = new Person();
         when(personService.getPersonByID(KNOWN_PERSON_ID)).thenReturn(Optional.of(person));
 
-        final WorkingTime workingTime = new WorkingTime(person, LocalDate.of(2020, 10, 2), GERMANY_BERLIN, false);
+        final WorkingTime workingTime = new WorkingTime(person, LocalDate.of(2020, OCTOBER, 2), GERMANY_BERLIN, false);
         workingTime.setWorkingDays(List.of(MONDAY), DayLength.FULL);
 
         // this results in `null` in the implementation at time of writing this.
@@ -238,11 +241,11 @@ class WorkingTimeViewControllerTest {
 
     private static Stream<Arguments> dateInputAndLocalDateTuple() {
         return Stream.of(
-            Arguments.of("25.03.2022", LocalDate.of(2022, 3, 25)),
-            Arguments.of("25.03.22", LocalDate.of(2022, 3, 25)),
-            Arguments.of("25.3.2022", LocalDate.of(2022, 3, 25)),
-            Arguments.of("25.3.22", LocalDate.of(2022, 3, 25)),
-            Arguments.of("1.4.22", LocalDate.of(2022, 4, 1))
+            Arguments.of("25.03.2022", LocalDate.of(2022, MARCH, 25)),
+            Arguments.of("25.03.22", LocalDate.of(2022, MARCH, 25)),
+            Arguments.of("25.3.2022", LocalDate.of(2022, MARCH, 25)),
+            Arguments.of("25.3.22", LocalDate.of(2022, MARCH, 25)),
+            Arguments.of("1.4.22", LocalDate.of(2022, APRIL, 1))
         );
     }
 


### PR DESCRIPTION
Replaces the 1226 int month literals reported by SonarQube rule java:S8694 ("Month" and "DayOfWeek" enums should be used instead of numeric literals) with statically imported java.time.Month constants, e.g.

    LocalDate.of(2022, 10, 5)  ->  LocalDate.of(2022, OCTOBER, 5)

Files that already qualified the constants as Month.OCTOBER now use the static import as well, so each touched file sticks to one style.

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
