### PR TITLE
fix: sort sick notes and overtimes on the overview page explicitly

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/overview/OverviewViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overview/OverviewViewController.java
@@ -39,11 +39,13 @@ import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.Year;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.SortedMap;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
@@ -277,6 +279,33 @@ public class OverviewViewController implements HasLaunchpad, HasPersonSearch {
             .toList();
     }
 
+    /**
+     * Selects the entries closest to today: the next upcoming ones and, since most of the time there are no upcoming
+     * ones, the most recent past ones to fill up the remaining slots.
+     *
+     * @return the selected entries, sorted descending by start date, the upcoming ones first
+     */
+    static <T> List<T> entriesClosestToToday(List<T> entries, Function<T, LocalDate> startDate, LocalDate today, int pastLimit, int futureLimit) {
+
+        final Comparator<T> byStartDate = comparing(startDate);
+
+        final List<T> futureEntries = entries.stream()
+            .filter(entry -> !startDate.apply(entry).isBefore(today))
+            .sorted(byStartDate)
+            .limit(futureLimit)
+            .toList();
+
+        final List<T> pastEntries = entries.stream()
+            .filter(entry -> startDate.apply(entry).isBefore(today))
+            .sorted(byStartDate.reversed())
+            .limit((long) pastLimit - futureEntries.size())
+            .toList();
+
+        return Stream.concat(futureEntries.stream(), pastEntries.stream())
+            .sorted(byStartDate.reversed())
+            .toList();
+    }
+
     private void prepareSickNoteInformation(Person person, Person signedInUser, int year, Model model) {
 
         final LocalDate from = Year.of(year).atDay(1);
@@ -286,20 +315,8 @@ public class OverviewViewController implements HasLaunchpad, HasPersonSearch {
 
         final LocalDate today = LocalDate.now(clock);
 
-        // most of the time there are no future sick notes therefore we fill with past sick notes
-        final List<SickNote> futureSickNotes = sickNotes.stream()
-            .filter(s -> !s.getStartDate().isBefore(today))
-            .sorted(comparing(SickNote::getStartDate))
-            .limit(NUMBER_OF_FUTR_SICK_NOTES_ON_OVERVIEW)
-            .toList();
-
-        final List<SickNote> pastSickNotes = sickNotes.stream()
-            .filter(s -> s.getStartDate().isBefore(today))
-            .sorted(comparing(SickNote::getStartDate).reversed())
-            .limit((long) NUMBER_OF_PAST_SICK_NOTES_ON_OVERVIEW - futureSickNotes.size())
-            .toList();
-
-        final List<SickNote> shownSickNotes = Stream.concat(futureSickNotes.stream(), pastSickNotes.stream()).toList();
+        final List<SickNote> shownSickNotes = entriesClosestToToday(sickNotes, SickNote::getStartDate, today,
+            NUMBER_OF_PAST_SICK_NOTES_ON_OVERVIEW, NUMBER_OF_FUTR_SICK_NOTES_ON_OVERVIEW);
 
         final boolean isSamePerson = person.equals(signedInUser);
         final boolean userIsAllowedToSubmitSickNotes = isSamePerson && settingsService.getSettings().getSickNoteSettings().getUserIsAllowedToSubmitSickNotes();
@@ -345,21 +362,8 @@ public class OverviewViewController implements HasLaunchpad, HasPersonSearch {
 
         final LocalDate today = LocalDate.now(clock);
 
-        // most of the time there are no future sick notes therefore we fill with past sick notes
-        final List<Overtime> futureOvertimes = overtimes.stream()
-            .filter(s -> !s.startDate().isBefore(today))
-            .sorted(comparing(Overtime::startDate))
-            .limit(NUMBER_OF_FUTR_OVERTIMES_ON_OVERVIEW)
-            .toList();
-
-
-        final List<Overtime> pastOvertimes = overtimes.stream()
-            .filter(s -> s.startDate().isBefore(today))
-            .sorted(comparing(Overtime::startDate).reversed())
-            .limit((long) NUMBER_OF_PAST_OVERTIMES_ON_OVERVIEW - futureOvertimes.size())
-            .toList();
-
-        final List<Overtime> shownOvertimes = Stream.concat(futureOvertimes.stream(), pastOvertimes.stream()).toList();
+        final List<Overtime> shownOvertimes = entriesClosestToToday(overtimes, Overtime::startDate, today,
+            NUMBER_OF_PAST_OVERTIMES_ON_OVERVIEW, NUMBER_OF_FUTR_OVERTIMES_ON_OVERVIEW);
 
         final OvertimeOverviewDto overtimeOverviewDto = new OvertimeOverviewDto(
             settingsService.getSettings().getOvertimeSettings().isOvertimeActive(),

--- a/src/test/java/org/synyx/urlaubsverwaltung/overview/OverviewViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overview/OverviewViewControllerTest.java
@@ -1229,6 +1229,64 @@ class OverviewViewControllerTest {
         }
     }
 
+    @Nested
+    class EntriesClosestToToday {
+
+        private static final LocalDate TODAY = LocalDate.parse("2026-08-04");
+
+        @Test
+        void ensureSortedDescendingByStartDateIndependentOfTheFutureLimit() {
+
+            final List<LocalDate> entries = List.of(
+                LocalDate.parse("2026-07-01"),
+                LocalDate.parse("2026-07-20"),
+                LocalDate.parse("2026-08-10"),
+                LocalDate.parse("2026-09-01")
+            );
+
+            final List<LocalDate> actual = OverviewViewController.entriesClosestToToday(entries, identity(), TODAY, 3, 2);
+
+            assertThat(actual).containsExactly(
+                LocalDate.parse("2026-09-01"),
+                LocalDate.parse("2026-08-10"),
+                LocalDate.parse("2026-07-20")
+            );
+        }
+
+        @Test
+        void ensureFillsTheFreeSlotsWithTheMostRecentPastEntries() {
+
+            final List<LocalDate> entries = List.of(
+                LocalDate.parse("2026-06-01"),
+                LocalDate.parse("2026-07-01"),
+                LocalDate.parse("2026-07-20"),
+                LocalDate.parse("2026-08-10")
+            );
+
+            final List<LocalDate> actual = OverviewViewController.entriesClosestToToday(entries, identity(), TODAY, 3, 1);
+
+            assertThat(actual).containsExactly(
+                LocalDate.parse("2026-08-10"),
+                LocalDate.parse("2026-07-20"),
+                LocalDate.parse("2026-07-01")
+            );
+        }
+
+        @Test
+        void ensureEntryStartingTodayIsAnUpcomingEntry() {
+
+            final List<LocalDate> entries = List.of(
+                LocalDate.parse("2026-07-20"),
+                TODAY,
+                LocalDate.parse("2026-09-01")
+            );
+
+            final List<LocalDate> actual = OverviewViewController.entriesClosestToToday(entries, identity(), TODAY, 3, 1);
+
+            assertThat(actual).containsExactly(TODAY, LocalDate.parse("2026-07-20"));
+        }
+    }
+
     private Person somePerson() {
         return new Person();
     }


### PR DESCRIPTION
Die angezeigten Krankmeldungen und Überstunden wurden in zwei Töpfen ermittelt – die anstehenden aufsteigend, die jüngsten vergangenen absteigend – und anschließend ohne weitere Sortierung aneinandergehängt.

Dass die Liste heute absteigend gelesen wird, ist ein Nebeneffekt des Limits: der Zukunfts-Topf darf genau **einen** Eintrag enthalten, und ein einzelner Eintrag ist in jeder Sortierrichtung gleich. Wird das Limit auf 2 erhöht – zum Beispiel, um mehr anstehende Krankmeldungen zu zeigen – stehen die zukünftigen Einträge aufsteigend über den absteigend sortierten vergangenen, und die Liste springt in der Mitte.

## Was sich ändert

Die Auswahl liegt jetzt in `entriesClosestToToday(entries, startDate, today, pastLimit, futureLimit)` und wird von beiden Stellen genutzt. Die zusammengesetzte Liste wird dort **explizit absteigend** nach Startdatum sortiert, unabhängig von den Limits.

Nebeneffekt: die zweimal duplizierte Filter-/Sortier-/Limit-Kette entfällt, ebenso der kopierte Kommentar, der bei den Überstunden noch von "sick notes" sprach.

**Das Verhalten mit den aktuellen Konstanten ist unverändert** (1 anstehender Eintrag, 3 Einträge insgesamt). Der Fix wirkt erst, wenn die Limits erhöht werden.

## Tests

Neue `@Nested`-Klasse `EntriesClosestToToday` in `OverviewViewControllerTest`:

* absteigende Reihenfolge unabhängig vom Limit der zukünftigen Einträge
* freie Plätze werden mit den jüngsten vergangenen Einträgen aufgefüllt
* ein heute beginnender Eintrag zählt als anstehend

Umgesetzt in zwei Schritten: erst die reine Extraktion der Methode ohne Verhaltensänderung (bestehende Tests grün), dann der Test mit `futureLimit = 2`, der gegen den alten Stand mit `[10.08., 01.09., 20.07.]` scheitert, und danach die Sortierung.

Closes #6462
