### PR TITLE
A department head does not reject the application of their own second stage authority either

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissions.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissions.java
@@ -41,8 +41,8 @@ public final class ApplicationForLeavePermissions {
 
     /**
      * Whether the user may allow a waiting application. A boss decides about every application, including their own. A
-     * department head does not decide about the application of a person that is their own second stage authority,
-     * because that person decides about the department head. Depending on the department, a department head may allow it
+     * department head does not decide about the application of a person that is their own second stage authority, see
+     * {@link #isNotDecidingAboutTheirOwnApprover()}. Depending on the department, a department head may allow it
      * temporarily only, see {@link #isAllowedToAllowTemporarily()}.
      *
      * @return {@code true} if the user may allow the waiting application, {@code false} otherwise
@@ -51,7 +51,7 @@ public final class ApplicationForLeavePermissions {
         return application.hasStatus(WAITING)
             && (signedInUser.hasRole(BOSS)
             || (secondStageAuthorityOfPerson && isNotOwnApplication())
-            || (departmentHeadOfPerson && isNotOwnApplication() && !personIsSecondStageAuthorityOfSignedInUser));
+            || (departmentHeadOfPerson && isNotOwnApplication() && isNotDecidingAboutTheirOwnApprover()));
     }
 
     /**
@@ -79,14 +79,18 @@ public final class ApplicationForLeavePermissions {
     }
 
     /**
-     * Nobody rejects their own application, withdrawing it is revoking, see {@link #isAllowedToRevoke()}.
+     * Nobody rejects their own application, withdrawing it is revoking, see {@link #isAllowedToRevoke()}. Refusing an
+     * application is deciding about it just as granting it is, so a department head does not reject the application of
+     * their own second stage authority either, see {@link #isNotDecidingAboutTheirOwnApprover()}.
      *
      * @return {@code true} if the user may reject the application, {@code false} otherwise
      */
     public boolean isAllowedToReject() {
         return (application.hasStatus(WAITING) || application.hasStatus(TEMPORARY_ALLOWED))
             && isNotOwnApplication()
-            && (signedInUser.hasRole(BOSS) || isManagerOfPerson());
+            && (signedInUser.hasRole(BOSS)
+            || secondStageAuthorityOfPerson
+            || (departmentHeadOfPerson && isNotDecidingAboutTheirOwnApprover()));
     }
 
     /**
@@ -183,6 +187,19 @@ public final class ApplicationForLeavePermissions {
     private boolean isAllowedToAdminister(Role role) {
         return signedInUser.hasRole(OFFICE)
             || ((signedInUser.hasRole(BOSS) || isManagerOfPerson()) && signedInUser.hasRole(role));
+    }
+
+    /**
+     * Whether the person of the application is <em>not</em> the second stage authority that decides about the
+     * applications of the signed in user. A department head neither grants nor refuses the leave of their own
+     * approver.
+     *
+     * <p>The rule stops at deciding. A department head may still refer the application to somebody who can decide
+     * about it and say why, see {@link #isAllowedToRefer()} and {@link #isAllowedToComment()} - taking those away
+     * would leave them without a way to hand the application on.
+     */
+    private boolean isNotDecidingAboutTheirOwnApprover() {
+        return !personIsSecondStageAuthorityOfSignedInUser;
     }
 
     private boolean isManagerOfPerson() {

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissionEvaluatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissionEvaluatorTest.java
@@ -190,6 +190,41 @@ class ApplicationForLeavePermissionEvaluatorTest {
             assertThat(permissionsOnUnmanagedPerson(TEMPORARY_ALLOWED, BOSS).isAllowedToReject()).isTrue();
             assertThat(permissionsOnUnmanagedPerson(ALLOWED, BOSS).isAllowedToReject()).isFalse();
         }
+
+        @Test
+        void ensureDepartmentHeadMayNotRejectApplicationOfOwnSecondStageAuthority() {
+
+            final Person departmentHead = person(SIGNED_IN_USER_ID, DEPARTMENT_HEAD);
+            final Person secondStageAuthority = person(OTHER_PERSON_ID, SECOND_STAGE_AUTHORITY);
+
+            when(departmentService.isDepartmentHeadAllowedToManagePerson(departmentHead, secondStageAuthority)).thenReturn(true);
+            when(departmentService.isSecondStageAuthorityAllowedToManagePerson(departmentHead, secondStageAuthority)).thenReturn(false);
+            when(departmentService.isSecondStageAuthorityAllowedToManagePerson(secondStageAuthority, departmentHead)).thenReturn(true);
+
+            final ApplicationForLeavePermissions permissions = sut.of(departmentHead, application(secondStageAuthority, WAITING));
+
+            // refusing is deciding just as granting is
+            assertThat(permissions.isAllowedToReject()).isFalse();
+            assertThat(permissions.isAllowedToAllowWaiting()).isFalse();
+
+            // but the application can still be handed on to somebody who decides about it, with a reason
+            assertThat(permissions.isAllowedToRefer()).isTrue();
+            assertThat(permissions.isAllowedToComment()).isTrue();
+        }
+
+        @Test
+        void ensureSecondStageAuthorityOfThePersonMayRejectEvenIfThatPersonIsTheirOwnApprover() {
+
+            final Person signedInUser = person(SIGNED_IN_USER_ID, DEPARTMENT_HEAD, SECOND_STAGE_AUTHORITY);
+            final Person other = person(OTHER_PERSON_ID, SECOND_STAGE_AUTHORITY);
+
+            when(departmentService.isDepartmentHeadAllowedToManagePerson(signedInUser, other)).thenReturn(true);
+            when(departmentService.isSecondStageAuthorityAllowedToManagePerson(signedInUser, other)).thenReturn(true);
+            when(departmentService.isSecondStageAuthorityAllowedToManagePerson(other, signedInUser)).thenReturn(true);
+
+            // the rule holds back a department head, not somebody who is a second stage authority themselves
+            assertThat(sut.of(signedInUser, application(other, WAITING)).isAllowedToReject()).isTrue();
+        }
     }
 
     @Nested


### PR DESCRIPTION
Behebt #6580.

Die Regel, dass eine Abteilungsleitung nicht über den Antrag der Person entscheidet, die ihre eigene
Freigabe-Verantwortliche ist, saß nur auf dem Genehmigen. Ablehnen wurde nie gefragt.

Damit konnte eine Abteilungsleitung der eigenen Freigabe-Verantwortlichen den Urlaub **verweigern**,
aber nicht gewähren – und mit `APPLICATION_CANCEL` den Antrag nach der Genehmigung durch jemand
anderen wieder stornieren. Zwei Wege, den Urlaub zu nehmen, keiner, ihn zu geben.

Die Regel ist älter als sie aussieht. Vor 364f5dd63 (März 2022) stand dort

```java
// DEPARTMENT_HEAD can _not_ allow SECOND_STAGE_AUTHORITY
final boolean isSecondStageAuthorityApplication = application.getPerson().hasRole(SECOND_STAGE_AUTHORITY);
```

also jede Person mit der Rolle, in jeder Abteilung. Der Commit hat das auf die Freigabe-Verantwortliche
eingegrenzt, die tatsächlich für diese Abteilungsleitung zuständig ist – aber auf dem Genehmigen belassen.

## Änderung

Ablehnen ist Entscheiden genauso wie Genehmigen, also fragt `isAllowedToReject` dieselbe Frage. Beide
Regeln sind gleich geschrieben, damit man das sieht, und die Bedingung hat einen Namen:

```java
public boolean isAllowedToReject() {
    return (application.hasStatus(WAITING) || application.hasStatus(TEMPORARY_ALLOWED))
        && isNotOwnApplication()
        && (signedInUser.hasRole(BOSS)
        || secondStageAuthorityOfPerson
        || (departmentHeadOfPerson && isNotDecidingAboutTheirOwnApprover()));
}
```

Der mittlere Zweig ist wichtig: wer selbst Freigabe-Verantwortliche *dieser Person* ist, wird nicht
aufgehalten, auch wenn die Person umgekehrt die eigene Freigabe-Verantwortliche ist. Die Regel hält
eine Abteilungsleitung auf, keine gleichrangige Person.

## Bewusst nicht dabei

* **Weiterleiten und Kommentieren** bleiben offen. Nimmt man sie weg, hat die Abteilungsleitung keine
  Möglichkeit mehr, den Antrag an jemanden weiterzugeben, der entscheiden darf, und keine, zu sagen
  warum.
* **Stornieren** eines bereits genehmigten Antrags und das **Ablehnen eines Stornierungsantrags**
  bleiben wie sie sind. Eine Genehmigung rückgängig zu machen ist derselbe Interessenkonflikt wie
  eine zu verweigern, aber das ist eine eigene Regel mit eigenen Rollen – eigenes Issue wert, nicht
  hier mit hineingezogen.

## Was sich für Anwenderinnen und Anwender ändert

Eine Abteilungsleitung kann den Antrag der Person, die ihre eigene Freigabe-Verantwortliche ist, nicht
mehr ablehnen. Genehmigen konnte sie ihn noch nie: bis #6471 war der Button da und das Genehmigen
scheiterte mit „Du hast nicht die korrekten Berechtigungen um diesen Antrag zu genehmigen!\", seit
#6471 ist der Button weg. Weiterleiten und Kommentieren bleiben möglich.

## Tests

* `Reject.ensureDepartmentHeadMayNotRejectApplicationOfOwnSecondStageAuthority` – ablehnen und
  genehmigen beide `false`, weiterleiten und kommentieren beide `true`.
* `Reject.ensureSecondStageAuthorityOfThePersonMayRejectEvenIfThatPersonIsTheirOwnApprover` – der
  mittlere Zweig.
