### PR TITLE
Convert only sick notes that are active

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNotePermissions.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNotePermissions.java
@@ -10,6 +10,7 @@ import static org.synyx.urlaubsverwaltung.person.Role.SICK_NOTE_CANCEL;
 import static org.synyx.urlaubsverwaltung.person.Role.SICK_NOTE_COMMENT;
 import static org.synyx.urlaubsverwaltung.person.Role.SICK_NOTE_EDIT;
 import static org.synyx.urlaubsverwaltung.person.Role.SICK_NOTE_VIEW;
+import static org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteStatus.ACTIVE;
 
 /**
  * Permissions of a user on sick notes of one certain person, see
@@ -94,11 +95,16 @@ public final class SickNotePermissions {
     }
 
     /**
-     * @return {@code true} if the user may convert a sick note of the person into an application for leave,
+     * Only a sick note with status {@link SickNoteStatus#ACTIVE} may be converted. A submitted one has to be accepted
+     * first, a cancelled or already converted one cannot be converted at all. Note that this is narrower than
+     * {@link SickNote#isActive()}, which also holds for a submitted sick note.
+     *
+     * @param sickNote sick note to be converted, has to belong to the person of these permissions
+     * @return {@code true} if the user may convert the given sick note into an application for leave,
      * {@code false} otherwise
      */
-    public boolean isAllowedToConvert() {
-        return signedInUser.hasRole(OFFICE);
+    public boolean isAllowedToConvert(SickNote sickNote) {
+        return ACTIVE.equals(sickNote.getStatus()) && signedInUser.hasRole(OFFICE);
     }
 
     /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewController.java
@@ -195,7 +195,7 @@ class SickNoteViewController implements HasLaunchpad, HasPersonSearch {
 
             model.addAttribute("canAcceptSickNote", permissions.isAllowedToAccept());
             model.addAttribute("canEditSickNote", permissions.isAllowedToEdit(sickNote));
-            model.addAttribute("canConvertSickNote", permissions.isAllowedToConvert());
+            model.addAttribute("canConvertSickNote", permissions.isAllowedToConvert(sickNote));
             model.addAttribute("canDeleteSickNote", permissions.isAllowedToCancel(sickNote));
             model.addAttribute("canCommentSickNote", permissions.isAllowedToComment());
 
@@ -460,7 +460,9 @@ class SickNoteViewController implements HasLaunchpad, HasPersonSearch {
     public String convertSickNoteToVacation(@PathVariable("id") Long id, Model model) throws UnknownSickNoteException {
 
         final SickNote sickNote = getSickNote(id);
-        if (!sickNote.isActive()) {
+        final Person signedInUser = personService.getSignedInUser();
+
+        if (!sickNotePermissionEvaluator.of(signedInUser, sickNote).isAllowedToConvert(sickNote)) {
             return "redirect:/web/sicknote/" + id;
         }
 
@@ -480,6 +482,12 @@ class SickNoteViewController implements HasLaunchpad, HasPersonSearch {
     ) throws UnknownSickNoteException {
 
         final SickNote sickNote = getSickNote(id);
+        final Person signedInUser = personService.getSignedInUser();
+
+        if (!sickNotePermissionEvaluator.of(signedInUser, sickNote).isAllowedToConvert(sickNote)) {
+            throw new AccessDeniedException("User '%s' has not the correct permissions to convert the sick note of user '%s'".formatted(signedInUser.getId(), sickNote.getPerson().getId()));
+        }
+
         sickNoteConvertFormValidator.validate(sickNoteConvertForm, errors);
 
         if (errors.hasErrors()) {
@@ -492,7 +500,7 @@ class SickNoteViewController implements HasLaunchpad, HasPersonSearch {
         }
 
         final Application application = generateApplicationForLeave(sickNoteConvertForm);
-        sickNoteInteractionService.convert(sickNote, application, personService.getSignedInUser());
+        sickNoteInteractionService.convert(sickNote, application, signedInUser);
 
         return "redirect:/web/sicknote/" + id;
     }

--- a/src/main/resources/templates/sicknote/sick_note_detail.html
+++ b/src/main/resources/templates/sicknote/sick_note_detail.html
@@ -58,7 +58,7 @@
                   <span th:text="#{action.edit}" class="sr-only"></span>
                 </a>
               </th:block>
-              <th:block th:if="${canConvertSickNote && sickNote.status.name == 'ACTIVE'}">
+              <th:block th:if="${canConvertSickNote}">
                 <a
                   th:href="@{/web/sicknote/__${sickNote.id}__/convert}"
                   class="icon-link"

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNotePermissionEvaluatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNotePermissionEvaluatorTest.java
@@ -284,14 +284,20 @@ class SickNotePermissionEvaluatorTest {
 
         @Test
         void ensureOnlyOfficeMayConvert() {
-            assertThat(permissionsOnUnmanagedPerson(OFFICE).isAllowedToConvert()).isTrue();
+            assertThat(permissionsOnUnmanagedPerson(OFFICE).isAllowedToConvert(sickNote(OTHER_PERSON_ID, ACTIVE))).isTrue();
         }
 
         @ParameterizedTest
         @EnumSource(value = Role.class, names = {"BOSS", "DEPARTMENT_HEAD", "SECOND_STAGE_AUTHORITY"})
         void ensureManagerWithEveryTaskRoleMayNotConvert(Role role) {
             final Person signedInUser = person(SIGNED_IN_USER_ID, role, SICK_NOTE_VIEW, SICK_NOTE_ADD, SICK_NOTE_EDIT, SICK_NOTE_CANCEL, SICK_NOTE_COMMENT);
-            assertThat(sut.of(signedInUser, person(OTHER_PERSON_ID, USER)).isAllowedToConvert()).isFalse();
+            assertThat(sut.of(signedInUser, person(OTHER_PERSON_ID, USER)).isAllowedToConvert(sickNote(OTHER_PERSON_ID, ACTIVE))).isFalse();
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = SickNoteStatus.class, names = {"SUBMITTED", "CANCELLED", "CONVERTED_TO_VACATION"})
+        void ensureOnlyASickNoteWithStatusActiveMayBeConverted(SickNoteStatus status) {
+            assertThat(permissionsOnUnmanagedPerson(OFFICE).isAllowedToConvert(sickNote(OTHER_PERSON_ID, status))).isFalse();
         }
     }
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewControllerTest.java
@@ -1196,6 +1196,22 @@ class SickNoteViewControllerTest {
     }
 
     @ParameterizedTest
+    @EnumSource(value = SickNoteStatus.class, names = {"SUBMITTED", "CANCELLED", "CONVERTED_TO_VACATION"})
+    void ensureGetSickNoteDetailsCannotConvertSickNoteWithStatusOtherThanActive(SickNoteStatus status) throws Exception {
+
+        when(settingsService.getSettings()).thenReturn(new Settings());
+        when(personService.getSignedInUser()).thenReturn(personWithRole(OFFICE));
+        when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
+            .startDate(LocalDate.of(2025, FEBRUARY, 10))
+            .endDate(LocalDate.of(2025, FEBRUARY, 20)).person(new Person()).status(status).build()));
+        when(sickNoteCommentService.getCommentsBySickNote(any(SickNote.class))).thenReturn(List.of());
+
+        perform(get("/web/sicknote/15"))
+            .andExpect(view().name("sicknote/sick_note_detail"))
+            .andExpect(model().attribute("canConvertSickNote", false));
+    }
+
+    @ParameterizedTest
     @EnumSource(value = SickNoteStatus.class, names = {"CANCELLED", "CONVERTED_TO_VACATION"})
     void ensureGetSickNoteDetailsOfInactiveSickNoteCanNeitherBeEditedNorCancelled(SickNoteStatus status) throws Exception {
 
@@ -1780,6 +1796,7 @@ class SickNoteViewControllerTest {
 
         when(vacationTypeService.getById(42L)).thenReturn(Optional.of(ProvidedVacationType.builder(new StaticMessageSource()).category(OVERTIME).build()));
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(sickNote));
+        when(personService.getSignedInUser()).thenReturn(personWithRole(OFFICE));
 
         perform(post("/web/sicknote/15/convert").param("vacationType", "42"))
             .andExpect(status().isFound())
@@ -1833,13 +1850,29 @@ class SickNoteViewControllerTest {
         ).hasCauseInstanceOf(UnknownSickNoteException.class);
     }
 
-    @Test
-    void ensureGetConvertSickNoteToVacationThrowsSickNoteAlreadyInactiveException() throws Exception {
+    @ParameterizedTest
+    @EnumSource(value = SickNoteStatus.class, names = {"SUBMITTED", "CANCELLED", "CONVERTED_TO_VACATION"})
+    void ensureGetConvertSickNoteToVacationRedirectsToDetailsWhenStatusIsNotActive(SickNoteStatus status) throws Exception {
 
-        when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder().person(new Person()).status(CANCELLED).build()));
+        when(personService.getSignedInUser()).thenReturn(personWithRole(OFFICE));
+        when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder().person(new Person()).status(status).build()));
 
         perform(get("/web/sicknote/15/convert"))
             .andExpect(view().name("redirect:/web/sicknote/15"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SickNoteStatus.class, names = {"SUBMITTED", "CANCELLED", "CONVERTED_TO_VACATION"})
+    void ensurePostConvertSickNoteToVacationIsForbiddenWhenStatusIsNotActive(SickNoteStatus status) {
+
+        when(personService.getSignedInUser()).thenReturn(personWithRole(OFFICE));
+        when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder().person(new Person()).status(status).build()));
+
+        assertThatThrownBy(() ->
+            perform(post("/web/sicknote/15/convert").param("vacationType", "42"))
+        ).hasCauseInstanceOf(AccessDeniedException.class);
+
+        verifyNoInteractions(sickNoteInteractionService);
     }
 
     @Test
@@ -1847,6 +1880,7 @@ class SickNoteViewControllerTest {
 
         overtimeActive(false);
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder().person(new Person()).status(ACTIVE).build()));
+        when(personService.getSignedInUser()).thenReturn(personWithRole(OFFICE));
 
         final List<VacationType<?>> vacationTypes = List.of(ProvidedVacationType.builder(new StaticMessageSource()).build());
         when(vacationTypeService.getActiveVacationTypesWithoutCategory(OVERTIME)).thenReturn(vacationTypes);
@@ -1862,6 +1896,7 @@ class SickNoteViewControllerTest {
 
         overtimeActive(true);
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder().person(new Person()).status(ACTIVE).build()));
+        when(personService.getSignedInUser()).thenReturn(personWithRole(OFFICE));
 
         final List<VacationType<?>> vacationTypes = List.of(ProvidedVacationType.builder(new StaticMessageSource()).build());
         when(vacationTypeService.getActiveVacationTypes()).thenReturn(vacationTypes);
@@ -1878,6 +1913,7 @@ class SickNoteViewControllerTest {
         overtimeActive(false);
 
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder().person(new Person()).status(ACTIVE).build()));
+        when(personService.getSignedInUser()).thenReturn(personWithRole(OFFICE));
 
         perform(get("/web/sicknote/15/convert"))
             .andExpect(view().name("sicknote/sick_note_convert"));
@@ -1896,6 +1932,7 @@ class SickNoteViewControllerTest {
 
         overtimeActive(false);
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder().person(new Person()).status(ACTIVE).build()));
+        when(personService.getSignedInUser()).thenReturn(personWithRole(OFFICE));
 
         final List<VacationType<?>> vacationTypes = List.of(ProvidedVacationType.builder(new StaticMessageSource()).build());
         when(vacationTypeService.getActiveVacationTypesWithoutCategory(OVERTIME)).thenReturn(vacationTypes);
@@ -1919,6 +1956,7 @@ class SickNoteViewControllerTest {
 
         overtimeActive(true);
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder().person(new Person()).status(ACTIVE).build()));
+        when(personService.getSignedInUser()).thenReturn(personWithRole(OFFICE));
 
         final List<VacationType<?>> vacationTypes = List.of(ProvidedVacationType.builder(new StaticMessageSource()).build());
         when(vacationTypeService.getActiveVacationTypes()).thenReturn(vacationTypes);
@@ -1948,7 +1986,7 @@ class SickNoteViewControllerTest {
         when(vacationTypeService.getById(42L)).thenReturn(Optional.of(ProvidedVacationType.builder(new StaticMessageSource()).category(OVERTIME).build()));
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(sickNote));
 
-        final Person signedInPerson = new Person();
+        final Person signedInPerson = personWithRole(OFFICE);
         when(personService.getSignedInUser()).thenReturn(signedInPerson);
 
         perform(post("/web/sicknote/15/convert")
@@ -1969,7 +2007,7 @@ class SickNoteViewControllerTest {
         when(vacationTypeService.getById(42L)).thenReturn(Optional.of(ProvidedVacationType.builder(new StaticMessageSource()).category(OVERTIME).build()));
         when(sickNoteService.getById(15L)).thenReturn(Optional.of(sickNote));
 
-        final Person signedInPerson = new Person();
+        final Person signedInPerson = personWithRole(OFFICE);
         when(personService.getSignedInUser()).thenReturn(signedInPerson);
 
         perform(post("/web/sicknote/15/convert")


### PR DESCRIPTION
Whether a sick note may be converted into an application for leave was decided in the detail template alone. Both convert endpoints never asked SickNotePermissions: the GET used a weaker hand-written check that let a submitted sick note reach the form, the POST had no check at all and happily converted a cancelled or already converted sick note.

Moves the rule into SickNotePermissions, where the detail page and both endpoints pick it up.

Closes #6575

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
