### PR TITLE
refactor: deduplicate weekend check and use Objects.equals consistently

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/web/AbsenceOverviewViewController.java
@@ -30,7 +30,6 @@ import org.synyx.urlaubsverwaltung.workingtime.WorkingTime;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeService;
 
 import java.time.Clock;
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.Year;
 import java.time.format.TextStyle;
@@ -47,8 +46,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static java.lang.Integer.parseInt;
-import static java.time.DayOfWeek.SATURDAY;
-import static java.time.DayOfWeek.SUNDAY;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toCollection;
@@ -59,6 +56,7 @@ import static org.synyx.urlaubsverwaltung.person.Role.DEPARTMENT_HEAD;
 import static org.synyx.urlaubsverwaltung.person.Role.INACTIVE;
 import static org.synyx.urlaubsverwaltung.person.Role.OFFICE;
 import static org.synyx.urlaubsverwaltung.person.Role.SECOND_STAGE_AUTHORITY;
+import static org.synyx.urlaubsverwaltung.util.DateUtil.isWeekend;
 
 @RequestMapping("/web/absences")
 @Controller
@@ -604,11 +602,6 @@ public class AbsenceOverviewViewController implements HasLaunchpad, HasPersonSea
             return now.withMonth(parseInt(month)).with(firstOrLastOfMonthSupplier.get());
         }
         return now.with(firstOrLastOfMonthSupplier.get());
-    }
-
-    private static boolean isWeekend(LocalDate date) {
-        final DayOfWeek dayOfWeek = date.getDayOfWeek();
-        return dayOfWeek == SATURDAY || dayOfWeek == SUNDAY;
     }
 
     private List<Person> getActiveMembersOfPerson(final Person person) {

--- a/src/main/java/org/synyx/urlaubsverwaltung/account/AccountSettings.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/account/AccountSettings.java
@@ -137,7 +137,7 @@ public class AccountSettings implements Serializable {
             && doRemainingVacationDaysExpireGlobally == that.doRemainingVacationDaysExpireGlobally
             && Objects.equals(defaultVacationDays, that.defaultVacationDays)
             && Objects.equals(maximumAnnualVacationDays, that.maximumAnnualVacationDays)
-            && expiryDateMonth == that.expiryDateMonth;
+            && Objects.equals(expiryDateMonth, that.expiryDateMonth);
     }
 
     @Override

--- a/src/main/java/org/synyx/urlaubsverwaltung/util/DateUtil.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/util/DateUtil.java
@@ -24,6 +24,16 @@ public final class DateUtil {
     }
 
     /**
+     * Check if the given date is on a weekend.
+     *
+     * @param date to check
+     * @return {@code true} if the given date is on a weekend, else {@code false}
+     */
+    public static boolean isWeekend(LocalDate date) {
+        return !isWorkDay(date);
+    }
+
+    /**
      * Check if given date is on Christmas Eve.
      *
      * @param date to check

--- a/src/test/java/org/synyx/urlaubsverwaltung/util/DateUtilTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/util/DateUtilTest.java
@@ -37,6 +37,28 @@ class DateUtilTest {
     }
 
     @Test
+    void ensureReturnsTrueIfGivenDayIsOnAWeekend() {
+
+        // Saturday
+        LocalDate date = LocalDate.of(2014, NOVEMBER, 22);
+
+        boolean returnValue = DateUtil.isWeekend(date);
+
+        assertThat(returnValue).isTrue();
+    }
+
+    @Test
+    void ensureReturnsFalseIfGivenDayIsNotOnAWeekend() {
+
+        // Monday
+        LocalDate date = LocalDate.of(2011, DECEMBER, 26);
+
+        boolean returnValue = DateUtil.isWeekend(date);
+
+        assertThat(returnValue).isFalse();
+    }
+
+    @Test
     void ensureReturnsTrueForChristmasEve() {
 
         LocalDate date = LocalDate.of(2011, DECEMBER, 24);

--- a/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeCalendarFactory.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/workingtime/WorkingTimeCalendarFactory.java
@@ -3,18 +3,16 @@ package org.synyx.urlaubsverwaltung.workingtime;
 import org.synyx.urlaubsverwaltung.absence.DateRange;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeCalendar.WorkingDayInformation;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-import static java.time.DayOfWeek.SATURDAY;
-import static java.time.DayOfWeek.SUNDAY;
 import static org.synyx.urlaubsverwaltung.period.DayLength.FULL;
 import static org.synyx.urlaubsverwaltung.period.DayLength.MORNING;
 import static org.synyx.urlaubsverwaltung.period.DayLength.NOON;
 import static org.synyx.urlaubsverwaltung.period.DayLength.ZERO;
+import static org.synyx.urlaubsverwaltung.util.DateUtil.isWeekend;
 import static org.synyx.urlaubsverwaltung.workingtime.WorkingTimeCalendar.WorkingDayInformation.WorkingTimeCalendarEntryType.NO_WORKDAY;
 import static org.synyx.urlaubsverwaltung.workingtime.WorkingTimeCalendar.WorkingDayInformation.WorkingTimeCalendarEntryType.WORKDAY;
 
@@ -121,10 +119,5 @@ public class WorkingTimeCalendarFactory {
             map.put(date, dayLengthProvider.apply(date));
         }
         return map;
-    }
-
-    private static boolean isWeekend(LocalDate date) {
-        final DayOfWeek dayOfWeek = date.getDayOfWeek();
-        return dayOfWeek == SATURDAY || dayOfWeek == SUNDAY;
     }
 }


### PR DESCRIPTION
AbsenceOverviewViewController and WorkingTimeCalendarFactory each carried their own private isWeekend(LocalDate), both reimplementing the logic that DateUtil.isWorkDay already provides. Both now delegate to a new DateUtil.isWeekend, following the existing convention of statically importing DateUtil methods.

AccountSettings.equals compared expiryDateMonth with == while the two adjacent reference comparisons use Objects.equals. Behaviour is unchanged for the enum field, this only makes the method consistent.

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
