### PR TITLE
Remove unused google-http-client-jackson2 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,11 +201,6 @@
       <artifactId>google-api-services-calendar</artifactId>
       <version>v3-rev20251207-2.0.0</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client-jackson2</artifactId>
-      <version>2.2.0</version>
-    </dependency>
 
     <!-- Security -->
     <dependency>


### PR DESCRIPTION
The google calendar integration uses GsonFactory throughout, in GoogleApiConfiguration and GoogleCalendarOAuthHandshakeViewController. GsonFactory comes from google-http-client-gson, pulled in transitively by google-api-client, and there is no JacksonFactory reference under src/ at all.

The dependency had already been removed in 5e9ffd158 when the integration was switched to gson. Commit 8d5b1274f re-added it: it was authored in 2021 but only landed on main in July 2023, seven months after the removal, so a stale branch brought back a dependency nobody uses. The build passes either way, which is why it went unnoticed.

It was also pinned to 2.2.0 while the rest of the google-http-client stack resolves to 2.0.0.

closes #6482


<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
