### PR TITLE
Batch fetch vacation types and sick note types

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/application/vacationtype/VacationTypeEntity.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/vacationtype/VacationTypeEntity.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.annotations.BatchSize;
 import org.synyx.urlaubsverwaltung.tenancy.tenant.AbstractTenantAwareEntity;
 
 import java.util.Locale;
@@ -23,6 +24,7 @@ import static jakarta.persistence.GenerationType.SEQUENCE;
  * @since 2.15.0
  */
 @Entity(name = "vacation_type")
+@BatchSize(size = 500)
 public class VacationTypeEntity extends AbstractTenantAwareEntity {
 
     @Id

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknotetype/SickNoteType.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknotetype/SickNoteType.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.annotations.BatchSize;
 import org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteCategory;
 import org.synyx.urlaubsverwaltung.tenancy.tenant.AbstractTenantAwareEntity;
 
@@ -16,6 +17,7 @@ import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.GenerationType.SEQUENCE;
 
 @Entity
+@BatchSize(size = 500)
 public class SickNoteType extends AbstractTenantAwareEntity {
 
     @Id

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationRepositoryIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationRepositoryIT.java
@@ -761,6 +761,61 @@ class ApplicationRepositoryIT extends SingleTenantTestContainersBase {
         assertThat(statementsForThreeApplicants).isEqualTo(statementsForOneApplicant);
     }
 
+    @Test
+    void ensureVacationTypesAreFetchedWithoutOneQueryPerVacationType() {
+
+        final List<VacationTypeEntity> vacationTypes = vacationTypeService.getAllVacationTypes().stream()
+            .map(VacationTypeServiceImpl::convert)
+            .toList();
+        assertThat(vacationTypes).hasSizeGreaterThan(1);
+
+        final Person person = personService.create("muster", "Max", "Mustermann", "mustermann@example.org");
+        final LocalDate askedStartDate = LocalDate.now(UTC).with(firstDayOfMonth());
+        final LocalDate askedEndDate = LocalDate.now(UTC).with(lastDayOfMonth());
+
+        // same person and same number of applications in both measurements below, so that the number of distinct
+        // vacation types to resolve for the eager `vacationType` association is the only thing that differs.
+        for (int i = 0; i < vacationTypes.size(); i++) {
+            final ApplicationEntity application = applicationEntity(person, vacationTypes.getFirst(), askedStartDate, askedEndDate, FULL);
+            application.setStatus(WAITING);
+            sut.save(application);
+        }
+
+        final long statementsForOneVacationType = fetchAndTouchVacationTypes(person, askedStartDate, askedEndDate, vacationTypes.size());
+
+        // now give every application its own vacation type
+        final List<ApplicationEntity> applications = sut.findByPersonInAndEndDateIsGreaterThanEqualAndStartDateIsLessThanEqualAndStatusIn(
+            List.of(person), askedStartDate, askedEndDate, List.of(WAITING));
+        for (int i = 0; i < applications.size(); i++) {
+            final ApplicationEntity application = applications.get(i);
+            application.setVacationType(vacationTypes.get(i));
+            sut.save(application);
+        }
+
+        final long statementsForDistinctVacationTypes = fetchAndTouchVacationTypes(person, askedStartDate, askedEndDate, vacationTypes.size());
+
+        // resolving one distinct vacation type per application must not cost any extra queries
+        assertThat(statementsForDistinctVacationTypes).isEqualTo(statementsForOneVacationType);
+    }
+
+    private long fetchAndTouchVacationTypes(Person person, LocalDate from, LocalDate to, int expectedApplicationCount) {
+
+        // force the next query to actually hit the database instead of returning managed entities from the session cache
+        entityManager.flush();
+        entityManager.clear();
+
+        final Statistics statistics = entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+        statistics.setStatisticsEnabled(true);
+        statistics.clear();
+
+        final List<ApplicationEntity> applications = sut.findByPersonInAndEndDateIsGreaterThanEqualAndStartDateIsLessThanEqualAndStatusIn(
+            List.of(person), from, to, List.of(WAITING));
+        applications.forEach(application -> application.getVacationType().getCategory());
+
+        assertThat(applications).hasSize(expectedApplicationCount);
+        return statistics.getPrepareStatementCount();
+    }
+
     private long fetchAndTouchApplicants(List<Person> persons, LocalDate from, LocalDate to, int expectedApplicationCount) {
 
         // force the next query to actually hit the database instead of returning managed entities from the session cache

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteRepositoryIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteRepositoryIT.java
@@ -1,5 +1,9 @@
 package org.synyx.urlaubsverwaltung.sicknote.sicknote;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -7,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.synyx.urlaubsverwaltung.SingleTenantTestContainersBase;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
+import org.synyx.urlaubsverwaltung.sicknote.sicknotetype.SickNoteType;
+import org.synyx.urlaubsverwaltung.sicknote.sicknotetype.SickNoteTypeService;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -29,6 +35,15 @@ class SickNoteRepositoryIT extends SingleTenantTestContainersBase {
 
     @Autowired
     private PersonService personService;
+
+    @Autowired
+    private SickNoteTypeService sickNoteTypeService;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
 
     @Test
     void ensureToFindSickNotesForNotificationOfSickPayEnd() {
@@ -244,6 +259,60 @@ class SickNoteRepositoryIT extends SingleTenantTestContainersBase {
         final List<SickNoteEntity> actualSickNotes = sickNoteRepository.findByStatusInAndPersonInAndEndDateIsGreaterThanEqualAndStartDateIsLessThanEqual(statuses, persons, askedStartDate, askedEndDate);
 
         assertThat(actualSickNotes).contains(noteStartingBeforePeriod, noteEndingAfterPeriod, noteInBetween, noteStartingAtPeriod, noteEndingAtPeriod);
+    }
+
+    @Test
+    void ensureSickNoteTypesAreFetchedWithoutOneQueryPerSickNoteType() {
+
+        final List<SickNoteType> sickNoteTypes = sickNoteTypeService.getSickNoteTypes();
+        assertThat(sickNoteTypes).hasSizeGreaterThan(1);
+
+        final Person person = personService.create("muster", "Max", "Mustermann", "mustermann@example.org");
+
+        final LocalDate askedStartDate = LocalDate.now(UTC).with(firstDayOfMonth());
+        final LocalDate askedEndDate = LocalDate.now(UTC).with(lastDayOfMonth());
+
+        // same person and same number of sick notes in both measurements below, so that the number of distinct
+        // sick note types to resolve for the eager `sickNoteType` association is the only thing that differs.
+        for (int i = 0; i < sickNoteTypes.size(); i++) {
+            final SickNoteEntity sickNote = createSickNote(person, askedStartDate, askedEndDate, ACTIVE);
+            sickNote.setSickNoteType(sickNoteTypes.getFirst());
+            sickNoteRepository.save(sickNote);
+        }
+
+        final long statementsForOneSickNoteType = fetchAndTouchSickNoteTypes(person, askedStartDate, askedEndDate, sickNoteTypes.size());
+
+        // now give every sick note its own type
+        final List<SickNoteEntity> sickNotes = sickNoteRepository.findByStatusInAndPersonInAndEndDateIsGreaterThanEqualAndStartDateIsLessThanEqual(
+            List.of(ACTIVE), List.of(person), askedStartDate, askedEndDate);
+        for (int i = 0; i < sickNotes.size(); i++) {
+            final SickNoteEntity sickNote = sickNotes.get(i);
+            sickNote.setSickNoteType(sickNoteTypes.get(i));
+            sickNoteRepository.save(sickNote);
+        }
+
+        final long statementsForDistinctSickNoteTypes = fetchAndTouchSickNoteTypes(person, askedStartDate, askedEndDate, sickNoteTypes.size());
+
+        // resolving one distinct sick note type per sick note must not cost any extra queries
+        assertThat(statementsForDistinctSickNoteTypes).isEqualTo(statementsForOneSickNoteType);
+    }
+
+    private long fetchAndTouchSickNoteTypes(Person person, LocalDate from, LocalDate to, int expectedSickNoteCount) {
+
+        // force the next query to actually hit the database instead of returning managed entities from the session cache
+        entityManager.flush();
+        entityManager.clear();
+
+        final Statistics statistics = entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+        statistics.setStatisticsEnabled(true);
+        statistics.clear();
+
+        final List<SickNoteEntity> sickNotes = sickNoteRepository.findByStatusInAndPersonInAndEndDateIsGreaterThanEqualAndStartDateIsLessThanEqual(
+            List.of(ACTIVE), List.of(person), from, to);
+        sickNotes.forEach(sickNote -> sickNote.getSickNoteType().getCategory());
+
+        assertThat(sickNotes).hasSize(expectedSickNoteCount);
+        return statistics.getPrepareStatementCount();
     }
 
     private SickNoteEntity createSickNote(Person person, LocalDate startDate, LocalDate endDate, SickNoteStatus active) {


### PR DESCRIPTION
`ApplicationEntity.vacationType` and `SickNoteEntity.sickNoteType` are default-EAGER `@ManyToOne` associations that Hibernate resolves one FK at a time, so every distinct type of the loaded rows costs its own SELECT. With the 16 seeded default vacation types that is up to 15 extra round trips per persistence context - and since `spring.jpa.open-in-view` is disabled, every service call gets its own context and pays again.

Measured for 16 applications of one person on a leave statistics style query: 20 prepared statements for 16 distinct vacation types versus 5 for a single one. With `@BatchSize` it stays at 5.

Same treatment as the `Person` entity already gets.

closes #6476

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
