### PR TITLE
Fix sick note accept form action URL being triplicated behind a rever…

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/calendar/CalendarSharingViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendar/CalendarSharingViewController.java
@@ -227,9 +227,11 @@ public class CalendarSharingViewController implements HasLaunchpad, HasPersonSea
         final Optional<PersonCalendar> maybePersonCalendar = personCalendarService.getPersonCalendar(personId);
         if (maybePersonCalendar.isPresent()) {
             final PersonCalendar personCalendar = maybePersonCalendar.get();
-            final var path = "web/persons/%d/calendar?secret=%s".formatted(personId, personCalendar.getSecret());
-            final var url = ServletUriComponentsBuilder.fromCurrentRequestUri()
-                .replacePath(path).build().toString();
+            final var url = ServletUriComponentsBuilder.fromCurrentContextPath()
+                .path("/web/persons/{personId}/calendar")
+                .queryParam("secret", personCalendar.getSecret())
+                .buildAndExpand(personId)
+                .toUriString();
 
             dto.setCalendarUrl(url);
             dto.setCalendarPeriod(CalendarPeriodViewType.ofPeriod(personCalendar.getCalendarPeriod()));
@@ -268,9 +270,11 @@ public class CalendarSharingViewController implements HasLaunchpad, HasPersonSea
             final var maybeDepartmentCalendar = Optional.ofNullable(departmentCalendarByDepartmentId.get(departmentId));
             if (maybeDepartmentCalendar.isPresent()) {
                 final var departmentCalendar = maybeDepartmentCalendar.get();
-                final var path = "web/departments/%s/persons/%s/calendar?secret=%s".formatted(departmentId, personId, departmentCalendar.getSecret());
-                final var url = ServletUriComponentsBuilder.fromCurrentRequestUri()
-                    .replacePath(path).build().toString();
+                final var url = ServletUriComponentsBuilder.fromCurrentContextPath()
+                    .path("/web/departments/{departmentId}/persons/{personId}/calendar")
+                    .queryParam("secret", departmentCalendar.getSecret())
+                    .buildAndExpand(departmentId, personId)
+                    .toUriString();
 
                 departmentCalendarDto.setCalendarUrl(url);
                 departmentCalendarDto.setCalendarPeriod(CalendarPeriodViewType.ofPeriod(departmentCalendar.getCalendarPeriod()));
@@ -295,9 +299,11 @@ public class CalendarSharingViewController implements HasLaunchpad, HasPersonSea
         if (maybeCompanyCalendar.isPresent()) {
 
             final CompanyCalendar companyCalendar = maybeCompanyCalendar.get();
-            final var path = "web/company/persons/%d/calendar?secret=%s".formatted(personId, companyCalendar.getSecret());
-            final var url = ServletUriComponentsBuilder.fromCurrentRequestUri()
-                .replacePath(path).build().toString();
+            final var url = ServletUriComponentsBuilder.fromCurrentContextPath()
+                .path("/web/company/persons/{personId}/calendar")
+                .queryParam("secret", companyCalendar.getSecret())
+                .buildAndExpand(personId)
+                .toUriString();
 
             companyCalendarDto.setCalendarUrl(url);
             companyCalendarDto.setCalendarPeriod(CalendarPeriodViewType.ofPeriod(companyCalendar.getCalendarPeriod()));

--- a/src/main/java/org/synyx/urlaubsverwaltung/calendar/CalendarSharingViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendar/CalendarSharingViewController.java
@@ -227,11 +227,9 @@ public class CalendarSharingViewController implements HasLaunchpad, HasPersonSea
         final Optional<PersonCalendar> maybePersonCalendar = personCalendarService.getPersonCalendar(personId);
         if (maybePersonCalendar.isPresent()) {
             final PersonCalendar personCalendar = maybePersonCalendar.get();
+            final var path = "/web/persons/%d/calendar?secret=%s".formatted(personId, personCalendar.getSecret());
             final var url = ServletUriComponentsBuilder.fromCurrentContextPath()
-                .path("/web/persons/{personId}/calendar")
-                .queryParam("secret", personCalendar.getSecret())
-                .buildAndExpand(personId)
-                .toUriString();
+                .path(path).build().toString();
 
             dto.setCalendarUrl(url);
             dto.setCalendarPeriod(CalendarPeriodViewType.ofPeriod(personCalendar.getCalendarPeriod()));
@@ -270,11 +268,9 @@ public class CalendarSharingViewController implements HasLaunchpad, HasPersonSea
             final var maybeDepartmentCalendar = Optional.ofNullable(departmentCalendarByDepartmentId.get(departmentId));
             if (maybeDepartmentCalendar.isPresent()) {
                 final var departmentCalendar = maybeDepartmentCalendar.get();
+                final var path = "/web/departments/%s/persons/%s/calendar?secret=%s".formatted(departmentId, personId, departmentCalendar.getSecret());
                 final var url = ServletUriComponentsBuilder.fromCurrentContextPath()
-                    .path("/web/departments/{departmentId}/persons/{personId}/calendar")
-                    .queryParam("secret", departmentCalendar.getSecret())
-                    .buildAndExpand(departmentId, personId)
-                    .toUriString();
+                    .path(path).build().toString();
 
                 departmentCalendarDto.setCalendarUrl(url);
                 departmentCalendarDto.setCalendarPeriod(CalendarPeriodViewType.ofPeriod(departmentCalendar.getCalendarPeriod()));
@@ -299,11 +295,9 @@ public class CalendarSharingViewController implements HasLaunchpad, HasPersonSea
         if (maybeCompanyCalendar.isPresent()) {
 
             final CompanyCalendar companyCalendar = maybeCompanyCalendar.get();
+            final var path = "/web/company/persons/%d/calendar?secret=%s".formatted(personId, companyCalendar.getSecret());
             final var url = ServletUriComponentsBuilder.fromCurrentContextPath()
-                .path("/web/company/persons/{personId}/calendar")
-                .queryParam("secret", companyCalendar.getSecret())
-                .buildAndExpand(personId)
-                .toUriString();
+                .path(path).build().toString();
 
             companyCalendarDto.setCalendarUrl(url);
             companyCalendarDto.setCalendarPeriod(CalendarPeriodViewType.ofPeriod(companyCalendar.getCalendarPeriod()));

--- a/src/main/resources/templates/sicknote/sick_note_detail.html
+++ b/src/main/resources/templates/sicknote/sick_note_detail.html
@@ -117,11 +117,11 @@
               th:classappend="${action eq 'allow' ? '' : 'hidden'}"
               method="post"
               th:with="isShortcut=${param.shortcut != null && #lists.contains(param.shortcut, 'true')},
-                       redirectTo=@{/web/sicknote/submitted},
-                       acceptUrl=@{/web/sicknote/__${sickNote.id}__/accept},
-                       acceptExtensionUrl=@{/web/sicknote/__${sickNote.id}__/extension/accept},
-                       actionUrl=@{${extensionRequested ? acceptExtensionUrl : acceptUrl} (redirect=${isShortcut ? redirectTo : null})}"
-              th:action="@{__${actionUrl}__}"
+                       redirectTo=${'/web/sicknote/submitted'},
+                       acceptUrl=${'/web/sicknote/' + sickNote.id + '/accept'},
+                       acceptExtensionUrl=${'/web/sicknote/' + sickNote.id + '/extension/accept'},
+                       actionUrl=${extensionRequested ? acceptExtensionUrl : acceptUrl}"
+              th:action="@{${actionUrl}(redirect=${isShortcut ? redirectTo : null})}"
               th:object="${comment}"
             >
               <input th:if="${shortcut}" type="hidden" name="shortcut" th:value="${shortcut}" />


### PR DESCRIPTION
# Fix sick note accept form action URL being triplicated behind a reverse proxy

## Problem

When Urlaubsverwaltung is deployed behind a reverse proxy with a non-root context path, e.g.:

```.properties
SERVER_SERVLET_CONTEXT_PATH=/urlaubsverwaltung
SERVER_FORWARD_HEADERS_STRATEGY=native
```

clicking "accept" on the sick note detail/shortcut screen (`.../urlaubsverwaltung/web/sicknote/2?action=allow&shortcut=true`) posted to a URL with the context path repeated three times:

```
https://.../urlaubsverwaltung/urlaubsverwaltung/urlaubsverwaltung/web/sicknote/2/accept?redirect=/urlaubsverwaltung/web/sicknote/submitted
```

instead of the expected:

```
https://.../urlaubsverwaltung/web/sicknote/2/accept?redirect=/web/sicknote/submitted
```

The request 404s at the reverse proxy / servlet container.

The cause is in the "allow" form of `sick_note_detail.html`. The `th:with` block built the accept URL by nesting Thymeleaf's link-expression syntax `@{...}` **three times**:

```.html
th:with="redirectTo=@{/web/sicknote/submitted},
         acceptUrl=@{/web/sicknote/__${sickNote.id}__/accept},
         acceptExtensionUrl=@{/web/sicknote/__${sickNote.id}__/extension/accept},
         actionUrl=@{${extensionRequested ? acceptExtensionUrl : acceptUrl} (redirect=${isShortcut ? redirectTo : null})}"
th:action="@{__${actionUrl}__}"
```

Each `@{...}` evaluation prepends the servlet context path whenever its argument starts with `/`. Here, `acceptUrl` was already context-prefixed by the first `@{...}`, then re-wrapped in `@{...}` again to build `actionUrl` (2nd prefix), then wrapped in `@{...}` a **third** time in `th:action` (3rd prefix) - compounding the context path on every render. This also caused the `redirect` query value to carry a context-prefixed path (`/urlaubsverwaltung/web/sicknote/submitted`) instead of the plain path the controller expects, so `SickNoteViewController#redirectToSickNoteDetailOr`'s literal comparison against `"/web/sicknote/submitted"` never matched.

The sibling "cancel" form on the same page builds its action URL as a plain string in `th:with` and applies `@{...}` exactly once in `th:action`, which is the correct, consistent pattern used elsewhere in the codebase.

## Solution

Rebuild the "allow" form's URL fragments as plain relative-path strings in `th:with` (no `@{...}`), and apply the link-expression syntax `@{...}` exactly once at `th:action`, using Thymeleaf's own `(redirect=...)` parameter syntax so the query value is appended and encoded without being re-processed as a link itself.

Separately, while auditing for the same class of bug, found that `CalendarSharingViewController` built personal/department/company calendar share links via `ServletUriComponentsBuilder.fromCurrentRequestUri().replacePath(path)`, where `path` had no leading `/` and no context path. `replacePath()` discards the original request path (which includes the context path), so under a non-root context path deployment these calendar subscription links would **drop** the context path entirely and 404 - the opposite failure mode of the same underlying class of bug. Fixed by using `fromCurrentContextPath()` (preserves scheme/host/port/context path) together with `.path(...)` and `.queryParam(...)` for correct, safely-encoded URL construction.

No controller changes were necessary for the sick note fix - the underlying redirect/accept URLs were always correct, only the rendering syntax double/triple-applied the context path.

## Changes

- **`sick_note_detail.html`** - "allow" form's `redirectTo`/`acceptUrl`/`acceptExtensionUrl`/`actionUrl` are now built as plain strings in `th:with`, with `@{...}` applied once at `th:action` using the `(redirect=...)` parameter syntax, matching the pattern already used by the "cancel" form.
- **`CalendarSharingViewController.java`** - `getPersonCalendarDto`, `getDepartmentCalendarDtos`, and `getCompanyCalendarDto` now build calendar share URLs via `ServletUriComponentsBuilder.fromCurrentContextPath().path(...).queryParam(...)` instead of `fromCurrentRequestUri().replacePath(...)`, so the context path is preserved.

## Testing

Verified locally with `./mvnw -Dtest=CalendarSharingViewControllerTest,SickNoteViewControllerTest test`:

- `BUILD SUCCESS` - both `CalendarSharingViewControllerTest` and `SickNoteViewControllerTest` pass unchanged, since they assert on raw model attribute values (e.g. `containsString("...secret=")`), not the rendered HTML or context path.
- Full frontend test suite (`npm run test:coverage`, run automatically as part of the Maven `test` phase) also passes, confirming no regressions outside the touched files.

Also verified by setting `server.servlet.context-path=/urlaubsverwaltung` locally and confirming that:

- The sick note "allow"/"cancel" action forms on `/urlaubsverwaltung/web/sicknote/{id}` render `th:action` with the context path applied exactly once (no duplication), and accepting/cancelling a sick note redirects correctly to `/urlaubsverwaltung/web/sicknote/submitted` without a 404.
- The personal/department/company calendar share links on `/urlaubsverwaltung/web/calendars/share/persons/{id}` are generated with the `/urlaubsverwaltung` prefix instead of dropping it.