### PR TITLE
Show the applications when the submitted sick notes are not accessible

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveViewController.java
@@ -15,7 +15,6 @@ import org.synyx.urlaubsverwaltung.search.HasPersonSearch;
 import org.synyx.urlaubsverwaltung.search.PersonSearchUiFragmentSupplier;
 import org.synyx.urlaubsverwaltung.search.PersonSuggestionUrlStrategy;
 import org.synyx.urlaubsverwaltung.settings.SettingsService;
-import org.synyx.urlaubsverwaltung.sicknote.settings.SickNoteSettings;
 import org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNote;
 import org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNotePermissionEvaluator;
 import org.synyx.urlaubsverwaltung.sicknote.sicknote.SubmittedSickNote;
@@ -114,20 +113,25 @@ class ApplicationForLeaveViewController implements HasLaunchpad, HasPersonSearch
 
     @GetMapping("/sicknote/submitted")
     public String showApplicationWithSickNoteSubmittedContent(Model model, Locale locale) {
+
+        // the tab is not rendered without this permission, so activating it would leave the page without any active
+        // tab at all - show the applications instead
+        if (!isAllowedToAccessSickNoteSubmissions(personService.getSignedInUser())) {
+            return "redirect:/web/application";
+        }
+
         prepareApplicationModels(model, locale, Tab.SICK_NOTE);
         return "application/application-overview";
     }
 
     private void prepareApplicationModels(Model model, Locale locale, Tab activeTab) {
 
-        final SickNoteSettings sickNoteSettings = settingsService.getSettings().getSickNoteSettings();
-
         final Person signedInUser = personService.getSignedInUser();
         model.addAttribute("signedInUser", signedInUser);
 
         model.addAttribute("canAccessCancellationRequests", isAllowedToAccessCancellationRequest(signedInUser));
         model.addAttribute("canAccessOtherApplications", isAllowedToAccessOtherApplications(signedInUser));
-        model.addAttribute("canAccessSickNoteSubmissions", sickNoteSettings.getUserIsAllowedToSubmitSickNotes() && sickNotePermissionEvaluator.isAllowedToAccessSickNoteSubmissions(signedInUser));
+        model.addAttribute("canAccessSickNoteSubmissions", isAllowedToAccessSickNoteSubmissions(signedInUser));
 
         final List<Person> membersAsDepartmentHead = signedInUser.hasRole(DEPARTMENT_HEAD) ? departmentService.getMembersForDepartmentHead(signedInUser) : List.of();
         final List<Person> membersAsSecondStageAuthority = signedInUser.hasRole(SECOND_STAGE_AUTHORITY) ? departmentService.getMembersForSecondStageAuthority(signedInUser) : List.of();
@@ -142,6 +146,18 @@ class ApplicationForLeaveViewController implements HasLaunchpad, HasPersonSearch
         prepareApplicationCancellationRequests(model, signedInUser, membersAsDepartmentHead, membersAsSecondStageAuthority, locale);
 
         model.addAttribute("activeContent", activeTab.name);
+    }
+
+    /**
+     * Whether the submitted sick notes tab is shown to the given user at all - the feature has to be enabled and the
+     * user needs the permission to work on submitted sick notes.
+     *
+     * @param signedInUser user asking for the tab
+     * @return {@code true} if the tab is shown, {@code false} otherwise
+     */
+    private boolean isAllowedToAccessSickNoteSubmissions(Person signedInUser) {
+        return settingsService.getSettings().getSickNoteSettings().getUserIsAllowedToSubmitSickNotes()
+            && sickNotePermissionEvaluator.isAllowedToAccessSickNoteSubmissions(signedInUser);
     }
 
     private void prepareUserApplications(Model model, Person signedInUser, List<Person> membersOfDepartmentHead, List<Person> memberOfSecondStageAuthority, Locale locale) {

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveViewControllerTest.java
@@ -1802,6 +1802,23 @@ class ApplicationForLeaveViewControllerTest {
             .build();
     }
 
+    @Test
+    void ensureSubmittedSickNotesRedirectsToTheApplicationsWhenTheTabIsNotAccessible() throws Exception {
+
+        final Person person = new Person("muster", "Muster", "Marlene", "muster@example.org");
+        person.setId(1L);
+        person.setPermissions(List.of(USER));
+        when(personService.getSignedInUser()).thenReturn(person);
+
+        final Settings settings = new Settings();
+        settings.getSickNoteSettings().setUserIsAllowedToSubmitSickNotes(false);
+        when(settingsService.getSettings()).thenReturn(settings);
+
+        perform(get("/web/sicknote/submitted"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(view().name("redirect:/web/application"));
+    }
+
     private ResultActions perform(MockHttpServletRequestBuilder builder) throws Exception {
         return standaloneSetup(sut).build().perform(builder);
     }


### PR DESCRIPTION
Fixes gh-6570

## The bug

`/web/application`, `/web/application/replacement` and `/web/sicknote/submitted` are three tabs of one page, distinguished only by the `Tab` passed to `prepareApplicationModels`.

The submitted sick notes tab renders only under `th:if="${canAccessSickNoteSubmissions}"` — the `userIsAllowedToSubmitSickNotes` setting **and** `isAllowedToAccessSickNoteSubmissions(signedInUser)`. But its endpoint answered 200 regardless and set `activeContent = 'sicknote'`.

Without the permission the page therefore renders with **no active tab at all**: the sick note tab is not in the DOM, and the applications tab highlights only for `activeContent == 'application' || 'replacement'`.

Found while tracking down #6569 — it is why cancelling a sick note appeared to dump you on a dead page.

## The fix

Redirect to `/web/application` when the tab is not accessible. The permission was computed inline inside `prepareApplicationModels`, so it moves into a small method both call sites share.

## Tests

New `ensureSubmittedSickNotesRedirectsToTheApplicationsWhenTheTabIsNotAccessible`; it fails on `main` with `expected:<REDIRECTION> but was:<SUCCESSFUL>`. The accessible path stays covered by the existing `getSubmittedSickNotesForOffice`, which is parameterized over both URLs.

`ApplicationForLeaveViewControllerTest`: 33 tests, 0 failures.
