### PR TITLE
Apply context path once to sick note action form URLs

### DIFF
--- a/src/main/resources/templates/sicknote/sick_note_detail.html
+++ b/src/main/resources/templates/sicknote/sick_note_detail.html
@@ -109,19 +109,15 @@
           </p>
         </th:block>
 
-        <div class="actions">
+        <div class="actions" th:with="redirectTo=${shortcut ? '/web/sicknote/submitted' : null}">
           <th:block th:if="${canAcceptSickNote}">
             <form
               id="allow"
               class="alert alert-success"
               th:classappend="${action eq 'allow' ? '' : 'hidden'}"
               method="post"
-              th:with="isShortcut=${param.shortcut != null && #lists.contains(param.shortcut, 'true')},
-                       redirectTo=@{/web/sicknote/submitted},
-                       acceptUrl=@{/web/sicknote/__${sickNote.id}__/accept},
-                       acceptExtensionUrl=@{/web/sicknote/__${sickNote.id}__/extension/accept},
-                       actionUrl=@{${extensionRequested ? acceptExtensionUrl : acceptUrl} (redirect=${isShortcut ? redirectTo : null})}"
-              th:action="@{__${actionUrl}__}"
+              th:action="@{${extensionRequested ? '/web/sicknote/{sickNoteId}/extension/accept' : '/web/sicknote/{sickNoteId}/accept'}
+                           (sickNoteId=${sickNote.id}, redirect=${redirectTo})}"
               th:object="${comment}"
             >
               <input th:if="${shortcut}" type="hidden" name="shortcut" th:value="${shortcut}" />
@@ -164,8 +160,7 @@
               class="alert alert-danger"
               th:classappend="${(action == 'cancel') ? '' : 'hidden'}"
               method="post"
-              th:with="actionUrl=${param.shortcut != null && #lists.contains(param.shortcut, 'true') ? '/web/sicknote/__${sickNote.id}__/cancel?redirect=/web/sicknote/submitted' : '/web/sicknote/__${sickNote.id}__/cancel'}"
-              th:action="@{__${actionUrl}__}"
+              th:action="@{/web/sicknote/{sickNoteId}/cancel(sickNoteId=${sickNote.id}, redirect=${redirectTo})}"
               th:object="${comment}"
             >
               <input th:if="${shortcut}" type="hidden" name="shortcut" th:value="${shortcut}" />

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteDetailViewControllerIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteDetailViewControllerIT.java
@@ -1,0 +1,186 @@
+package org.synyx.urlaubsverwaltung.sicknote.sicknote;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.OidcLoginRequestPostProcessor;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.synyx.urlaubsverwaltung.SingleTenantTestContainersBase;
+import org.synyx.urlaubsverwaltung.department.DepartmentService;
+import org.synyx.urlaubsverwaltung.person.Person;
+import org.synyx.urlaubsverwaltung.person.PersonService;
+import org.synyx.urlaubsverwaltung.person.Role;
+import org.synyx.urlaubsverwaltung.settings.Settings;
+import org.synyx.urlaubsverwaltung.settings.SettingsService;
+import org.synyx.urlaubsverwaltung.sicknote.sicknotetype.SickNoteType;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import static java.time.Month.JANUARY;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.synyx.urlaubsverwaltung.period.DayLength.FULL;
+import static org.synyx.urlaubsverwaltung.person.Role.OFFICE;
+import static org.synyx.urlaubsverwaltung.person.Role.USER;
+import static org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteCategory.SICK_NOTE;
+import static org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteStatus.SUBMITTED;
+
+/**
+ * Renders the real {@code sicknote/sick_note_detail} Thymeleaf template (unlike {@link SickNoteViewControllerTest},
+ * which uses a standalone MockMvc setup that never touches the view resolver) to guard the action URLs of the
+ * {@code allow} and {@code cancel} forms - they must carry the context path exactly once, and the {@code redirect}
+ * query parameter must stay a plain path, because {@code SickNoteViewController} compares it literally.
+ */
+// the action forms sit far down the page - without buffering the whole render, the response is already committed
+// when Thymeleaf asks for the session to write the CSRF token of th:action
+@SpringBootTest(properties = "spring.thymeleaf.servlet.produce-partial-output-while-processing=false")
+@AutoConfigureMockMvc
+class SickNoteDetailViewControllerIT extends SingleTenantTestContainersBase {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PersonService personService;
+    @MockitoBean
+    private DepartmentService departmentService;
+    @MockitoBean
+    private SickNoteService sickNoteService;
+    @MockitoBean
+    private SettingsService settingsService;
+
+    private Person office;
+
+    @BeforeEach
+    void setUp() {
+
+        office = new Person("office", "Muster", "Marlene", "office@example.org");
+        office.setId(1L);
+        office.setPermissions(List.of(USER, OFFICE));
+
+        final SickNoteType sickNoteType = new SickNoteType();
+        sickNoteType.setCategory(SICK_NOTE);
+        sickNoteType.setMessageKey("application.data.sicknotetype.sicknote");
+
+        final SickNote sickNote = SickNote.builder()
+            .id(42L)
+            .person(office)
+            .applier(office)
+            .sickNoteType(sickNoteType)
+            .startDate(LocalDate.of(2022, JANUARY, 10))
+            .endDate(LocalDate.of(2022, JANUARY, 11))
+            .dayLength(FULL)
+            .status(SUBMITTED)
+            .build();
+
+        when(personService.getSignedInUser()).thenReturn(office);
+        when(sickNoteService.getById(42L)).thenReturn(Optional.of(sickNote));
+        when(departmentService.getAssignedDepartmentsOfMember(office)).thenReturn(List.of());
+        when(settingsService.getSettings()).thenReturn(new Settings());
+    }
+
+    @Test
+    void allowFormActionKeepsContextPathExactlyOnce() throws Exception {
+
+        mockMvc.perform(get("/ctx/web/sicknote/42").contextPath("/ctx")
+                .param("action", "allow")
+                .locale(Locale.GERMAN)
+                .with(oidcSubject(office, List.of(USER, OFFICE))))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("action=\"/ctx/web/sicknote/42/accept?redirect=\"")))
+            .andExpect(content().string(not(containsString("/ctx/ctx/"))));
+    }
+
+    @Test
+    void allowFormActionRedirectsToSubmittedWithoutContextPathInTheQueryParameter() throws Exception {
+
+        mockMvc.perform(get("/ctx/web/sicknote/42").contextPath("/ctx")
+                .param("action", "allow")
+                .param("shortcut", "true")
+                .locale(Locale.GERMAN)
+                .with(oidcSubject(office, List.of(USER, OFFICE))))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString(
+                "action=\"/ctx/web/sicknote/42/accept?redirect=/web/sicknote/submitted\"")));
+    }
+
+    @Test
+    void shortcutIsReadAsBooleanAndNotComparedToTheLiteralTrue() throws Exception {
+
+        // the controller binds shortcut as boolean, so Spring accepts on/yes/1 as well
+        mockMvc.perform(get("/ctx/web/sicknote/42").contextPath("/ctx")
+                .param("action", "allow")
+                .param("shortcut", "1")
+                .locale(Locale.GERMAN)
+                .with(oidcSubject(office, List.of(USER, OFFICE))))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString(
+                "action=\"/ctx/web/sicknote/42/accept?redirect=/web/sicknote/submitted\"")));
+    }
+
+    @Test
+    void cancelFormActionKeepsContextPathExactlyOnce() throws Exception {
+
+        mockMvc.perform(get("/ctx/web/sicknote/42").contextPath("/ctx")
+                .param("action", "cancel")
+                .locale(Locale.GERMAN)
+                .with(oidcSubject(office, List.of(USER, OFFICE))))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("action=\"/ctx/web/sicknote/42/cancel?redirect=\"")));
+    }
+
+    @Test
+    void cancelFormActionRedirectsToSubmittedWithoutContextPathInTheQueryParameter() throws Exception {
+
+        mockMvc.perform(get("/ctx/web/sicknote/42").contextPath("/ctx")
+                .param("action", "cancel")
+                .param("shortcut", "true")
+                .locale(Locale.GERMAN)
+                .with(oidcSubject(office, List.of(USER, OFFICE))))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString(
+                "action=\"/ctx/web/sicknote/42/cancel?redirect=/web/sicknote/submitted\"")));
+    }
+
+    @Test
+    void formActionsAreRenderedWithoutContextPathWhenDeployedAtRoot() throws Exception {
+
+        mockMvc.perform(get("/web/sicknote/42")
+                .param("action", "allow")
+                .param("shortcut", "true")
+                .locale(Locale.GERMAN)
+                .with(oidcSubject(office, List.of(USER, OFFICE))))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString(
+                "action=\"/web/sicknote/42/accept?redirect=/web/sicknote/submitted\"")))
+            .andExpect(content().string(containsString(
+                "action=\"/web/sicknote/42/cancel?redirect=/web/sicknote/submitted\"")));
+    }
+
+    private static OidcLoginRequestPostProcessor oidcSubject(Person person, List<Role> roles) {
+
+        final OidcIdToken.Builder tokenBuilder = OidcIdToken.withTokenValue("not-empty-token-value")
+            .claim("sub", person.getUsername());
+
+        final List<SimpleGrantedAuthority> authorities = roles.stream().map(Role::name).map(SimpleGrantedAuthority::new).toList();
+
+        final OidcUser oidcUser = new DefaultOidcUser(authorities, tokenBuilder.build());
+
+        return oidcLogin().oidcUser(oidcUser);
+    }
+}


### PR DESCRIPTION
Fixes gh-6565

Splits out the sick note half of #6521 (thanks @roboes for finding and first fixing this), with test coverage.

## The bug

The `allow` form of `sick_note_detail.html` nested Thymeleaf's link expression three deep:

```html
th:with="redirectTo=@{/web/sicknote/submitted},
         acceptUrl=@{/web/sicknote/__${sickNote.id}__/accept},
         actionUrl=@{${extensionRequested ? acceptExtensionUrl : acceptUrl} (redirect=${isShortcut ? redirectTo : null})}"
th:action="@{__${actionUrl}__}"
```

Each `@{...}` prepends the context path to an argument starting with `/`, so the prefix compounds once per level. Rendered under `server.servlet.context-path=/ctx` on `main`, the IT added here produces:

```
action="/ctx/ctx/ctx/web/sicknote/42/accept?redirect=/ctx/web/sicknote/submitted"
```

The context-prefixed `redirect` value is a second failure: `SickNoteViewController#redirectToSickNoteDetailOr` compares it literally against `"/web/sicknote/submitted"`, so the shortcut never matched and silently fell back to the detail page.

## The fix

Both forms build their action with a single link expression using path variables, matching `user-settings.html`, `calendarsharing/index.html` and the rest of the templates:

```html
th:action="@{${extensionRequested ? '/web/sicknote/{sickNoteId}/extension/accept' : '/web/sicknote/{sickNoteId}/accept'}
             (sickNoteId=${sickNote.id}, redirect=${redirectTo})}"
```

`redirectTo` moves up to the enclosing `<div class="actions">` so both forms share one definition.

Two things worth flagging, both found by writing the test rather than by reading the diff:

- **The `cancel` form was not broken.** Applying `@{...}` once to a preprocessed string works, and it rendered `/ctx/web/sicknote/42/cancel?redirect=/web/sicknote/submitted` correctly on `main`. It is rewritten here only because it hand-rolled the redirect query *inside* the path string, so the two sibling forms built the same URL two different ways. This part is a consistency change, not a bug fix.
- **`isShortcut` was a real second bug.** The `allow` form recomputed it from `param.shortcut` by comparing against the literal string `'true'`, while the hidden input two lines below uses the `shortcut` model attribute, which the controller binds as `boolean`. Spring also accepts `on`, `yes` and `1`, so `?shortcut=1` rendered the hidden input but dropped the `redirect`. The model attribute is now the single source.

One cosmetic change: a null `redirect` renders as an empty `?redirect=` rather than being omitted — Thymeleaf has no conditional-parameter syntax. `main` already did this for the `allow` form; the `cancel` form now does too. It is inert (`"".equals("/web/sicknote/submitted")` is false, same as `null`).

## Tests

New `SickNoteDetailViewControllerIT` renders the real template, which nothing did before — `SickNoteViewControllerTest` uses a standalone MockMvc setup that never touches the view resolver and only asserts `view().name(...)`, so no existing test could have caught any of this. Six cases: allow and cancel actions under `/ctx` with and without `shortcut`, `?shortcut=1`, and the root-deployment baseline.

All six fail on `main` (four assertion failures plus the triplication) and pass here. `SickNoteViewControllerTest` is unchanged and still green: 120 tests, 0 failures.

The IT sets `spring.thymeleaf.servlet.produce-partial-output-while-processing=false`: the action forms sit far enough down the page that the response is already committed when Thymeleaf asks for the session to write the CSRF token of `th:action`.
