### PR TITLE
Offer edit and cancel only for active sick notes

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/overview/OverviewViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overview/OverviewViewController.java
@@ -344,7 +344,7 @@ public class OverviewViewController implements HasLaunchpad, HasPersonSearch {
                 sickNote.getStatus(),
                 sickNote.getSickNoteType(),
                 permissions.isAllowedToEdit(sickNote),
-                permissions.isAllowedToCancel()
+                permissions.isAllowedToCancel(sickNote)
             )).toList();
     }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/me/SickNotesViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/me/SickNotesViewController.java
@@ -162,7 +162,7 @@ public class SickNotesViewController implements HasLaunchpad, HasPersonSearch {
             sickNote.getStatus(),
             sickNote.getSickNoteType(),
             permissions.isAllowedToEdit(sickNote),
-            permissions.isAllowedToCancel()
+            permissions.isAllowedToCancel(sickNote)
         );
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNotePermissions.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNotePermissions.java
@@ -82,12 +82,15 @@ public final class SickNotePermissions {
     }
 
     /**
+     * A sick note that is no longer active, i.e. cancelled or converted into an application for leave, cannot be
+     * edited by anyone.
+     *
      * @param sickNote sick note to be edited, has to belong to the person of these permissions
      * @return {@code true} if the user may edit the given sick note, {@code false} otherwise
      */
     public boolean isAllowedToEdit(SickNote sickNote) {
-        return isAllowedToMaintain(SICK_NOTE_EDIT)
-            || (isSamePerson() && sickNote.isSubmitted());
+        return sickNote.isActive()
+            && (isAllowedToMaintain(SICK_NOTE_EDIT) || (isSamePerson() && sickNote.isSubmitted()));
     }
 
     /**
@@ -99,10 +102,14 @@ public final class SickNotePermissions {
     }
 
     /**
-     * @return {@code true} if the user may cancel a sick note of the person, {@code false} otherwise
+     * A sick note that is no longer active, i.e. cancelled or converted into an application for leave, cannot be
+     * cancelled again.
+     *
+     * @param sickNote sick note to be cancelled, has to belong to the person of these permissions
+     * @return {@code true} if the user may cancel the given sick note, {@code false} otherwise
      */
-    public boolean isAllowedToCancel() {
-        return isAllowedToMaintain(SICK_NOTE_CANCEL);
+    public boolean isAllowedToCancel(SickNote sickNote) {
+        return sickNote.isActive() && isAllowedToMaintain(SICK_NOTE_CANCEL);
     }
 
     /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewController.java
@@ -196,7 +196,7 @@ class SickNoteViewController implements HasLaunchpad, HasPersonSearch {
             model.addAttribute("canAcceptSickNote", permissions.isAllowedToAccept());
             model.addAttribute("canEditSickNote", permissions.isAllowedToEdit(sickNote));
             model.addAttribute("canConvertSickNote", permissions.isAllowedToConvert());
-            model.addAttribute("canDeleteSickNote", permissions.isAllowedToCancel());
+            model.addAttribute("canDeleteSickNote", permissions.isAllowedToCancel(sickNote));
             model.addAttribute("canCommentSickNote", permissions.isAllowedToComment());
 
             model.addAttribute("departmentsOfPerson", departmentService.getAssignedDepartmentsOfMember(sickNotePerson));
@@ -510,7 +510,7 @@ class SickNoteViewController implements HasLaunchpad, HasPersonSearch {
         final SickNote sickNote = getSickNote(id);
         final Person signedInUser = personService.getSignedInUser();
 
-        if (!sickNotePermissionEvaluator.of(signedInUser, sickNote).isAllowedToCancel()) {
+        if (!sickNotePermissionEvaluator.of(signedInUser, sickNote).isAllowedToCancel(sickNote)) {
             throw new AccessDeniedException("User '%s' has not the correct permissions to cancel the sick note of user '%s'".formatted(signedInUser.getId(), sickNote.getPerson().getId()));
         }
 

--- a/src/main/resources/templates/sicknote/sick_note_detail.html
+++ b/src/main/resources/templates/sicknote/sick_note_detail.html
@@ -52,41 +52,35 @@
                   <span th:text="#{action.acceptSicknote}" class="sr-only"></span>
                 </button>
               </th:block>
-              <th:block th:if="${sickNote.active}">
-                <th:block th:if="${canEditSickNote}">
-                  <a
-                    th:href="@{/web/sicknote/__${sickNote.id}__/edit}"
-                    class="icon-link"
-                    th:data-title="#{action.edit}"
-                  >
-                    <svg th:replace="~{icon/pencil::svg(className='w-5 h-5')}"></svg>
-                    <span th:text="#{action.edit}" class="sr-only"></span>
-                  </a>
-                </th:block>
-                <th:block th:if="${canConvertSickNote && sickNote.status.name == 'ACTIVE'}">
-                  <a
-                    th:href="@{/web/sicknote/__${sickNote.id}__/convert}"
-                    class="icon-link"
-                    th:data-title="#{action.convert}"
-                  >
-                    <svg th:replace="~{icon/refresh-ccw::svg(className='w-5 h-5')}"></svg>
-                    <span th:text="#{action.convert}" class="sr-only"></span>
-                  </a>
-                </th:block>
-                <th:block th:if="${canDeleteSickNote}">
-                  <button
-                    type="button"
-                    class="icon-link bg-transparent hover:text-red-500"
-                    onclick="
-                      document.querySelector('#cancel')?.classList.remove('hidden');
-                      document.querySelector('#allow')?.classList.add('hidden');
-                    "
-                    th:data-title="#{action.delete.request}"
-                  >
-                    <svg th:replace="~{icon/trash-2::svg(className='w-5 h-5')}"></svg>
-                    <span class="sr-only" th:text="#{action.delete.request}"></span>
-                  </button>
-                </th:block>
+              <th:block th:if="${canEditSickNote}">
+                <a th:href="@{/web/sicknote/__${sickNote.id}__/edit}" class="icon-link" th:data-title="#{action.edit}">
+                  <svg th:replace="~{icon/pencil::svg(className='w-5 h-5')}"></svg>
+                  <span th:text="#{action.edit}" class="sr-only"></span>
+                </a>
+              </th:block>
+              <th:block th:if="${canConvertSickNote && sickNote.status.name == 'ACTIVE'}">
+                <a
+                  th:href="@{/web/sicknote/__${sickNote.id}__/convert}"
+                  class="icon-link"
+                  th:data-title="#{action.convert}"
+                >
+                  <svg th:replace="~{icon/refresh-ccw::svg(className='w-5 h-5')}"></svg>
+                  <span th:text="#{action.convert}" class="sr-only"></span>
+                </a>
+              </th:block>
+              <th:block th:if="${canDeleteSickNote}">
+                <button
+                  type="button"
+                  class="icon-link bg-transparent hover:text-red-500"
+                  onclick="
+                    document.querySelector('#cancel')?.classList.remove('hidden');
+                    document.querySelector('#allow')?.classList.add('hidden');
+                  "
+                  th:data-title="#{action.delete.request}"
+                >
+                  <svg th:replace="~{icon/trash-2::svg(className='w-5 h-5')}"></svg>
+                  <span class="sr-only" th:text="#{action.delete.request}"></span>
+                </button>
               </th:block>
             </div>
           </th:block>

--- a/src/test/java/org/synyx/urlaubsverwaltung/overview/OverviewViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overview/OverviewViewControllerTest.java
@@ -70,6 +70,7 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
@@ -1083,6 +1084,53 @@ class OverviewViewControllerTest {
             .isNotNull()
             .hasFieldOrPropertyWithValue("numberOfShownSickNotes", 2)
             .hasFieldOrPropertyWithValue("numberOfTotalSickNotes", 2);
+    }
+
+    @Test
+    void ensureSickNotesOverviewOffersNoActionsForSickNotesThatAreNotActive() throws Exception {
+        when(settingsService.getSettings()).thenReturn(new Settings());
+
+        final Person office = new Person();
+        office.setId(1L);
+        office.setPermissions(List.of(USER, OFFICE));
+        when(personService.getSignedInUser()).thenReturn(office);
+        when(personService.getPersonByID(1L)).thenReturn(Optional.of(office));
+        when(departmentService.isSignedInUserAllowedToAccessPersonData(office, office)).thenReturn(true);
+        stubSickNoteWorkDaysCount(BigDecimal.valueOf(2));
+
+        final LocalDate localDate = LocalDate.parse("2021-06-10");
+        final SickNoteType sickNoteType = new SickNoteType();
+        sickNoteType.setCategory(SICK_NOTE);
+
+        final SickNote activeSickNote = SickNote.builder()
+            .startDate(localDate.minusDays(5))
+            .endDate(localDate.minusDays(4))
+            .status(SickNoteStatus.ACTIVE)
+            .sickNoteType(sickNoteType)
+            .person(office)
+            .build();
+
+        final SickNote cancelledSickNote = SickNote.builder()
+            .startDate(localDate.minusDays(3))
+            .endDate(localDate.minusDays(2))
+            .status(SickNoteStatus.CANCELLED)
+            .sickNoteType(sickNoteType)
+            .person(office)
+            .build();
+
+        when(sickNoteService.getByPersonAndPeriod(eq(office), any(), any())).thenReturn(List.of(activeSickNote, cancelledSickNote));
+
+        final ResultActions actions = perform(get("/web/person/1/overview").param("year", "2021"));
+        final ModelAndView mav = actions.andReturn().getModelAndView();
+        assertThat(mav).isNotNull();
+
+        final SickNotesOverviewDTO sickNotesOverview = (SickNotesOverviewDTO) mav.getModel().get("sickNotesOverview");
+        assertThat(sickNotesOverview.sickNotes())
+            .extracting(SickNoteDto::status, SickNoteDto::allowedToEdit, SickNoteDto::allowedToCancel)
+            .containsExactlyInAnyOrder(
+                tuple(SickNoteStatus.ACTIVE, true, true),
+                tuple(SickNoteStatus.CANCELLED, false, false)
+            );
     }
 
     // APPLICATION OVERVIEW COUNT TESTS

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/me/SickNotesViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/me/SickNotesViewControllerTest.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -28,6 +30,7 @@ import org.synyx.urlaubsverwaltung.settings.Settings;
 import org.synyx.urlaubsverwaltung.settings.SettingsService;
 import org.synyx.urlaubsverwaltung.sicknote.settings.SickNoteSettings;
 import org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNote;
+import org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteStatus;
 import org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNotePermissionEvaluator;
 import org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteService;
 import org.synyx.urlaubsverwaltung.sicknote.sicknotetype.SickNoteType;
@@ -41,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasProperty;
@@ -553,6 +557,45 @@ class SickNotesViewControllerTest {
             .andExpect(model().attribute("sickNotes", hasSize(1)))
             .andExpect(model().attribute("sickNotes",
                 hasItem(hasProperty("allowedToEdit", is(false)))));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SickNoteStatus.class, names = {"CANCELLED", "CONVERTED_TO_VACATION"})
+    void ensureSickNoteThatIsNotActiveOffersNoActionsToOfficeUser(SickNoteStatus status) throws Exception {
+        final Person person = new Person();
+        person.setId(36L);
+
+        final Person signedInUser = new Person();
+        signedInUser.setId(37L);
+        signedInUser.setPermissions(List.of(Role.OFFICE));
+
+        final SickNoteType sickNoteType = new SickNoteType();
+        sickNoteType.setId(1L);
+        sickNoteType.setCategory(SICK_NOTE);
+        sickNoteType.setMessageKey("key");
+
+        final SickNote sickNote = SickNote.builder()
+            .id(1L)
+            .person(person)
+            .startDate(LocalDate.of(2022, JANUARY, 2))
+            .endDate(LocalDate.of(2022, JANUARY, 4))
+            .dayLength(FULL)
+            .sickNoteType(sickNoteType)
+            .status(status)
+            .build();
+
+        when(personService.getPersonByID(36L)).thenReturn(Optional.of(person));
+        when(personService.getSignedInUser()).thenReturn(signedInUser);
+        when(departmentService.getAssignedDepartmentsOfMember(person)).thenReturn(List.of());
+        when(sickNoteService.getByPersonAndPeriod(eq(person), any(LocalDate.class), any(LocalDate.class))).thenReturn(List.of(sickNote));
+        when(settingsService.getSettings()).thenReturn(new Settings());
+
+        perform(get(MY_SICKNOTES_PATH.replace("{personId}", "36")))
+            .andExpect(status().isOk())
+            .andExpect(view().name("me/sicknotes"))
+            .andExpect(model().attribute("sickNotes", hasSize(1)))
+            .andExpect(model().attribute("sickNotes",
+                hasItem(allOf(hasProperty("allowedToEdit", is(false)), hasProperty("allowedToCancel", is(false))))));
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNotePermissionEvaluatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNotePermissionEvaluatorTest.java
@@ -264,6 +264,19 @@ class SickNotePermissionEvaluatorTest {
             assertThat(permissions.isAllowedToEdit(sickNote(OTHER_PERSON_ID, ACTIVE))).isFalse();
             assertThat(permissions.isAllowedToAdd()).isTrue();
         }
+
+        @ParameterizedTest
+        @EnumSource(value = SickNoteStatus.class, names = {"CANCELLED", "CONVERTED_TO_VACATION"})
+        void ensureNobodyMayEditInactiveSickNote(SickNoteStatus status) {
+            assertThat(permissionsOnUnmanagedPerson(OFFICE).isAllowedToEdit(sickNote(OTHER_PERSON_ID, status))).isFalse();
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = SickNoteStatus.class, names = {"CANCELLED", "CONVERTED_TO_VACATION"})
+        void ensurePersonMayNotEditOwnInactiveSickNote(SickNoteStatus status) {
+            final Person signedInUser = person(SIGNED_IN_USER_ID, USER);
+            assertThat(sut.of(signedInUser, signedInUser).isAllowedToEdit(sickNote(SIGNED_IN_USER_ID, status))).isFalse();
+        }
     }
 
     @Nested
@@ -287,35 +300,46 @@ class SickNotePermissionEvaluatorTest {
 
         @Test
         void ensureOfficeMayCancel() {
-            assertThat(permissionsOnUnmanagedPerson(OFFICE).isAllowedToCancel()).isTrue();
+            assertThat(permissionsOnUnmanagedPerson(OFFICE).isAllowedToCancel(sickNote(OTHER_PERSON_ID, ACTIVE))).isTrue();
         }
 
         @Test
         void ensureBossWithSickNoteCancelMayCancel() {
-            assertThat(permissionsOnUnmanagedPerson(BOSS, SICK_NOTE_CANCEL).isAllowedToCancel()).isTrue();
+            assertThat(permissionsOnUnmanagedPerson(BOSS, SICK_NOTE_CANCEL).isAllowedToCancel(sickNote(OTHER_PERSON_ID, ACTIVE))).isTrue();
         }
 
         @Test
         void ensureDepartmentHeadWithSickNoteCancelMayCancelForManagedMember() {
-            assertThat(permissionsOnManagedPerson(DEPARTMENT_HEAD, SICK_NOTE_CANCEL).isAllowedToCancel()).isTrue();
+            assertThat(permissionsOnManagedPerson(DEPARTMENT_HEAD, SICK_NOTE_CANCEL).isAllowedToCancel(sickNote(OTHER_PERSON_ID, ACTIVE))).isTrue();
+        }
+
+        @Test
+        void ensureSubmittedSickNoteMayBeCancelled() {
+            assertThat(permissionsOnUnmanagedPerson(OFFICE).isAllowedToCancel(sickNote(OTHER_PERSON_ID, SUBMITTED))).isTrue();
         }
 
         @Test
         void ensureDepartmentHeadWithSickNoteCancelMayNotCancelForPersonOutsideOfDepartment() {
-            assertThat(permissionsOnUnmanagedPerson(DEPARTMENT_HEAD, SICK_NOTE_CANCEL).isAllowedToCancel()).isFalse();
+            assertThat(permissionsOnUnmanagedPerson(DEPARTMENT_HEAD, SICK_NOTE_CANCEL).isAllowedToCancel(sickNote(OTHER_PERSON_ID, ACTIVE))).isFalse();
         }
 
         @Test
         void ensureSickNoteEditDoesNotAllowToCancel() {
             final SickNotePermissions permissions = permissionsOnManagedPerson(DEPARTMENT_HEAD, SICK_NOTE_EDIT);
-            assertThat(permissions.isAllowedToCancel()).isFalse();
+            assertThat(permissions.isAllowedToCancel(sickNote(OTHER_PERSON_ID, ACTIVE))).isFalse();
             assertThat(permissions.isAllowedToAccept()).isTrue();
         }
 
         @Test
         void ensurePersonMayNotCancelOwnSickNote() {
             final Person signedInUser = person(SIGNED_IN_USER_ID, USER);
-            assertThat(sut.of(signedInUser, signedInUser).isAllowedToCancel()).isFalse();
+            assertThat(sut.of(signedInUser, signedInUser).isAllowedToCancel(sickNote(SIGNED_IN_USER_ID, ACTIVE))).isFalse();
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = SickNoteStatus.class, names = {"CANCELLED", "CONVERTED_TO_VACATION"})
+        void ensureNobodyMayCancelInactiveSickNote(SickNoteStatus status) {
+            assertThat(permissionsOnUnmanagedPerson(OFFICE).isAllowedToCancel(sickNote(OTHER_PERSON_ID, status))).isFalse();
         }
     }
 
@@ -427,7 +451,7 @@ class SickNotePermissionEvaluatorTest {
             final SickNotePermissions permissions = sut.of(signedInUser, sickNotePerson);
             permissions.isAllowedToView();
             permissions.isAllowedToAccept();
-            permissions.isAllowedToCancel();
+            permissions.isAllowedToCancel(sickNote(OTHER_PERSON_ID, ACTIVE));
             permissions.isAllowedToComment();
 
             verify(departmentService).isDepartmentHeadAllowedToManagePerson(signedInUser, sickNotePerson);

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewControllerTest.java
@@ -90,6 +90,7 @@ import static org.synyx.urlaubsverwaltung.person.Role.SICK_NOTE_VIEW;
 import static org.synyx.urlaubsverwaltung.person.Role.USER;
 import static org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteStatus.ACTIVE;
 import static org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteStatus.CANCELLED;
+import static org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteStatus.CONVERTED_TO_VACATION;
 import static org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteStatus.SUBMITTED;
 
 @ExtendWith(MockitoExtension.class)
@@ -818,7 +819,7 @@ class SickNoteViewControllerTest {
         when(personService.getSignedInUser()).thenReturn(somePerson);
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
             .startDate(LocalDate.of(2025, FEBRUARY, 10))
-            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(somePerson).build()));
+            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(somePerson).status(ACTIVE).build()));
         perform(get("/web/sicknote/15")).andExpect(status().isOk());
     }
 
@@ -832,7 +833,7 @@ class SickNoteViewControllerTest {
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
             .startDate(LocalDate.of(2025, FEBRUARY, 10))
             .endDate(LocalDate.of(2025, FEBRUARY, 20))
-            .person(new Person()).build()));
+            .person(new Person()).status(ACTIVE).build()));
 
         perform(get("/web/sicknote/15")).andExpect(status().isOk());
     }
@@ -864,7 +865,7 @@ class SickNoteViewControllerTest {
         person.setId(2L);
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
             .startDate(LocalDate.of(2025, FEBRUARY, 10))
-            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).build()));
+            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).status(ACTIVE).build()));
 
         perform(get("/web/sicknote/15")).andExpect(status().isOk());
     }
@@ -884,7 +885,7 @@ class SickNoteViewControllerTest {
         person.setId(2L);
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
             .startDate(LocalDate.of(2025, FEBRUARY, 10))
-            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).build()));
+            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).status(ACTIVE).build()));
         when(departmentService.isDepartmentHeadAllowedToManagePerson(departmentHeadPerson, person)).thenReturn(true);
 
         perform(get("/web/sicknote/15")).andExpect(status().isOk());
@@ -905,7 +906,7 @@ class SickNoteViewControllerTest {
         person.setId(2L);
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
             .startDate(LocalDate.of(2025, FEBRUARY, 10))
-            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).build()));
+            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).status(ACTIVE).build()));
         when(departmentService.isDepartmentHeadAllowedToManagePerson(departmentHeadPerson, person)).thenReturn(true);
 
         perform(get("/web/sicknote/15")).andExpect(status().isOk());
@@ -966,7 +967,7 @@ class SickNoteViewControllerTest {
         person.setId(2L);
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
             .startDate(LocalDate.of(2025, FEBRUARY, 10))
-            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).build()));
+            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).status(ACTIVE).build()));
         when(departmentService.isSecondStageAuthorityAllowedToManagePerson(secondStageAuthority, person)).thenReturn(true);
 
         perform(get("/web/sicknote/15")).andExpect(status().isOk());
@@ -984,7 +985,7 @@ class SickNoteViewControllerTest {
         person.setId(2L);
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
             .startDate(LocalDate.of(2025, FEBRUARY, 10))
-            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).build()));
+            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).status(ACTIVE).build()));
         when(departmentService.isSecondStageAuthorityAllowedToManagePerson(secondStageAuthority, person)).thenReturn(true);
 
         perform(get("/web/sicknote/15")).andExpect(status().isOk());
@@ -1115,7 +1116,7 @@ class SickNoteViewControllerTest {
         final Person person = new Person();
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
             .startDate(LocalDate.of(2025, FEBRUARY, 10))
-            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).build()));
+            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).status(ACTIVE).build()));
         when(sickNoteCommentService.getCommentsBySickNote(any(SickNote.class))).thenReturn(List.of());
         when(departmentService.isDepartmentHeadAllowedToManagePerson(departmentHead, person)).thenReturn(true);
 
@@ -1152,7 +1153,7 @@ class SickNoteViewControllerTest {
         final Person person = new Person();
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
             .startDate(LocalDate.of(2025, FEBRUARY, 10))
-            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).build()));
+            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(person).status(ACTIVE).build()));
         when(sickNoteCommentService.getCommentsBySickNote(any(SickNote.class))).thenReturn(List.of());
         when(departmentService.isSecondStageAuthorityAllowedToManagePerson(ssa, person)).thenReturn(true);
 
@@ -1192,6 +1193,23 @@ class SickNoteViewControllerTest {
         perform(get("/web/sicknote/15"))
             .andExpect(view().name("sicknote/sick_note_detail"))
             .andExpect(model().attribute(can, true));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SickNoteStatus.class, names = {"CANCELLED", "CONVERTED_TO_VACATION"})
+    void ensureGetSickNoteDetailsOfInactiveSickNoteCanNeitherBeEditedNorCancelled(SickNoteStatus status) throws Exception {
+
+        when(settingsService.getSettings()).thenReturn(new Settings());
+        when(personService.getSignedInUser()).thenReturn(personWithRole(OFFICE));
+        when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
+            .startDate(LocalDate.of(2025, FEBRUARY, 10))
+            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(new Person()).status(status).build()));
+        when(sickNoteCommentService.getCommentsBySickNote(any(SickNote.class))).thenReturn(List.of());
+
+        perform(get("/web/sicknote/15"))
+            .andExpect(view().name("sicknote/sick_note_detail"))
+            .andExpect(model().attribute("canEditSickNote", false))
+            .andExpect(model().attribute("canDeleteSickNote", false));
     }
 
     @Test
@@ -2030,6 +2048,20 @@ class SickNoteViewControllerTest {
         assertThatThrownBy(() ->
             perform(post("/web/sicknote/15/cancel"))
         ).hasCauseInstanceOf(AccessDeniedException.class);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SickNoteStatus.class, names = {"CANCELLED", "CONVERTED_TO_VACATION"})
+    void ensureInactiveSickNoteCannotBeCancelledAgain(SickNoteStatus status) {
+
+        when(personService.getSignedInUser()).thenReturn(personWithRole(OFFICE));
+        when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder().id(1L).person(new Person()).status(status).build()));
+
+        assertThatThrownBy(() ->
+            perform(post("/web/sicknote/15/cancel"))
+        ).hasCauseInstanceOf(AccessDeniedException.class);
+
+        verifyNoInteractions(sickNoteInteractionService);
     }
 
     private void userIsAllowedToSubmitSickNotes(boolean allowed) {


### PR DESCRIPTION
A cancelled or converted sick note cannot be maintained any more. That rule lived in the detail template alone, so the person overview and the sick notes list still rendered both buttons - and cancelling an already cancelled sick note wrote another comment and sent the cancellation mails a second time.

Moves the rule into SickNotePermissions, which every view and the cancel endpoint go through.

Closes #6573

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
