### PR TITLE
Accept only sick notes that were submitted

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNotePermissions.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNotePermissions.java
@@ -66,20 +66,25 @@ public final class SickNotePermissions {
     }
 
     /**
-     * @return {@code true} if the user may accept a submitted sick note of the person, {@code false} otherwise
+     * Only a sick note with status {@link SickNoteStatus#SUBMITTED} may be accepted. An already accepted, cancelled or
+     * converted one has nothing left to accept.
+     *
+     * @param sickNote sick note to be accepted, has to belong to the person of these permissions
+     * @return {@code true} if the user may accept the given sick note, {@code false} otherwise
      */
-    public boolean isAllowedToAccept() {
-        return isAllowedToMaintain(SICK_NOTE_EDIT);
+    public boolean isAllowedToAccept(SickNote sickNote) {
+        return sickNote.isSubmitted() && isAllowedToMaintain(SICK_NOTE_EDIT);
     }
 
     /**
-     * Accepting a submitted extension changes the end date of an existing sick note and is therefore governed by the
-     * very same rule as accepting a sick note.
+     * Accepting a submitted extension changes the end date of an existing sick note. It needs the same role as
+     * accepting a sick note, but not the same state: an extension is handed in for a sick note that is already
+     * accepted, therefore no sick note is passed in here.
      *
      * @return {@code true} if the user may accept a submitted extension of the person, {@code false} otherwise
      */
     public boolean isAllowedToAcceptExtension() {
-        return isAllowedToAccept();
+        return isAllowedToMaintain(SICK_NOTE_EDIT);
     }
 
     /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewController.java
@@ -179,21 +179,22 @@ class SickNoteViewController implements HasLaunchpad, HasPersonSearch {
             model.addAttribute("doesSickPayDaysEnd", !sickNote.getEndDate().isBefore(sickNote.getStartDate().plusDays(maximumSickPayDays)));
             model.addAttribute("numberSickPayDaysSinceEnd", ChronoUnit.DAYS.between(sickPayDaysEndDate, LocalDate.now(clock)) + 1);
 
-            sickNoteExtensionService.findSubmittedExtensionOfSickNote(sickNote)
-                .ifPresentOrElse(
-                    extension -> {
-                        model.addAttribute("extensionRequested", true);
-                        model.addAttribute("sickNotePreviewCurrent", toSickNoteExtensionPreviewDto(sickNote));
-                        model.addAttribute("sickNotePreviewNext", toSickNoteExtensionPreviewDto(sickNote, extension));
-                    },
-                    () ->
-                        model.addAttribute("extensionRequested", false)
-                );
+            final Optional<SickNoteExtension> submittedExtension = sickNoteExtensionService.findSubmittedExtensionOfSickNote(sickNote);
+            submittedExtension.ifPresentOrElse(
+                extension -> {
+                    model.addAttribute("extensionRequested", true);
+                    model.addAttribute("sickNotePreviewCurrent", toSickNoteExtensionPreviewDto(sickNote));
+                    model.addAttribute("sickNotePreviewNext", toSickNoteExtensionPreviewDto(sickNote, extension));
+                },
+                () ->
+                    model.addAttribute("extensionRequested", false)
+            );
 
             final List<SickNoteCommentEntity> comments = sickNoteCommentService.getCommentsBySickNote(sickNote);
             model.addAttribute("comments", comments);
 
-            model.addAttribute("canAcceptSickNote", permissions.isAllowedToAccept());
+            model.addAttribute("canAcceptSickNote", permissions.isAllowedToAccept(sickNote));
+            model.addAttribute("canAcceptSickNoteExtension", submittedExtension.isPresent() && permissions.isAllowedToAcceptExtension());
             model.addAttribute("canEditSickNote", permissions.isAllowedToEdit(sickNote));
             model.addAttribute("canConvertSickNote", permissions.isAllowedToConvert(sickNote));
             model.addAttribute("canDeleteSickNote", permissions.isAllowedToCancel(sickNote));
@@ -408,7 +409,7 @@ class SickNoteViewController implements HasLaunchpad, HasPersonSearch {
         final SickNote sickNote = getSickNote(sickNoteId);
         final Person signedInUser = personService.getSignedInUser();
 
-        if (!sickNotePermissionEvaluator.of(signedInUser, sickNote).isAllowedToAccept()) {
+        if (!sickNotePermissionEvaluator.of(signedInUser, sickNote).isAllowedToAccept(sickNote)) {
             throw new AccessDeniedException("User '%s' has not the correct permissions to accept the sick note of user '%s'".formatted(signedInUser.getId(), sickNote.getPerson().getId()));
         }
 

--- a/src/main/resources/templates/sicknote/sick_note_detail.html
+++ b/src/main/resources/templates/sicknote/sick_note_detail.html
@@ -38,7 +38,7 @@
           </th:block>
           <th:block th:ref="sicknote-heading-actions">
             <div class="flex flex-row gap-2">
-              <th:block th:if="${canAcceptSickNote && (extensionRequested || sickNote.status.name == 'SUBMITTED')}">
+              <th:block th:if="${canAcceptSickNote || canAcceptSickNoteExtension}">
                 <button
                   type="button"
                   class="icon-link bg-transparent"
@@ -104,7 +104,7 @@
         </th:block>
 
         <div class="actions" th:with="redirectTo=${redirect}">
-          <th:block th:if="${canAcceptSickNote}">
+          <th:block th:if="${canAcceptSickNote || canAcceptSickNoteExtension}">
             <form
               id="allow"
               class="alert alert-success"
@@ -308,7 +308,7 @@
               </div>
             </details>
           </div>
-          <th:block th:if="${canAcceptSickNote && extensionRequested}">
+          <th:block th:if="${canAcceptSickNoteExtension}">
             <form
               action="#"
               th:action="@{/web/sicknote/__${sickNote.id}__/extension/accept}"

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNotePermissionEvaluatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNotePermissionEvaluatorTest.java
@@ -160,7 +160,7 @@ class SickNotePermissionEvaluatorTest {
         void ensureSickNoteEditDoesNotAllowToAdd() {
             final SickNotePermissions permissions = permissionsOnManagedPerson(DEPARTMENT_HEAD, SICK_NOTE_EDIT);
             assertThat(permissions.isAllowedToAdd()).isFalse();
-            assertThat(permissions.isAllowedToAccept()).isTrue();
+            assertThat(permissions.isAllowedToAccept(sickNote(OTHER_PERSON_ID, SUBMITTED))).isTrue();
         }
     }
 
@@ -187,37 +187,65 @@ class SickNotePermissionEvaluatorTest {
     class Accept {
 
         @Test
-        void ensureOfficeMayAccept() {
-            assertThat(permissionsOnUnmanagedPerson(OFFICE).isAllowedToAccept()).isTrue();
+        void ensureOfficeMayAcceptSubmittedSickNote() {
+            assertThat(permissionsOnUnmanagedPerson(OFFICE).isAllowedToAccept(sickNote(OTHER_PERSON_ID, SUBMITTED))).isTrue();
         }
 
         @Test
-        void ensureBossWithSickNoteEditMayAccept() {
-            assertThat(permissionsOnUnmanagedPerson(BOSS, SICK_NOTE_EDIT).isAllowedToAccept()).isTrue();
+        void ensureBossWithSickNoteEditMayAcceptSubmittedSickNote() {
+            assertThat(permissionsOnUnmanagedPerson(BOSS, SICK_NOTE_EDIT).isAllowedToAccept(sickNote(OTHER_PERSON_ID, SUBMITTED))).isTrue();
         }
 
         @Test
-        void ensureDepartmentHeadWithSickNoteEditMayAcceptForManagedMember() {
-            assertThat(permissionsOnManagedPerson(DEPARTMENT_HEAD, SICK_NOTE_EDIT).isAllowedToAccept()).isTrue();
+        void ensureDepartmentHeadWithSickNoteEditMayAcceptSubmittedSickNoteOfManagedMember() {
+            assertThat(permissionsOnManagedPerson(DEPARTMENT_HEAD, SICK_NOTE_EDIT).isAllowedToAccept(sickNote(OTHER_PERSON_ID, SUBMITTED))).isTrue();
         }
 
         @Test
         void ensureSickNoteAddDoesNotAllowToAccept() {
             final SickNotePermissions permissions = permissionsOnManagedPerson(DEPARTMENT_HEAD, SICK_NOTE_ADD);
-            assertThat(permissions.isAllowedToAccept()).isFalse();
+            assertThat(permissions.isAllowedToAccept(sickNote(OTHER_PERSON_ID, SUBMITTED))).isFalse();
             assertThat(permissions.isAllowedToAdd()).isTrue();
         }
 
         @Test
         void ensurePersonMayNotAcceptOwnSickNote() {
             final Person signedInUser = person(SIGNED_IN_USER_ID, USER);
-            assertThat(sut.of(signedInUser, signedInUser).isAllowedToAccept()).isFalse();
+            assertThat(sut.of(signedInUser, signedInUser).isAllowedToAccept(sickNote(SIGNED_IN_USER_ID, SUBMITTED))).isFalse();
         }
 
         @Test
-        void ensureAcceptingAnExtensionFollowsTheSameRuleAsAccepting() {
-            final SickNotePermissions permissions = permissionsOnManagedPerson(DEPARTMENT_HEAD, SICK_NOTE_EDIT);
-            assertThat(permissions.isAllowedToAcceptExtension()).isEqualTo(permissions.isAllowedToAccept());
+        void ensureNobodyMayAcceptAnAlreadyAcceptedSickNote() {
+            assertThat(permissionsOnUnmanagedPerson(OFFICE).isAllowedToAccept(sickNote(OTHER_PERSON_ID, ACTIVE))).isFalse();
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = SickNoteStatus.class, names = {"CANCELLED", "CONVERTED_TO_VACATION"})
+        void ensureNobodyMayAcceptInactiveSickNote(SickNoteStatus status) {
+            assertThat(permissionsOnUnmanagedPerson(OFFICE).isAllowedToAccept(sickNote(OTHER_PERSON_ID, status))).isFalse();
+        }
+
+        @Test
+        void ensureOfficeMayAcceptAnExtension() {
+            assertThat(permissionsOnUnmanagedPerson(OFFICE).isAllowedToAcceptExtension()).isTrue();
+        }
+
+        @Test
+        void ensureDepartmentHeadWithSickNoteEditMayAcceptAnExtensionOfManagedMember() {
+            assertThat(permissionsOnManagedPerson(DEPARTMENT_HEAD, SICK_NOTE_EDIT).isAllowedToAcceptExtension()).isTrue();
+        }
+
+        @Test
+        void ensureAcceptingAnExtensionDoesNotRequireASubmittedSickNote() {
+            final SickNotePermissions permissions = permissionsOnUnmanagedPerson(OFFICE);
+            assertThat(permissions.isAllowedToAccept(sickNote(OTHER_PERSON_ID, ACTIVE))).isFalse();
+            assertThat(permissions.isAllowedToAcceptExtension()).isTrue();
+        }
+
+        @Test
+        void ensurePersonMayNotAcceptAnExtensionOfOwnSickNote() {
+            final Person signedInUser = person(SIGNED_IN_USER_ID, USER);
+            assertThat(sut.of(signedInUser, signedInUser).isAllowedToAcceptExtension()).isFalse();
         }
 
         @Test
@@ -333,7 +361,7 @@ class SickNotePermissionEvaluatorTest {
         void ensureSickNoteEditDoesNotAllowToCancel() {
             final SickNotePermissions permissions = permissionsOnManagedPerson(DEPARTMENT_HEAD, SICK_NOTE_EDIT);
             assertThat(permissions.isAllowedToCancel(sickNote(OTHER_PERSON_ID, ACTIVE))).isFalse();
-            assertThat(permissions.isAllowedToAccept()).isTrue();
+            assertThat(permissions.isAllowedToAccept(sickNote(OTHER_PERSON_ID, SUBMITTED))).isTrue();
         }
 
         @Test
@@ -371,7 +399,7 @@ class SickNotePermissionEvaluatorTest {
         void ensureSickNoteEditDoesNotAllowToComment() {
             final SickNotePermissions permissions = permissionsOnManagedPerson(DEPARTMENT_HEAD, SICK_NOTE_EDIT);
             assertThat(permissions.isAllowedToComment()).isFalse();
-            assertThat(permissions.isAllowedToAccept()).isTrue();
+            assertThat(permissions.isAllowedToAccept(sickNote(OTHER_PERSON_ID, SUBMITTED))).isTrue();
         }
 
         @Test
@@ -456,7 +484,7 @@ class SickNotePermissionEvaluatorTest {
 
             final SickNotePermissions permissions = sut.of(signedInUser, sickNotePerson);
             permissions.isAllowedToView();
-            permissions.isAllowedToAccept();
+            permissions.isAllowedToAccept(sickNote(OTHER_PERSON_ID, SUBMITTED));
             permissions.isAllowedToCancel(sickNote(OTHER_PERSON_ID, ACTIVE));
             permissions.isAllowedToComment();
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewControllerSecurityIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewControllerSecurityIT.java
@@ -30,6 +30,7 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteStatus.ACTIVE;
+import static org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteStatus.SUBMITTED;
 
 /**
  * The unit tests of {@link SickNoteViewController} use a standalone {@code MockMvc} setup, which does not apply method
@@ -77,7 +78,7 @@ class SickNoteViewControllerSecurityIT extends SingleTenantTestContainersBase {
     @ValueSource(strings = {"USER", "BOSS", "SICK_NOTE_VIEW", "SICK_NOTE_ADD", "SICK_NOTE_CANCEL", "SICK_NOTE_COMMENT"})
     void ensureAcceptSickNoteIsForbiddenWithoutSickNoteEditRole(final String role) throws Exception {
         perform(post("/web/sicknote/" + SICK_NOTE_ID + "/accept")
-            .with(oidcLogin().authorities(signIn("USER", role)))
+            .with(oidcLogin().authorities(signIn(SUBMITTED, "USER", role)))
             .with(csrf())
         ).andExpect(status().isForbidden());
     }
@@ -86,7 +87,7 @@ class SickNoteViewControllerSecurityIT extends SingleTenantTestContainersBase {
     @ValueSource(strings = {"OFFICE", "SICK_NOTE_EDIT"})
     void ensureAcceptSickNoteIsAllowedForRole(final String role) throws Exception {
         perform(post("/web/sicknote/" + SICK_NOTE_ID + "/accept")
-            .with(oidcLogin().authorities(signIn("USER", "BOSS", role)))
+            .with(oidcLogin().authorities(signIn(SUBMITTED, "USER", "BOSS", role)))
             .with(csrf())
         ).andExpect(status().is3xxRedirection());
     }
@@ -130,6 +131,10 @@ class SickNoteViewControllerSecurityIT extends SingleTenantTestContainersBase {
     }
 
     private SimpleGrantedAuthority[] signIn(String... roles) {
+        return signIn(ACTIVE, roles);
+    }
+
+    private SimpleGrantedAuthority[] signIn(SickNoteStatus sickNoteStatus, String... roles) {
 
         final Person signedInUser = new Person();
         signedInUser.setId(1L);
@@ -143,7 +148,7 @@ class SickNoteViewControllerSecurityIT extends SingleTenantTestContainersBase {
             .person(sickNotePerson)
             .startDate(LocalDate.of(2025, 8, 4))
             .endDate(LocalDate.of(2025, 8, 8))
-            .status(ACTIVE)
+            .status(sickNoteStatus)
             .build();
 
         when(personService.getSignedInUser()).thenReturn(signedInUser);

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewControllerTest.java
@@ -39,11 +39,14 @@ import org.synyx.urlaubsverwaltung.sicknote.comment.SickNoteCommentFormDto;
 import org.synyx.urlaubsverwaltung.sicknote.comment.SickNoteCommentFormValidator;
 import org.synyx.urlaubsverwaltung.sicknote.comment.SickNoteCommentService;
 import org.synyx.urlaubsverwaltung.sicknote.settings.SickNoteSettings;
+import org.synyx.urlaubsverwaltung.sicknote.sicknote.extend.SickNoteExtension;
 import org.synyx.urlaubsverwaltung.sicknote.sicknote.extend.SickNoteExtensionInteractionService;
 import org.synyx.urlaubsverwaltung.sicknote.sicknote.extend.SickNoteExtensionService;
+import org.synyx.urlaubsverwaltung.sicknote.sicknote.extend.SickNoteExtensionStatus;
 import org.synyx.urlaubsverwaltung.sicknote.sicknotetype.SickNoteType;
 import org.synyx.urlaubsverwaltung.sicknote.sicknotetype.SickNoteTypeService;
 
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -930,13 +933,95 @@ class SickNoteViewControllerTest {
             .status(SUBMITTED)
             .build()));
 
-        // the very same flag renders the button to accept a submitted sick note extension, therefore it has to match
-        // the permission of the endpoint accepting it
         perform(get("/web/sicknote/15"))
             .andExpect(status().isOk())
             .andExpect(model().attribute("canAcceptSickNote", true))
             .andExpect(model().attribute("canDeleteSickNote", false))
             .andExpect(model().attribute("canCommentSickNote", false));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SickNoteStatus.class, names = {"ACTIVE", "CANCELLED", "CONVERTED_TO_VACATION"})
+    void ensureGetSickNoteDetailsDoesNotAllowToAcceptASickNoteThatWasNotSubmitted(SickNoteStatus status) throws Exception {
+
+        when(settingsService.getSettings()).thenReturn(new Settings());
+
+        final Person signedInUser = personWithRole(OFFICE);
+        signedInUser.setId(1L);
+        when(personService.getSignedInUser()).thenReturn(signedInUser);
+
+        final Person person = personWithRole(USER);
+        person.setId(2L);
+        when(sickNoteService.getById(15L)).thenReturn(Optional.of(SickNote.builder()
+            .startDate(LocalDate.of(2025, FEBRUARY, 10))
+            .endDate(LocalDate.of(2025, FEBRUARY, 20))
+            .person(person)
+            .status(status)
+            .build()));
+
+        perform(get("/web/sicknote/15"))
+            .andExpect(status().isOk())
+            .andExpect(model().attribute("canAcceptSickNote", false))
+            .andExpect(model().attribute("canAcceptSickNoteExtension", false));
+    }
+
+    @Test
+    void ensureGetSickNoteDetailsAllowsToAcceptTheExtensionOfAnAlreadyAcceptedSickNote() throws Exception {
+
+        when(settingsService.getSettings()).thenReturn(new Settings());
+
+        final Person signedInUser = personWithRole(OFFICE);
+        signedInUser.setId(1L);
+        when(personService.getSignedInUser()).thenReturn(signedInUser);
+
+        final Person person = personWithRole(USER);
+        person.setId(2L);
+        final SickNote sickNote = SickNote.builder()
+            .id(15L)
+            .startDate(LocalDate.of(2025, FEBRUARY, 10))
+            .endDate(LocalDate.of(2025, FEBRUARY, 20))
+            .person(person)
+            .status(ACTIVE)
+            .build();
+        when(sickNoteService.getById(15L)).thenReturn(Optional.of(sickNote));
+        when(sickNoteExtensionService.findSubmittedExtensionOfSickNote(sickNote)).thenReturn(Optional.of(
+            new SickNoteExtension(1L, 15L, LocalDate.of(2025, FEBRUARY, 25), SickNoteExtensionStatus.SUBMITTED, BigDecimal.valueOf(3))
+        ));
+
+        // an extension is handed in for a sick note that is already accepted - accepting the extension therefore must
+        // not depend on the sick note being submitted
+        perform(get("/web/sicknote/15"))
+            .andExpect(status().isOk())
+            .andExpect(model().attribute("extensionRequested", true))
+            .andExpect(model().attribute("canAcceptSickNote", false))
+            .andExpect(model().attribute("canAcceptSickNoteExtension", true));
+    }
+
+    @Test
+    void ensureGetSickNoteDetailsDoesNotAllowThePersonToAcceptTheExtensionOfOwnSickNote() throws Exception {
+
+        when(settingsService.getSettings()).thenReturn(new Settings());
+
+        final Person signedInUser = personWithRole(USER);
+        signedInUser.setId(1L);
+        when(personService.getSignedInUser()).thenReturn(signedInUser);
+
+        final SickNote sickNote = SickNote.builder()
+            .id(15L)
+            .startDate(LocalDate.of(2025, FEBRUARY, 10))
+            .endDate(LocalDate.of(2025, FEBRUARY, 20))
+            .person(signedInUser)
+            .status(ACTIVE)
+            .build();
+        when(sickNoteService.getById(15L)).thenReturn(Optional.of(sickNote));
+        when(sickNoteExtensionService.findSubmittedExtensionOfSickNote(sickNote)).thenReturn(Optional.of(
+            new SickNoteExtension(1L, 15L, LocalDate.of(2025, FEBRUARY, 25), SickNoteExtensionStatus.SUBMITTED, BigDecimal.valueOf(3))
+        ));
+
+        perform(get("/web/sicknote/15"))
+            .andExpect(status().isOk())
+            .andExpect(model().attribute("extensionRequested", true))
+            .andExpect(model().attribute("canAcceptSickNoteExtension", false));
     }
 
     @Test
@@ -1573,6 +1658,21 @@ class SickNoteViewControllerTest {
             .param("text", "comment"));
 
         verify(sickNoteInteractionService).accept(any(SickNote.class), eq(signedInPerson), eq("comment"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SickNoteStatus.class, names = {"ACTIVE", "CANCELLED", "CONVERTED_TO_VACATION"})
+    void ensureAcceptSickNoteIsDeniedForASickNoteThatWasNotSubmitted(SickNoteStatus status) {
+
+        final SickNote sickNote = SickNote.builder().id(15L).person(new Person()).status(status).build();
+        when(sickNoteService.getById(15L)).thenReturn(Optional.of(sickNote));
+        when(personService.getSignedInUser()).thenReturn(personWithRole(OFFICE));
+
+        assertThatThrownBy(() ->
+            perform(post("/web/sicknote/15/accept"))
+        ).hasCauseInstanceOf(AccessDeniedException.class);
+
+        verifyNoInteractions(sickNoteInteractionService);
     }
 
     @Test


### PR DESCRIPTION
The rule "only a submitted sick note may be accepted" lived in the detail template, while the sibling actions keep their state rule in SickNotePermissions. The template therefore hid the accept button for a sick note that is not submitted, but the accept form was still on the page and reachable via ?action=allow - and the endpoint checked the role only, so accepting could set a cancelled or converted sick note back to ACTIVE.

isAllowedToAccept now takes the sick note and demands status SUBMITTED, and the endpoint uses it. Accepting an extension no longer delegates to it: an extension is handed in for a sick note that is already accepted, so it needs the same role but not the same state. The template gets a separate canAcceptSickNoteExtension flag instead of deriving the state itself.

closes #6577 

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
