### PR TITLE
Keep context path in calendar subscription links

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/calendar/CalendarSharingViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/calendar/CalendarSharingViewController.java
@@ -227,9 +227,7 @@ public class CalendarSharingViewController implements HasLaunchpad, HasPersonSea
         final Optional<PersonCalendar> maybePersonCalendar = personCalendarService.getPersonCalendar(personId);
         if (maybePersonCalendar.isPresent()) {
             final PersonCalendar personCalendar = maybePersonCalendar.get();
-            final var path = "web/persons/%d/calendar?secret=%s".formatted(personId, personCalendar.getSecret());
-            final var url = ServletUriComponentsBuilder.fromCurrentRequestUri()
-                .replacePath(path).build().toString();
+            final var url = calendarUrl("/web/persons/{personId}/calendar", personCalendar.getSecret(), personId);
 
             dto.setCalendarUrl(url);
             dto.setCalendarPeriod(CalendarPeriodViewType.ofPeriod(personCalendar.getCalendarPeriod()));
@@ -268,9 +266,7 @@ public class CalendarSharingViewController implements HasLaunchpad, HasPersonSea
             final var maybeDepartmentCalendar = Optional.ofNullable(departmentCalendarByDepartmentId.get(departmentId));
             if (maybeDepartmentCalendar.isPresent()) {
                 final var departmentCalendar = maybeDepartmentCalendar.get();
-                final var path = "web/departments/%s/persons/%s/calendar?secret=%s".formatted(departmentId, personId, departmentCalendar.getSecret());
-                final var url = ServletUriComponentsBuilder.fromCurrentRequestUri()
-                    .replacePath(path).build().toString();
+                final var url = calendarUrl("/web/departments/{departmentId}/persons/{personId}/calendar", departmentCalendar.getSecret(), departmentId, personId);
 
                 departmentCalendarDto.setCalendarUrl(url);
                 departmentCalendarDto.setCalendarPeriod(CalendarPeriodViewType.ofPeriod(departmentCalendar.getCalendarPeriod()));
@@ -295,15 +291,32 @@ public class CalendarSharingViewController implements HasLaunchpad, HasPersonSea
         if (maybeCompanyCalendar.isPresent()) {
 
             final CompanyCalendar companyCalendar = maybeCompanyCalendar.get();
-            final var path = "web/company/persons/%d/calendar?secret=%s".formatted(personId, companyCalendar.getSecret());
-            final var url = ServletUriComponentsBuilder.fromCurrentRequestUri()
-                .replacePath(path).build().toString();
+            final var url = calendarUrl("/web/company/persons/{personId}/calendar", companyCalendar.getSecret(), personId);
 
             companyCalendarDto.setCalendarUrl(url);
             companyCalendarDto.setCalendarPeriod(CalendarPeriodViewType.ofPeriod(companyCalendar.getCalendarPeriod()));
         }
 
         return companyCalendarDto;
+    }
+
+    /**
+     * Builds the absolute subscription URL of a calendar, keeping the context path the application is deployed
+     * under. {@link ServletUriComponentsBuilder#fromCurrentContextPath()} preserves scheme, host, port and context
+     * path, so the link stays valid behind a reverse proxy with a non-root context path.
+     *
+     * @param path         path of the calendar, relative to the context path, with {@code {placeholders}}
+     * @param secret       secret of the calendar, appended as {@code secret} query parameter
+     * @param uriVariables values for the placeholders of {@code path}, in order of appearance
+     * @return the absolute, encoded calendar subscription URL
+     */
+    private static String calendarUrl(String path, String secret, Object... uriVariables) {
+        return ServletUriComponentsBuilder.fromCurrentContextPath()
+            .path(path)
+            .queryParam("secret", secret)
+            .buildAndExpand(uriVariables)
+            .encode()
+            .toUriString();
     }
 
     private Person getPersonOrThrow(long personId) {

--- a/src/test/java/org/synyx/urlaubsverwaltung/calendar/CalendarSharingViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/calendar/CalendarSharingViewControllerTest.java
@@ -21,9 +21,9 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.verify;
@@ -148,7 +148,7 @@ class CalendarSharingViewControllerTest {
         perform(get("/web/calendars/share/persons/1"))
             .andExpect(view().name("calendarsharing/index"))
             .andExpect(model().attributeExists("companyCalendarShare"))
-            .andExpect(model().attribute("companyCalendarShare", hasProperty("calendarUrl", containsString("/web/company/persons/1/calendar?secret="))))
+            .andExpect(model().attribute("companyCalendarShare", hasProperty("calendarUrl", is("http://localhost/web/company/persons/1/calendar?secret=s3cr3t"))))
             .andExpect(status().isOk());
     }
 
@@ -337,7 +337,7 @@ class CalendarSharingViewControllerTest {
         perform(get("/web/calendars/share/persons/1/departments/1337"))
             .andExpect(view().name("calendarsharing/index"))
             .andExpect(model().attribute("departmentCalendars", hasSize(2)))
-            .andExpect(model().attribute("departmentCalendars", hasItem(hasProperty("calendarUrl", containsString("web/departments/1337/persons/1/calendar?secret=")))))
+            .andExpect(model().attribute("departmentCalendars", hasItem(hasProperty("calendarUrl", is("http://localhost/web/departments/1337/persons/1/calendar?secret=s3cr3t")))))
             .andExpect(model().attribute("departmentCalendars", hasItem(hasProperty("calendarUrl", nullValue()))))
             .andExpect(status().isOk());
     }
@@ -503,7 +503,7 @@ class CalendarSharingViewControllerTest {
 
         perform(get("/web/calendars/share/persons/1"))
             .andExpect(view().name("calendarsharing/index"))
-            .andExpect(model().attribute("privateCalendarShare", hasProperty("calendarUrl", containsString("/web/persons/1/calendar?secret="))))
+            .andExpect(model().attribute("privateCalendarShare", hasProperty("calendarUrl", is("http://localhost/web/persons/1/calendar?secret=s3cr3t"))))
             .andExpect(status().isOk());
     }
 
@@ -646,28 +646,99 @@ class CalendarSharingViewControllerTest {
             .andExpect(status().isOk());
     }
 
+    @Test
+    void personCalendarUrlIsAbsoluteWithSecretAsQueryParameter() throws Exception {
+
+        final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        person.setId(1L);
+
+        when(personService.getSignedInUser()).thenReturn(person);
+        when(personService.getPersonByID(1L)).thenReturn(Optional.of(person));
+        when(departmentService.getAssignedDepartmentsOfMember(person)).thenReturn(Collections.emptyList());
+        when(personCalendarService.getPersonCalendar(1L))
+            .thenReturn(Optional.of(new PersonCalendar(person, Period.parse("P1Y"), "s3cr3t")));
+
+        perform(get("/web/calendars/share/persons/1"))
+            .andExpect(model().attribute("privateCalendarShare",
+                hasProperty("calendarUrl", is("http://localhost/web/persons/1/calendar?secret=s3cr3t"))))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void personCalendarUrlKeepsContextPath() throws Exception {
+
+        final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        person.setId(1L);
+
+        when(personService.getSignedInUser()).thenReturn(person);
+        when(personService.getPersonByID(1L)).thenReturn(Optional.of(person));
+        when(departmentService.getAssignedDepartmentsOfMember(person)).thenReturn(Collections.emptyList());
+        when(personCalendarService.getPersonCalendar(1L))
+            .thenReturn(Optional.of(new PersonCalendar(person, Period.parse("P1Y"), "s3cr3t")));
+
+        perform(get("/ctx/web/calendars/share/persons/1").contextPath("/ctx"))
+            .andExpect(model().attribute("privateCalendarShare",
+                hasProperty("calendarUrl", is("http://localhost/ctx/web/persons/1/calendar?secret=s3cr3t"))))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void departmentCalendarUrlKeepsContextPath() throws Exception {
+
+        final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        person.setId(1L);
+        person.setPermissions(List.of(USER));
+
+        final Department barfuslaeufer = createDepartment("barfußläufer");
+        barfuslaeufer.setId(1337L);
+
+        when(personService.getPersonByID(1L)).thenReturn(Optional.of(person));
+        when(personService.getSignedInUser()).thenReturn(person);
+        when(departmentService.getAssignedDepartmentsOfMember(person)).thenReturn(List.of(barfuslaeufer));
+        when(departmentCalendarService.getCalendarsForPerson(1L))
+            .thenReturn(List.of(new DepartmentCalendar(1337L, person, Period.parse("P1Y"), "s3cr3t")));
+
+        perform(get("/ctx/web/calendars/share/persons/1/departments/1337").contextPath("/ctx"))
+            .andExpect(model().attribute("departmentCalendars", hasItem(hasProperty("calendarUrl",
+                is("http://localhost/ctx/web/departments/1337/persons/1/calendar?secret=s3cr3t")))))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void companyCalendarUrlKeepsContextPath() throws Exception {
+
+        final Person bossPerson = new Person("boss", "Boss", "Bruce", "boss@example.org");
+        bossPerson.setId(2L);
+        bossPerson.setPermissions(List.of(USER, BOSS));
+
+        final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        person.setId(1L);
+
+        when(personService.getSignedInUser()).thenReturn(bossPerson);
+        when(personService.getPersonByID(1L)).thenReturn(Optional.of(person));
+        when(departmentService.getAssignedDepartmentsOfMember(person)).thenReturn(Collections.emptyList());
+        when(companyCalendarService.getCompanyCalendar(1))
+            .thenReturn(Optional.of(new CompanyCalendar(person, Period.parse("P1Y"), "s3cr3t")));
+
+        perform(get("/ctx/web/calendars/share/persons/1").contextPath("/ctx"))
+            .andExpect(model().attribute("companyCalendarShare",
+                hasProperty("calendarUrl", is("http://localhost/ctx/web/company/persons/1/calendar?secret=s3cr3t"))))
+            .andExpect(status().isOk());
+    }
+
     private PersonCalendar anyPersonCalendar() {
 
-        final PersonCalendar personCalendar = new PersonCalendar();
-        personCalendar.setCalendarPeriod(Period.parse("P1Y"));
-
-        return personCalendar;
+        return new PersonCalendar(null, Period.parse("P1Y"), "s3cr3t");
     }
 
     private DepartmentCalendar anyDepartmentCalendar() {
 
-        final DepartmentCalendar departmentCalendar = new DepartmentCalendar();
-        departmentCalendar.setCalendarPeriod(Period.parse("P1Y"));
-
-        return departmentCalendar;
+        return new DepartmentCalendar(null, null, Period.parse("P1Y"), "s3cr3t");
     }
 
     private CompanyCalendar anyCompanyCalendar() {
 
-        final CompanyCalendar companyCalendar = new CompanyCalendar();
-        companyCalendar.setCalendarPeriod(Period.parse("P1Y"));
-
-        return companyCalendar;
+        return new CompanyCalendar(null, Period.parse("P1Y"), "s3cr3t");
     }
 
     private ResultActions perform(MockHttpServletRequestBuilder builder) throws Exception {


### PR DESCRIPTION
Fixes gh-6566

Splits out the calendar half of #6521 (thanks @roboes for spotting this while working on the sick note bug), with test coverage and a correction.

## The bug

`CalendarSharingViewController` built all three calendar subscription URLs like this:

```java
final var path = "web/persons/%d/calendar?secret=%s".formatted(personId, personCalendar.getSecret());
final var url = ServletUriComponentsBuilder.fromCurrentRequestUri()
    .replacePath(path).build().toString();
```

`replacePath()` replaces the whole path of the current request — which includes the context path — and `path` carries neither a leading `/` nor the context path. Behind a reverse proxy with a non-root context path the personal, department and company subscription links therefore came out without the prefix and 404.

## Also fixed: the secret was never a query parameter

#6521 describes its fix as using `.path(...)` and `.queryParam(...)` "for correct, safely-encoded URL construction", but it only changed `replacePath` to `path` and left `?secret=...` inside the path string. `UriComponentsBuilder` does not treat `?` in `path()` as a delimiter, so the result is a `UriComponents` with `getQuery() == null` and a path containing `?secret=...`:

```
path("/web/persons/1/calendar?secret=abc").build()
  → toString() = http://host/ctx/web/persons/1/calendar?secret=abc
  → getPath()  = /ctx/web/persons/1/calendar?secret=abc     getQuery() = null
```

It renders correctly only because the unencoded `build().toString()` concatenates verbatim. Adding `.encode()` — or any `fromUriString` round-trip — yields `calendar%3Fsecret=abc` and breaks every subscription URL. This PR uses a real `queryParam`.

## The fix

`fromCurrentContextPath()` preserves scheme, host, port and context path. The three near-identical blocks collapse into one helper:

```java
private static String calendarUrl(String path, String secret, Object... uriVariables) {
    return ServletUriComponentsBuilder.fromCurrentContextPath()
        .path(path)
        .queryParam("secret", secret)
        .buildAndExpand(uriVariables)
        .encode()
        .toUriString();
}
```

## Tests

The existing assertions could not fail either way: they are `containsString("...?secret=")` against a `standaloneSetup` whose context path is `""`, and one of them even omitted the leading slash, so old and new code emit byte-identical strings.

Four new tests assert the **exact** URL for person, department and company calendars under `.contextPath("/ctx")`, plus one root-deployment baseline. The three context-path tests fail on `main` with the context path dropped. The three existing assertions are tightened from `containsString` to equality.

One knock-on: the `anyXxxCalendar()` test helpers built calendars with a `null` secret, which `String.format` used to render as the literal `secret=null` and which `queryParam` renders as a bare `secret`. Since a persisted calendar always has a generated secret, the helpers now set one — which is what let the assertions be tightened to exact URLs.

`CalendarSharingViewControllerTest`: 36 tests, 0 failures.
