### PR TITLE
Keep the wordmark clickable while the navigation is collapsed

### DIFF
--- a/src/main/css/components/topbar.css
+++ b/src/main/css/components/topbar.css
@@ -3,6 +3,17 @@
   height: var(--topbar-height);
 }
 
+@variant desktop {
+  /* the collapsed navigation is narrower than the wordmark, which therefore overflows
+   * into the neighbouring search cell. both cells share the topbar z-index, so the search
+   * container - later in the dom - would win the hit test and swallow clicks on the
+   * wordmark. lift the cell above every other topbar layer (the backdrop border below
+   * already uses + 1) so the overflowing part stays clickable. */
+  html[data-nav-collapsed] .launchpad-app-cell {
+    z-index: calc(var(--z-index-topbar) + 2);
+  }
+}
+
 .topbar-backdrop {
   anchor-name: --topbbar-backdrop-anchor;
   z-index: var(--z-index-topbar);


### PR DESCRIPTION
The collapsed navigation is 5rem wide, the "Urlaubsverwaltung" wordmark is not. It therefore overflows its grid cell into the neighbouring search cell. Both cells carry the topbar z-index, and the search container comes later in the dom, so it won the hit test and swallowed every click on the overflowing part of the wordmark.

Measured at 1440px with the navigation collapsed: the wordmark spans x=60..213, its cell ends at x=80 and the search container starts there. Only the leftmost 20px of the wordmark were clickable. The search input itself sits at x=468, so nothing visible overlaps - it is the empty left part of the container that intercepted the clicks.

Lift the launchpad cell above the other topbar layers while the navigation is collapsed. The expanded navigation is wide enough for the wordmark, so the stacking is left alone there.

closes #6486

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
