### PR TITLE
fix: show the applications closest to today on the overview page

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/overview/OverviewViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overview/OverviewViewController.java
@@ -74,7 +74,8 @@ public class OverviewViewController implements HasLaunchpad, HasPersonSearch {
 
     private static final String PERSON_ATTRIBUTE = "person";
     private static final int NUMBER_OF_PAST_APPLICATION_ON_OVERVIEW = 1;
-    private static final int NUMBER_OF_FUTR_APPLICATION_ON_OVERVIEW = 5;
+    private static final int NUMBER_OF_CURRENT_APPLICATION_ON_OVERVIEW = 1;
+    private static final int NUMBER_OF_FUTR_APPLICATION_ON_OVERVIEW = 4;
     private static final int NUMBER_OF_PAST_SICK_NOTES_ON_OVERVIEW = 3;
     private static final int NUMBER_OF_FUTR_SICK_NOTES_ON_OVERVIEW = 1;
     private static final int NUMBER_OF_PAST_OVERTIMES_ON_OVERVIEW = 3;
@@ -225,22 +226,33 @@ public class OverviewViewController implements HasLaunchpad, HasPersonSearch {
         } else {
             final LocalDate today = LocalDate.now(clock);
             final List<ApplicationForLeave> allForLeave = toApplicationsForLeave(applications);
-            // always show 3 applications if no application is in the fill with future application
-            final List<ApplicationDto> pastApplicationDtos = allForLeave.stream()
-                .filter(a -> a.getStartDate().isBefore(today))
+
+            // show the applications closest to today: the last one, the currently running one and the next ones
+            final List<ApplicationForLeave> currentApplications = allForLeave.stream()
+                .filter(a -> isCurrent(a, today))
                 .sorted(comparing(ApplicationForLeave::getStartDate))
-                .limit(NUMBER_OF_PAST_APPLICATION_ON_OVERVIEW)
-                .map(a -> applicationDto(a, signedInUser, locale))
+                .limit(NUMBER_OF_CURRENT_APPLICATION_ON_OVERVIEW)
                 .toList();
 
-            final List<ApplicationDto> futureApplicationDtos = allForLeave.stream()
-                .filter(a -> !a.getStartDate().isBefore(today))
+            final List<ApplicationForLeave> pastApplications = allForLeave.stream()
+                .filter(a -> a.getEndDate().isBefore(today))
                 .sorted(comparing(ApplicationForLeave::getStartDate).reversed())
-                .limit((long) NUMBER_OF_FUTR_APPLICATION_ON_OVERVIEW - pastApplicationDtos.size())
-                .map(a -> applicationDto(a, signedInUser, locale))
+                .limit(NUMBER_OF_PAST_APPLICATION_ON_OVERVIEW)
                 .toList();
 
-            applicationsForLeave = Stream.concat(futureApplicationDtos.stream(), pastApplicationDtos.stream()).toList();
+            // a currently running application takes one of the slots of the future applications
+            final List<ApplicationForLeave> futureApplications = allForLeave.stream()
+                .filter(a -> a.getStartDate().isAfter(today))
+                .sorted(comparing(ApplicationForLeave::getStartDate))
+                .limit((long) NUMBER_OF_FUTR_APPLICATION_ON_OVERVIEW - currentApplications.size())
+                .toList();
+
+            // future applications on top, the past one at the bottom
+            applicationsForLeave = Stream.of(pastApplications, currentApplications, futureApplications)
+                .flatMap(List::stream)
+                .sorted(comparing(ApplicationForLeave::getStartDate).reversed())
+                .map(a -> applicationDto(a, signedInUser, locale))
+                .toList();
             usedDaysOverview = new ApplicationDaysUsedSummaryDto(applications, year, workDaysCountService);
         }
 
@@ -252,6 +264,10 @@ public class OverviewViewController implements HasLaunchpad, HasPersonSearch {
             applicationsForLeave.size(),
             applications.size()
         ));
+    }
+
+    private static boolean isCurrent(ApplicationForLeave applicationForLeave, LocalDate today) {
+        return !applicationForLeave.getStartDate().isAfter(today) && !applicationForLeave.getEndDate().isBefore(today);
     }
 
     private List<ApplicationForLeave> toApplicationsForLeave(List<Application> applications) {

--- a/src/test/java/org/synyx/urlaubsverwaltung/overview/OverviewViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overview/OverviewViewControllerTest.java
@@ -62,6 +62,7 @@ import static java.math.BigDecimal.TEN;
 import static java.math.BigDecimal.ZERO;
 import static java.time.Month.APRIL;
 import static java.time.Month.JUNE;
+import static java.time.ZoneOffset.UTC;
 import static java.time.temporal.TemporalAdjusters.firstDayOfMonth;
 import static java.util.Arrays.asList;
 import static java.util.Locale.GERMAN;
@@ -1096,6 +1097,136 @@ class OverviewViewControllerTest {
         assertThat(applicationOverview).isNotNull();
         assertThat(applicationOverview.numberOfShownApplications()).isLessThanOrEqualTo(5);
         assertThat(applicationOverview.numberOfTotalApplications()).isEqualTo(2);
+    }
+
+    @Nested
+    class ApplicationsShownOnOverview {
+
+        private static final LocalDate TODAY = LocalDate.parse("2026-08-04");
+
+        private final Person person = new Person();
+
+        @BeforeEach
+        void setUpWithFixedClock() {
+            sut = new OverviewViewController(personService, accountService, vacationDaysService,
+                workDaysCountService, applicationService, sickNoteService, overtimeService, settingsService,
+                departmentService, vacationTypeViewModelService, personSearchUiFragmentSupplier,
+                Clock.fixed(TODAY.atStartOfDay(UTC).toInstant(), UTC));
+
+            person.setId(1L);
+        }
+
+        @Test
+        void ensureShowsNearestPastCurrentAndUpcomingApplications() throws Exception {
+
+            final Application firstOfYear = application(TODAY.withMonth(1).withDayOfMonth(5), TODAY.withMonth(1).withDayOfMonth(9));
+            final Application nearestPast = application(TODAY.minusMonths(1), TODAY.minusMonths(1).plusDays(2));
+            final Application current = application(TODAY.minusDays(3), TODAY.plusDays(3));
+            final Application firstUpcoming = application(TODAY.plusMonths(1), TODAY.plusMonths(1).plusDays(2));
+            final Application secondUpcoming = application(TODAY.plusMonths(2), TODAY.plusMonths(2).plusDays(2));
+            final Application thirdUpcoming = application(TODAY.plusMonths(3), TODAY.plusMonths(3).plusDays(2));
+            final Application lastOfYear = application(TODAY.withMonth(12).withDayOfMonth(20), TODAY.withMonth(12).withDayOfMonth(23));
+
+            final ApplicationOverviewDto applicationOverview = overviewFor(List.of(firstOfYear, nearestPast, current, firstUpcoming, secondUpcoming, thirdUpcoming, lastOfYear));
+
+            assertThat(applicationOverview.applications())
+                .extracting(ApplicationDto::startDate)
+                .containsExactly(
+                    thirdUpcoming.getStartDate(),
+                    secondUpcoming.getStartDate(),
+                    firstUpcoming.getStartDate(),
+                    current.getStartDate(),
+                    nearestPast.getStartDate()
+                );
+            assertThat(applicationOverview.numberOfShownApplications()).isEqualTo(5);
+            assertThat(applicationOverview.numberOfTotalApplications()).isEqualTo(7);
+        }
+
+        @Test
+        void ensureShowsFourUpcomingApplicationsWhenThereIsNoCurrentApplication() throws Exception {
+
+            final Application firstOfYear = application(TODAY.withMonth(1).withDayOfMonth(5), TODAY.withMonth(1).withDayOfMonth(9));
+            final Application nearestPast = application(TODAY.minusMonths(1), TODAY.minusMonths(1).plusDays(2));
+            final Application firstUpcoming = application(TODAY.plusMonths(1), TODAY.plusMonths(1).plusDays(2));
+            final Application secondUpcoming = application(TODAY.plusMonths(2), TODAY.plusMonths(2).plusDays(2));
+            final Application thirdUpcoming = application(TODAY.plusMonths(3), TODAY.plusMonths(3).plusDays(2));
+            final Application fourthUpcoming = application(TODAY.plusMonths(4), TODAY.plusMonths(4).plusDays(2));
+            final Application lastOfYear = application(TODAY.withMonth(12).withDayOfMonth(20), TODAY.withMonth(12).withDayOfMonth(23));
+
+            final ApplicationOverviewDto applicationOverview = overviewFor(List.of(firstOfYear, nearestPast, firstUpcoming, secondUpcoming, thirdUpcoming, fourthUpcoming, lastOfYear));
+
+            assertThat(applicationOverview.applications())
+                .extracting(ApplicationDto::startDate)
+                .containsExactly(
+                    fourthUpcoming.getStartDate(),
+                    thirdUpcoming.getStartDate(),
+                    secondUpcoming.getStartDate(),
+                    firstUpcoming.getStartDate(),
+                    nearestPast.getStartDate()
+                );
+        }
+
+        @Test
+        void ensureApplicationStartingTodayIsShownAsCurrentApplication() throws Exception {
+
+            final Application startingToday = application(TODAY, TODAY.plusDays(2));
+            final Application firstUpcoming = application(TODAY.plusMonths(1), TODAY.plusMonths(1).plusDays(2));
+            final Application secondUpcoming = application(TODAY.plusMonths(2), TODAY.plusMonths(2).plusDays(2));
+            final Application thirdUpcoming = application(TODAY.plusMonths(3), TODAY.plusMonths(3).plusDays(2));
+            final Application fourthUpcoming = application(TODAY.plusMonths(4), TODAY.plusMonths(4).plusDays(2));
+
+            final ApplicationOverviewDto applicationOverview = overviewFor(List.of(startingToday, firstUpcoming, secondUpcoming, thirdUpcoming, fourthUpcoming));
+
+            assertThat(applicationOverview.applications())
+                .extracting(ApplicationDto::startDate)
+                .containsExactly(
+                    thirdUpcoming.getStartDate(),
+                    secondUpcoming.getStartDate(),
+                    firstUpcoming.getStartDate(),
+                    startingToday.getStartDate()
+                );
+        }
+
+        @Test
+        void ensureApplicationEndingTodayIsShownAsCurrentApplication() throws Exception {
+
+            final Application endingToday = application(TODAY.minusDays(2), TODAY);
+            final Application nearestPast = application(TODAY.minusMonths(1), TODAY.minusMonths(1).plusDays(2));
+
+            final ApplicationOverviewDto applicationOverview = overviewFor(List.of(endingToday, nearestPast));
+
+            assertThat(applicationOverview.applications())
+                .extracting(ApplicationDto::startDate)
+                .containsExactly(endingToday.getStartDate(), nearestPast.getStartDate());
+        }
+
+        private ApplicationOverviewDto overviewFor(List<Application> applications) throws Exception {
+            when(settingsService.getSettings()).thenReturn(new Settings());
+            when(personService.getSignedInUser()).thenReturn(person);
+            when(personService.getPersonByID(1L)).thenReturn(Optional.of(person));
+            when(departmentService.isSignedInUserAllowedToAccessPersonData(person, person)).thenReturn(true);
+            when(applicationService.getApplicationsForACertainPeriodAndPerson(any(), any(), eq(person))).thenReturn(applications);
+            stubWorkDaysCountForApplications(ONE);
+
+            final ModelAndView mav = perform(get("/web/person/1/overview")
+                .param("year", String.valueOf(TODAY.getYear()))
+                .locale(GERMAN)
+            ).andReturn().getModelAndView();
+
+            assertThat(mav).isNotNull();
+            final ApplicationOverviewDto applicationOverview = (ApplicationOverviewDto) mav.getModel().get("applicationOverviewInformation");
+            assertThat(applicationOverview).isNotNull();
+            return applicationOverview;
+        }
+
+        private Application application(LocalDate startDate, LocalDate endDate) {
+            final Application application = new Application();
+            application.setVacationType(mock(VacationType.class));
+            application.setPerson(person);
+            application.setStartDate(startDate);
+            application.setEndDate(endDate);
+            return application;
+        }
     }
 
     private Person somePerson() {


### PR DESCRIPTION
Auf der Übersichtsseite wurden die Abwesenheiten angezeigt, die zeitlich am weitesten von heute entfernt sind, statt der nächstliegenden.

Beispiel: heute ist der 04.08.2026, die Person hat A 05.01., B 04.07., C 01.08.–07.08. (läuft gerade), D 04.09., E 04.10., F 20.12.

* vorher: `F, E, D, A`
* jetzt: `E, D, C, B`

## Was war falsch

* Der Vergangenheits-Topf wurde **aufsteigend** sortiert und auf einen Eintrag begrenzt, also gewann immer die **erste Abwesenheit des Jahres** statt der jüngsten vergangenen.
* Der Zukunfts-Topf wurde **absteigend** sortiert, es kamen also die **letzten** Abwesenheiten des Jahres statt der nächsten anstehenden.
* "Vergangen" wurde nur über das Startdatum bestimmt. Eine laufende Abwesenheit landete dadurch im Vergangenheits-Topf und wurde dort durch die aufsteigende Sortierung verdrängt – die gerade laufende Abwesenheit war die einzige, die nie angezeigt werden konnte.

## Was sich ändert

Drei disjunkte Töpfe, jeweils in Richtung heute sortiert:

* **vergangen**: `endDate < heute`
* **aktuell**: `startDate <= heute <= endDate`
* **zukünftig**: `startDate > heute`

Angezeigt werden maximal 5 Abwesenheiten: die jüngste vergangene, die aktuell laufende (sofern vorhanden) und bis zu 4 anstehende, wobei die laufende einen Platz der zukünftigen belegt. Die Liste bleibt absteigend nach Startdatum sortiert – zukünftige oben, die vergangene unten.

Krankmeldungen und Überstunden bleiben unverändert.

## Tests

Neue `@Nested`-Klasse `ApplicationsShownOnOverview` in `OverviewViewControllerTest` mit fester Uhr:

* jüngste vergangene + aktuelle + die nächsten anstehenden, in der richtigen Reihenfolge
* 4 anstehende, wenn keine Abwesenheit läuft
* eine heute beginnende Abwesenheit zählt als aktuell
* eine heute endende Abwesenheit zählt als aktuell

Alle vier Tests scheitern gegen den alten Stand mit genau der oben beschriebenen Reihenfolge.

Closes #6460
