### PR TITLE
ApplicationForLeavePermissions: an inactive application for leave is …

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissions.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissions.java
@@ -165,12 +165,17 @@ public final class ApplicationForLeavePermissions {
     }
 
     /**
+     * Whether the user may edit the application. Nobody edits an application that is not active any more, see
+     * {@link #isStillActive()} - a revoked, rejected or cancelled application cannot be reanimated, therefore changing
+     * its data would have no effect. Saying something about it is still possible, see {@link #isAllowedToComment()}.
+     *
      * @return {@code true} if the user may edit the application, {@code false} otherwise
      */
     public boolean isAllowedToEdit() {
-        return (application.hasStatus(WAITING) && isOwnApplication())
+        return isStillActive()
+            && ((application.hasStatus(WAITING) && isOwnApplication())
             || signedInUser.hasRole(OFFICE)
-            || (isManagerOfPerson() && signedInUser.hasRole(APPLICATION_EDIT));
+            || (isManagerOfPerson() && signedInUser.hasRole(APPLICATION_EDIT)));
     }
 
     /**
@@ -200,6 +205,14 @@ public final class ApplicationForLeavePermissions {
      */
     private boolean isNotDecidingAboutTheirOwnApprover() {
         return !personIsSecondStageAuthorityOfSignedInUser;
+    }
+
+    /**
+     * Whether the application still takes effect, which is the case for the
+     * {@link ApplicationStatus#activeStatuses() active statuses} only.
+     */
+    private boolean isStillActive() {
+        return ApplicationStatus.activeStatuses().stream().anyMatch(application::hasStatus);
     }
 
     private boolean isManagerOfPerson() {

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissionEvaluatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissionEvaluatorTest.java
@@ -311,6 +311,18 @@ class ApplicationForLeavePermissionEvaluatorTest {
         void ensureBossMayNotEditWithoutApplicationEditRole() {
             assertThat(permissionsOnUnmanagedPerson(ALLOWED, BOSS, APPLICATION_EDIT).isAllowedToEdit()).isFalse();
         }
+
+        @ParameterizedTest
+        @EnumSource(value = ApplicationStatus.class, names = {"REVOKED", "REJECTED", "CANCELLED"})
+        void ensureOfficeMayNotEditAnInactiveApplication(ApplicationStatus status) {
+            assertThat(permissionsOnUnmanagedPerson(status, OFFICE).isAllowedToEdit()).isFalse();
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = ApplicationStatus.class, names = {"REVOKED", "REJECTED", "CANCELLED"})
+        void ensureManagerMayNotEditAnInactiveApplication(ApplicationStatus status) {
+            assertThat(permissionsOnManagedPerson(status, DEPARTMENT_HEAD, APPLICATION_EDIT).isAllowedToEdit()).isFalse();
+        }
     }
 
     @Nested

--- a/src/test/java/org/synyx/urlaubsverwaltung/overview/OverviewViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overview/OverviewViewControllerTest.java
@@ -1304,7 +1304,9 @@ class OverviewViewControllerTest {
             departmentHead.setPermissions(List.of(USER, DEPARTMENT_HEAD, APPLICATION_EDIT));
 
             final Application first = application(TODAY.plusMonths(1), TODAY.plusMonths(1).plusDays(2));
+            first.setStatus(ALLOWED);
             final Application second = application(TODAY.plusMonths(2), TODAY.plusMonths(2).plusDays(2));
+            second.setStatus(ALLOWED);
 
             when(settingsService.getSettings()).thenReturn(new Settings());
             when(personService.getSignedInUser()).thenReturn(departmentHead);
@@ -1312,7 +1314,7 @@ class OverviewViewControllerTest {
             when(departmentService.isSignedInUserAllowedToAccessPersonData(departmentHead, person)).thenReturn(true);
             when(departmentService.getMembersForDepartmentHead(departmentHead)).thenReturn(List.of(person));
             when(applicationService.getApplicationsForACertainPeriodAndPerson(any(), any(), eq(person))).thenReturn(List.of(first, second));
-            stubWorkDaysCountForApplications(ONE);
+            stubWorkDaysCountForApplicationsWithUsedDaysSummary(ONE);
 
             final ModelAndView mav = perform(get("/web/person/1/overview")
                 .param("year", String.valueOf(TODAY.getYear()))


### PR DESCRIPTION
…not edited any more

A revoked, rejected or cancelled application cannot be reanimated, therefore changing its data has no effect. Editing is now bound to the active statuses, which takes the edit button off the details view, the application overview, the own applications and the person overview and lets the edit form and the edit request itself refuse. Commenting stays untouched, so the reason for a decision can still be given on the details view.

closes #5746

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
