### PR TITLE
Fix the mobile navigation on pages without javascript

### DIFF
--- a/src/main/css/bundles/style.css
+++ b/src/main/css/bundles/style.css
@@ -35,7 +35,7 @@
 @layer base {
   :root {
     /* info-banner is optional and value is overridden by javascript with real height on runtime. as we don't know the content yet... */
-    --info-banner-height: 0;
+    --info-banner-height: 0px;
   }
 
   html {

--- a/src/main/css/theme.css
+++ b/src/main/css/theme.css
@@ -4,6 +4,16 @@
   initial-value: 300px;
 }
 
+/* must be a length, never a unitless 0. it is used in calc() with other lengths
+ * (e.g. the mobile navigation drawer) and a unitless value makes those invalid at
+ * computed-value time, dropping the declaration. registering the type guarantees a
+ * usable value even on pages without javascript, e.g. the error pages. */
+@property --info-banner-height {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 0px;
+}
+
 /* regular variables not required by tailwindcss toolchain */
 :root {
   --nav-width: 300px;
@@ -16,7 +26,7 @@
   --z-index-sticky: 100;
 
   /* info-banner is optional and value is overridden by javascript with real height on runtime. as we don't know the content yet... */
-  --info-banner-height: 0;
+  --info-banner-height: 0px;
   --topbar-height: 3.5rem;
   --search-bar-height: 3.5rem;
 

--- a/src/main/javascript/bundles/frame.js
+++ b/src/main/javascript/bundles/frame.js
@@ -1,0 +1,3 @@
+// javascript of the page frame (navigation, info banner, topbar, ...) without any page specific behaviour.
+// used by pages that only render the frame around static content, e.g. the error pages.
+import "../js/common";

--- a/src/main/resources/templates/application/application-not-editable.html
+++ b/src/main/resources/templates/application/application-not-editable.html
@@ -5,9 +5,16 @@
   th:class="|theme-${theme}|"
   th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
+  xmlns:asset="http://www.w3.org/1999/xhtml"
 >
-  <head th:replace="~{_layout::head(~{::title})}">
+  <head th:replace="~{_layout::head(title=~{::title}, scriptsDefer=~{::scriptsDefer}, preload=~{::preload})}">
     <title th:text="#{application.error.notEditable.title}"></title>
+    <th:block th:fragment="preload">
+      <link rel="preload" th:replace="~{fragments/asset-dependency-preload::links('frame.js')}" />
+    </th:block>
+    <th:block th:fragment="scriptsDefer">
+      <script defer type="module" asset:src="frame.js"></script>
+    </th:block>
   </head>
   <body th:replace="~{_layout::body(content=~{::main})}">
     <main th:fragment="main" class="content-container content--max-w text-center">

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -5,9 +5,16 @@
   th:class="|theme-${theme}|"
   th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
+  xmlns:asset="http://www.w3.org/1999/xhtml"
 >
-  <head th:replace="~{_layout::head(title=~{::title})}">
+  <head th:replace="~{_layout::head(title=~{::title}, scriptsDefer=~{::scriptsDefer}, preload=~{::preload})}">
     <title th:text="#{error-page.common.meta.title}"></title>
+    <th:block th:fragment="preload">
+      <link rel="preload" th:replace="~{fragments/asset-dependency-preload::links('frame.js')}" />
+    </th:block>
+    <th:block th:fragment="scriptsDefer">
+      <script defer type="module" asset:src="frame.js"></script>
+    </th:block>
   </head>
   <body th:replace="~{_layout::body(content=~{::main})}">
     <main th:fragment="main" class="content-container content--max-w">

--- a/src/main/resources/templates/error/403.html
+++ b/src/main/resources/templates/error/403.html
@@ -5,9 +5,16 @@
   th:class="|theme-${theme}|"
   th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
+  xmlns:asset="http://www.w3.org/1999/xhtml"
 >
-  <head th:replace="~{_layout::head(title=~{::title})}">
+  <head th:replace="~{_layout::head(title=~{::title}, scriptsDefer=~{::scriptsDefer}, preload=~{::preload})}">
     <title th:text="#{error-page.common.meta.title}"></title>
+    <th:block th:fragment="preload">
+      <link rel="preload" th:replace="~{fragments/asset-dependency-preload::links('frame.js')}" />
+    </th:block>
+    <th:block th:fragment="scriptsDefer">
+      <script defer type="module" asset:src="frame.js"></script>
+    </th:block>
   </head>
   <body th:replace="~{_layout::body(content=~{::main})}">
     <main th:ref="main" class="content-container content--max-w">

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -5,9 +5,16 @@
   th:class="|theme-${theme}|"
   th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
+  xmlns:asset="http://www.w3.org/1999/xhtml"
 >
-  <head th:replace="~{_layout::head(title=~{::title})}">
+  <head th:replace="~{_layout::head(title=~{::title}, scriptsDefer=~{::scriptsDefer}, preload=~{::preload})}">
     <title th:text="#{error-page.common.meta.title}"></title>
+    <th:block th:fragment="preload">
+      <link rel="preload" th:replace="~{fragments/asset-dependency-preload::links('frame.js')}" />
+    </th:block>
+    <th:block th:fragment="scriptsDefer">
+      <script defer type="module" asset:src="frame.js"></script>
+    </th:block>
   </head>
   <body th:replace="~{_layout::body(content=~{::main})}">
     <main th:ref="main" class="content-container content--max-w">

--- a/src/main/resources/templates/error/5xx.html
+++ b/src/main/resources/templates/error/5xx.html
@@ -5,9 +5,16 @@
   th:class="|theme-${theme}|"
   th:data-nav-collapsed="${navigationCollapsed ? 'true' : null}"
   xmlns:th="http://www.thymeleaf.org"
+  xmlns:asset="http://www.w3.org/1999/xhtml"
 >
-  <head th:replace="~{_layout::head(title=~{::title})}">
+  <head th:replace="~{_layout::head(title=~{::title}, scriptsDefer=~{::scriptsDefer}, preload=~{::preload})}">
     <title th:text="#{error-page.common.meta.title}"></title>
+    <th:block th:fragment="preload">
+      <link rel="preload" th:replace="~{fragments/asset-dependency-preload::links('frame.js')}" />
+    </th:block>
+    <th:block th:fragment="scriptsDefer">
+      <script defer type="module" asset:src="frame.js"></script>
+    </th:block>
   </head>
   <body th:replace="~{_layout::body(content=~{::main})}">
     <main th:fragment="main" class="content-container content--max-w">

--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/pages/NavigationPage.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/pages/NavigationPage.java
@@ -33,6 +33,11 @@ public class NavigationPage {
      * Clicks the link, does not wait for anything. You have to wait for the next visible page yourself!
      */
     public void clickSickNotes() {
+        // this navigation item has sub items, therefore it is rendered as a `button[data-href]` and not as an `a[href]`.
+        // such a button is navigated by the click handler of navigation.js, so clicking it before the javascript of the
+        // page has been evaluated is silently swallowed and the browser stays on the current page. waiting for
+        // DOMContentLoaded guarantees the deferred module scripts ran and the handler is registered.
+        page.waitForLoadState(DOMCONTENTLOADED);
         page.locator(SICK_NOTES_SELECTOR).click();
     }
 


### PR DESCRIPTION
--info-banner-height was declared as a unitless 0. Every consumer uses it in calc() together with lengths, e.g. the mobile navigation drawer

    top: calc(var(--topbar-height) + var(--info-banner-height));

which mixes <length> with <number> and is therefore invalid at computed-value time. top and height fell back to auto, leaving only bottom: 0 from the user agent stylesheet, so the opened drawer was content sized and pinned to the bottom of the viewport instead of covering it.

Regular pages never showed this because info-banner.js injects the variable with a px unit at runtime. The error pages load no javascript bundle at all, so the broken default survived there.

Declare the variable as a length and register it with @property, the way --nav-width already is, so a unitless value cannot break the calc()s again.

The error pages did not run any javascript either, which left #nav-toggle and the other frame behaviour dead. Add a frame.js bundle with the common frame javascript and load it on the pages that only render static content inside the frame.

closes #6484

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
