### PR TITLE
Berechtigungen für Anträge und Krankmeldungen gehören in die Permissions

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewController.java
@@ -312,9 +312,7 @@ class ApplicationForLeaveDetailsViewController implements HasLaunchpad, HasPerso
                 "for leave of user '%s'", signedInUser.getId(), application.getPerson().getId()));
         }
 
-        // comment is mandatory if cancel for another user or cancellation request of own
-        final boolean isCommentMandatory = allowedToStartCancellationRequest || !signedInUser.equals(application.getPerson());
-        comment.setMandatory(isCommentMandatory);
+        comment.setMandatory(permissions.isCommentMandatoryToCancel());
 
         commentValidator.validate(comment, errors);
         if (errors.hasErrors()) {
@@ -493,6 +491,7 @@ class ApplicationForLeaveDetailsViewController implements HasLaunchpad, HasPerso
         model.addAttribute("isAllowedToCancelApplication", permissions.isAllowedToCancel());
         model.addAttribute("isAllowedToCancelDirectlyApplication", permissions.isAllowedToCancelDirectly());
         model.addAttribute("isAllowedToStartCancellationRequest", permissions.isAllowedToStartCancellationRequest());
+        model.addAttribute("isCommentMandatoryToCancelApplication", permissions.isCommentMandatoryToCancel());
 
         model.addAttribute("isAllowedToDeclineCancellationRequest", permissions.isAllowedToDeclineCancellationRequest());
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewController.java
@@ -177,7 +177,7 @@ class ApplicationForLeaveDetailsViewController implements HasLaunchpad, HasPerso
         final Person person = application.getPerson();
 
         final ApplicationForLeavePermissions permissions = permissionEvaluator.of(signedInUser, application);
-        if (!(permissions.isAllowedToAllowWaiting() || permissions.isAllowedToAllowTemporaryAllowed())) {
+        if (!permissions.isAllowedToAllowInAnyWay()) {
             throw new AccessDeniedException("User '%s' has not the correct permissions to allow application for leave of user '%s'".formatted(
                 signedInUser.getId(), person.getId()));
         }
@@ -480,6 +480,7 @@ class ApplicationForLeaveDetailsViewController implements HasLaunchpad, HasPerso
         model.addAttribute("isAllowedToAllowWaitingApplication", permissions.isAllowedToAllowWaiting());
         model.addAttribute("isAllowedToAllowTemporaryAllowedApplication", permissions.isAllowedToAllowTemporaryAllowed());
         model.addAttribute("isAllowedToAllowTemporarilyApplication", permissions.isAllowedToAllowTemporarily());
+        model.addAttribute("isAllowedToAllowApplicationInAnyWay", permissions.isAllowedToAllowInAnyWay());
 
         model.addAttribute("isAllowedToRejectApplication", permissions.isAllowedToReject());
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewController.java
@@ -303,11 +303,7 @@ class ApplicationForLeaveDetailsViewController implements HasLaunchpad, HasPerso
 
         final boolean requiresApprovalToCancel = application.getVacationType().isRequiresApprovalToCancel();
         final ApplicationForLeavePermissions permissions = permissionEvaluator.of(signedInUser, application);
-        final boolean allowedToRevokeApplication = permissions.isAllowedToRevoke();
-        final boolean allowedToCancelApplication = permissions.isAllowedToCancel();
-        final boolean allowedToCancelDirectlyApplication = permissions.isAllowedToCancelDirectly();
-        final boolean allowedToStartCancellationRequest = permissions.isAllowedToStartCancellationRequest();
-        if (!(allowedToRevokeApplication || allowedToCancelApplication || allowedToCancelDirectlyApplication || allowedToStartCancellationRequest)) {
+        if (!permissions.isAllowedToCancelInAnyWay()) {
             throw new AccessDeniedException(format("User '%s' has not the correct permissions to cancel or revoke application " +
                 "for leave of user '%s'", signedInUser.getId(), application.getPerson().getId()));
         }
@@ -487,9 +483,8 @@ class ApplicationForLeaveDetailsViewController implements HasLaunchpad, HasPerso
 
         model.addAttribute("isAllowedToRejectApplication", permissions.isAllowedToReject());
 
-        model.addAttribute("isAllowedToRevokeApplication", permissions.isAllowedToRevoke());
-        model.addAttribute("isAllowedToCancelApplication", permissions.isAllowedToCancel());
-        model.addAttribute("isAllowedToCancelDirectlyApplication", permissions.isAllowedToCancelDirectly());
+        model.addAttribute("isAllowedToCancelApplicationRightAway", permissions.isAllowedToCancelRightAway());
+        model.addAttribute("isAllowedToCancelApplicationInAnyWay", permissions.isAllowedToCancelInAnyWay());
         model.addAttribute("isAllowedToStartCancellationRequest", permissions.isAllowedToStartCancellationRequest());
         model.addAttribute("isCommentMandatoryToCancelApplication", permissions.isCommentMandatoryToCancel());
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewController.java
@@ -483,11 +483,10 @@ class ApplicationForLeaveDetailsViewController implements HasLaunchpad, HasPerso
 
         // Signed in person is allowed to manage
         final ApplicationForLeavePermissions permissions = permissionEvaluator.of(signedInUser, application);
-        final boolean isDepartmentHeadOfPerson = departmentService.isDepartmentHeadAllowedToManagePerson(signedInUser, application.getPerson());
-        final boolean isSecondStageAuthorityOfPerson = departmentService.isSecondStageAuthorityAllowedToManagePerson(signedInUser, application.getPerson());
 
         model.addAttribute("isAllowedToAllowWaitingApplication", permissions.isAllowedToAllowWaiting());
         model.addAttribute("isAllowedToAllowTemporaryAllowedApplication", permissions.isAllowedToAllowTemporaryAllowed());
+        model.addAttribute("isAllowedToAllowTemporarilyApplication", permissions.isAllowedToAllowTemporarily());
 
         model.addAttribute("isAllowedToRejectApplication", permissions.isAllowedToReject());
 
@@ -509,8 +508,6 @@ class ApplicationForLeaveDetailsViewController implements HasLaunchpad, HasPerso
         }
         model.addAttribute("isAllowedToCommentApplication", permissions.isAllowedToComment());
 
-        model.addAttribute("isDepartmentHeadOfPerson", isDepartmentHeadOfPerson);
-        model.addAttribute("isSecondStageAuthorityOfPerson", isSecondStageAuthorityOfPerson);
         model.addAttribute("isBoss", signedInUser.hasRole(BOSS));
         model.addAttribute("isOffice", signedInUser.hasRole(OFFICE));
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewController.java
@@ -63,7 +63,6 @@ import static org.synyx.urlaubsverwaltung.application.application.ApplicationSta
 import static org.synyx.urlaubsverwaltung.application.comment.ApplicationCommentAction.COMMENTED;
 import static org.synyx.urlaubsverwaltung.person.Role.BOSS;
 import static org.synyx.urlaubsverwaltung.person.Role.DEPARTMENT_HEAD;
-import static org.synyx.urlaubsverwaltung.person.Role.OFFICE;
 import static org.synyx.urlaubsverwaltung.person.Role.SECOND_STAGE_AUTHORITY;
 import static org.synyx.urlaubsverwaltung.security.SecurityRules.IS_BOSS_OR_DEPARTMENT_HEAD_OR_SECOND_STAGE_AUTHORITY;
 import static org.synyx.urlaubsverwaltung.security.SecurityRules.IS_PRIVILEGED_USER;
@@ -507,9 +506,6 @@ class ApplicationForLeaveDetailsViewController implements HasLaunchpad, HasPerso
             model.addAttribute("referredPerson", new ReferredPerson());
         }
         model.addAttribute("isAllowedToCommentApplication", permissions.isAllowedToComment());
-
-        model.addAttribute("isBoss", signedInUser.hasRole(BOSS));
-        model.addAttribute("isOffice", signedInUser.hasRole(OFFICE));
 
         // UNSPECIFIC ATTRIBUTES
         model.addAttribute("selectedYear", year);

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissions.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissions.java
@@ -157,6 +157,17 @@ public final class ApplicationForLeavePermissions {
     }
 
     /**
+     * Whether a comment has to be given to cancel the application. Cancelling the application of somebody else has to
+     * be explained, and so has asking for the cancellation of an own one - whoever decides about the request has to
+     * know what it is about. Cancelling an own application without asking anybody needs no comment.
+     *
+     * @return {@code true} if a comment is mandatory to cancel the application, {@code false} otherwise
+     */
+    public boolean isCommentMandatoryToCancel() {
+        return isAllowedToStartCancellationRequest() || isNotOwnApplication();
+    }
+
+    /**
      * @return {@code true} if the user may decline a cancellation request of the application, {@code false} otherwise
      */
     public boolean isAllowedToDeclineCancellationRequest() {

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissions.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissions.java
@@ -144,6 +144,17 @@ public final class ApplicationForLeavePermissions {
     }
 
     /**
+     * Whether the user may end the application right away, no matter how - by revoking it, by cancelling an allowed
+     * one or by cancelling it without asking anybody. The counterpart is
+     * {@link #isAllowedToStartCancellationRequest()}, which the user has to fall back to when this one does not hold.
+     *
+     * @return {@code true} if the user may cancel or revoke the application without asking, {@code false} otherwise
+     */
+    public boolean isAllowedToCancelRightAway() {
+        return isAllowedToRevoke() || isAllowedToCancel() || isAllowedToCancelDirectly();
+    }
+
+    /**
      * Whether the user may ask for the cancellation of an already allowed application. Only the person itself and the
      * management of that person may ask for it, and only if they may not cancel it right away.
      *
@@ -165,6 +176,17 @@ public final class ApplicationForLeavePermissions {
      */
     public boolean isCommentMandatoryToCancel() {
         return isAllowedToStartCancellationRequest() || isNotOwnApplication();
+    }
+
+    /**
+     * Whether the user may get rid of the application at all - either right away or by asking somebody to cancel it.
+     * Guards everything that leads to the cancellation of an application, the cancel form of the detail page as well
+     * as the delete buttons of the application lists.
+     *
+     * @return {@code true} if the user may cancel the application in any way, {@code false} otherwise
+     */
+    public boolean isAllowedToCancelInAnyWay() {
+        return isAllowedToCancelRightAway() || isAllowedToStartCancellationRequest();
     }
 
     /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissions.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissions.java
@@ -65,6 +65,17 @@ public final class ApplicationForLeavePermissions {
     }
 
     /**
+     * Whether the user may allow the application at all, no matter whether it is waiting or allowed temporarily
+     * already. Guards everything that leads to an allowed application, the allow form of the detail page as well as
+     * the approve buttons of the application lists.
+     *
+     * @return {@code true} if the user may allow the application in any way, {@code false} otherwise
+     */
+    public boolean isAllowedToAllowInAnyWay() {
+        return isAllowedToAllowWaiting() || isAllowedToAllowTemporaryAllowed();
+    }
+
+    /**
      * Whether allowing the application results in a temporary approval only, which is the case for a department head of
      * a department with two stage approval.
      *

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveViewController.java
@@ -133,9 +133,12 @@ class ApplicationForLeaveViewController implements HasLaunchpad, HasPersonSearch
         final Person signedInUser = personService.getSignedInUser();
         model.addAttribute("signedInUser", signedInUser);
 
+        final boolean canAccessOtherApplications = isAllowedToAccessOtherApplications(signedInUser);
+        final boolean canAccessSickNoteSubmissions = isAllowedToAccessSickNoteSubmissions(signedInUser);
         model.addAttribute("canAccessCancellationRequests", isAllowedToAccessCancellationRequest(signedInUser));
-        model.addAttribute("canAccessOtherApplications", isAllowedToAccessOtherApplications(signedInUser));
-        model.addAttribute("canAccessSickNoteSubmissions", isAllowedToAccessSickNoteSubmissions(signedInUser));
+        model.addAttribute("canAccessOtherApplications", canAccessOtherApplications);
+        model.addAttribute("canAccessSickNoteSubmissions", canAccessSickNoteSubmissions);
+        model.addAttribute("canAccessOtherAbsences", canAccessOtherApplications || canAccessSickNoteSubmissions);
 
         final List<Person> membersAsDepartmentHead = signedInUser.hasRole(DEPARTMENT_HEAD) ? departmentService.getMembersForDepartmentHead(signedInUser) : List.of();
         final List<Person> membersAsSecondStageAuthority = signedInUser.hasRole(SECOND_STAGE_AUTHORITY) ? departmentService.getMembersForSecondStageAuthority(signedInUser) : List.of();

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveViewController.java
@@ -266,9 +266,8 @@ class ApplicationForLeaveViewController implements HasLaunchpad, HasPersonSearch
 
         final boolean isAllowedToEdit = permissions.isAllowedToEdit();
         final boolean isAllowedToTemporaryApprove = permissions.isAllowedToAllowTemporarily();
-        final boolean isAllowedToApprove = permissions.isAllowedToAllowWaiting() || permissions.isAllowedToAllowTemporaryAllowed();
-        final boolean isAllowedToCancel = permissions.isAllowedToRevoke() || permissions.isAllowedToCancel()
-            || permissions.isAllowedToCancelDirectly() || permissions.isAllowedToStartCancellationRequest();
+        final boolean isAllowedToApprove = permissions.isAllowedToAllowInAnyWay();
+        final boolean isAllowedToCancel = permissions.isAllowedToCancelInAnyWay();
         final boolean isAllowedToReject = permissions.isAllowedToReject();
 
         return ApplicationForLeaveDto.builder()

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/me/ApplicationDto.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/me/ApplicationDto.java
@@ -40,6 +40,7 @@ public class ApplicationDto {
     private boolean allowedToCancel;
     private boolean allowedToCancelDirectly;
     private boolean allowedToStartCancellationRequest;
+    private boolean allowedToCancelInAnyWay;
 
     public Long getId() {
         return id;
@@ -241,6 +242,14 @@ public class ApplicationDto {
         this.allowedToStartCancellationRequest = allowedToStartCancellationRequest;
     }
 
+    public boolean isAllowedToCancelInAnyWay() {
+        return allowedToCancelInAnyWay;
+    }
+
+    public void setAllowedToCancelInAnyWay(boolean allowedToCancelInAnyWay) {
+        this.allowedToCancelInAnyWay = allowedToCancelInAnyWay;
+    }
+
     @Override
     public String toString() {
         return "ApplicationDto{" +
@@ -267,6 +276,7 @@ public class ApplicationDto {
             ", allowedToCancel=" + allowedToCancel +
             ", allowedToCancelDirectly=" + allowedToCancelDirectly +
             ", allowedToStartCancellationRequest=" + allowedToStartCancellationRequest +
+            ", allowedToCancelInAnyWay=" + allowedToCancelInAnyWay +
             '}';
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/me/ApplicationsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/me/ApplicationsViewController.java
@@ -188,6 +188,7 @@ public class ApplicationsViewController implements HasLaunchpad, HasPersonSearch
         final boolean allowedToCancel = permissions.isAllowedToCancel();
         final boolean allowedToCancelDirectly = permissions.isAllowedToCancelDirectly();
         final boolean allowedToStartCancellationRequest = permissions.isAllowedToStartCancellationRequest();
+        final boolean allowedToCancelInAnyWay = permissions.isAllowedToCancelInAnyWay();
 
         final ApplicationDto dto = new ApplicationDto();
         dto.setId(applicationForLeave.getId());
@@ -215,6 +216,7 @@ public class ApplicationsViewController implements HasLaunchpad, HasPersonSearch
         dto.setAllowedToCancel(allowedToCancel);
         dto.setAllowedToCancelDirectly(allowedToCancelDirectly);
         dto.setAllowedToStartCancellationRequest(allowedToStartCancellationRequest);
+        dto.setAllowedToCancelInAnyWay(allowedToCancelInAnyWay);
         return dto;
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/overview/ApplicationDto.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overview/ApplicationDto.java
@@ -37,6 +37,7 @@ record ApplicationDto(
     boolean allowedToRevoke,
     boolean allowedToCancel,
     boolean allowedToCancelDirectly,
-    boolean allowedToStartCancellationRequest
+    boolean allowedToStartCancellationRequest,
+    boolean allowedToCancelInAnyWay
 ) {
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/overview/OverviewViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overview/OverviewViewController.java
@@ -398,6 +398,7 @@ public class OverviewViewController implements HasLaunchpad, HasPersonSearch {
         final boolean allowedToCancel = permissions.isAllowedToCancel();
         final boolean allowedToCancelDirectly = permissions.isAllowedToCancelDirectly();
         final boolean allowedToStartCancellationRequest = permissions.isAllowedToStartCancellationRequest();
+        final boolean allowedToCancelInAnyWay = permissions.isAllowedToCancelInAnyWay();
 
         return new ApplicationDto(
             applicationForLeave.getId(),
@@ -424,7 +425,8 @@ public class OverviewViewController implements HasLaunchpad, HasPersonSearch {
             allowedToRevoke,
             allowedToCancel,
             allowedToCancelDirectly,
-            allowedToStartCancellationRequest
+            allowedToStartCancellationRequest,
+            allowedToCancelInAnyWay
         );
     }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewController.java
@@ -193,8 +193,11 @@ class SickNoteViewController implements HasLaunchpad, HasPersonSearch {
             final List<SickNoteCommentEntity> comments = sickNoteCommentService.getCommentsBySickNote(sickNote);
             model.addAttribute("comments", comments);
 
-            model.addAttribute("canAcceptSickNote", permissions.isAllowedToAccept(sickNote));
-            model.addAttribute("canAcceptSickNoteExtension", submittedExtension.isPresent() && permissions.isAllowedToAcceptExtension());
+            final boolean canAcceptSickNote = permissions.isAllowedToAccept(sickNote);
+            final boolean canAcceptSickNoteExtension = submittedExtension.isPresent() && permissions.isAllowedToAcceptExtension();
+            model.addAttribute("canAcceptSickNote", canAcceptSickNote);
+            model.addAttribute("canAcceptSickNoteExtension", canAcceptSickNoteExtension);
+            model.addAttribute("canAcceptSickNoteOrExtension", canAcceptSickNote || canAcceptSickNoteExtension);
             model.addAttribute("canEditSickNote", permissions.isAllowedToEdit(sickNote));
             model.addAttribute("canConvertSickNote", permissions.isAllowedToConvert(sickNote));
             model.addAttribute("canDeleteSickNote", permissions.isAllowedToCancel(sickNote));

--- a/src/main/resources/templates/application/app-sections/action-allow.html
+++ b/src/main/resources/templates/application/app-sections/action-allow.html
@@ -24,7 +24,7 @@
 
       <button
         th:if="${isAllowedToAllowWaitingApplication}"
-        th:with="messageKey=${isDepartmentHeadOfPerson && !isSecondStageAuthorityOfPerson && app.twoStageApproval ? 'action.temporary_allow' : 'action.allow'}"
+        th:with="messageKey=${isAllowedToAllowTemporarilyApplication ? 'action.temporary_allow' : 'action.allow'}"
         class="icon-link bg-transparent hover:text-emerald-500"
         onclick="
           document.querySelector('#reject')?.classList.add('hidden');
@@ -46,7 +46,7 @@
         class="alert alert-success"
         th:classappend="${action eq 'allow' ? '' : 'hidden'}"
         method="post"
-        th:with="temporary=${isDepartmentHeadOfPerson && !isSecondStageAuthorityOfPerson && app.twoStageApproval && app.status.name == 'WAITING'}"
+        th:with="temporary=${isAllowedToAllowTemporarilyApplication}"
         th:action="@{/web/application/{applicationId}/allow(applicationId=${app.id}, redirect=${redirect})}"
         th:object="${comment}"
       >

--- a/src/main/resources/templates/application/app-sections/action-cancel.html
+++ b/src/main/resources/templates/application/app-sections/action-cancel.html
@@ -7,7 +7,7 @@
   <body>
     <th:block th:fragment="buttons">
       <button
-        th:if="${isAllowedToRevokeApplication || isAllowedToCancelApplication || isAllowedToCancelDirectlyApplication}"
+        th:if="${isAllowedToCancelApplicationRightAway}"
         class="icon-link bg-transparent hover:text-red-500"
         onclick="
           document.querySelector('#reject')?.classList.add('hidden');

--- a/src/main/resources/templates/application/app-sections/action-cancel.html
+++ b/src/main/resources/templates/application/app-sections/action-cancel.html
@@ -45,7 +45,7 @@
         class="alert alert-danger"
         th:classappend="${action eq 'cancel' ? '' : 'hidden'}"
         method="post"
-        th:with="deleteRequest=${app.vacationType.requiresApprovalToCancel == true && (app.status.name == 'ALLOWED' || app.status.name == 'TEMPORARY_ALLOWED') && !isOffice && !signedInUser.hasRole('APPLICATION_CANCEL')}"
+        th:with="deleteRequest=${isAllowedToStartCancellationRequest}"
         th:action="@{/web/application/{applicationId}/cancel(applicationId=${app.id}, redirect=${redirect})}"
         th:object="${comment}"
       >

--- a/src/main/resources/templates/application/app-sections/action-cancel.html
+++ b/src/main/resources/templates/application/app-sections/action-cancel.html
@@ -60,7 +60,7 @@
 
         <div class="mb-4">
           <label
-            th:with="commentMandatory=${app.person.id != signedInUser.id || app.status.name == 'ALLOWED' || app.status.name == 'TEMPORARY_ALLOWED' || app.status.name == 'ALLOWED_CANCELLATION_REQUESTED'}"
+            th:with="commentMandatory=${isCommentMandatoryToCancelApplication}"
             th:text="|${commentMandatory == true ? #messages.msg('action.comment.mandatory') : #messages.msg('action.comment.optional')}:|"
             for="text-cancel"
             >Kommentar, optional</label

--- a/src/main/resources/templates/application/app-sections/action-decline-cancellation-request.html
+++ b/src/main/resources/templates/application/app-sections/action-decline-cancellation-request.html
@@ -37,11 +37,7 @@
         </div>
 
         <div class="mb-4">
-          <label
-            th:with="commentMandatory=${app.status.name == 'ALLOWED_CANCELLATION_REQUESTED'}"
-            th:text="|${commentMandatory == true ? #messages.msg('action.comment.mandatory') : #messages.msg('action.comment.optional')}:|"
-            for="text-decline-cancellation-request"
-          ></label>
+          <label th:text="|#{action.comment.mandatory}:|" for="text-decline-cancellation-request"></label>
           <textarea id="text-decline-cancellation-request" rows="2" name="text" th:errorclass="error"></textarea>
         </div>
 

--- a/src/main/resources/templates/application/application-detail.html
+++ b/src/main/resources/templates/application/application-detail.html
@@ -109,7 +109,7 @@
           ></th:block>
 
           <th:block
-            th:if="${isAllowedToRevokeApplication || isAllowedToCancelApplication || isAllowedToCancelDirectlyApplication || isAllowedToStartCancellationRequest}"
+            th:if="${isAllowedToCancelApplicationInAnyWay}"
             th:replace="~{application/app-sections/action-cancel::form}"
           ></th:block>
 

--- a/src/main/resources/templates/application/application-detail.html
+++ b/src/main/resources/templates/application/application-detail.html
@@ -94,7 +94,7 @@
           ></th:block>
 
           <th:block
-            th:if="${isAllowedToAllowWaitingApplication || isAllowedToAllowTemporaryAllowedApplication}"
+            th:if="${isAllowedToAllowApplicationInAnyWay}"
             th:replace="~{application/app-sections/action-allow::form}"
           ></th:block>
 

--- a/src/main/resources/templates/application/application-overview.html
+++ b/src/main/resources/templates/application/application-overview.html
@@ -318,7 +318,7 @@
         </div>
       </div>
 
-      <th:block th:if="${canAccessOtherApplications || canAccessSickNoteSubmissions}">
+      <th:block th:if="${canAccessOtherAbsences}">
         <div
           th:replace="~{fragments/section-heading::section-heading-paddingless(~{::new-other-applications-heading-body}, ~{})}"
         >

--- a/src/main/resources/templates/me/applications.html
+++ b/src/main/resources/templates/me/applications.html
@@ -244,7 +244,7 @@
                     <a
                       class="button flex-1 justify-center"
                       th:href="@{/web/application/{app} (app=${app.id}, action='cancel', redirect=|/web/persons/${person.id}/applications?year=${selectedYear}|)}"
-                      th:if="${app.allowedToRevoke || app.allowedToCancel || app.allowedToCancelDirectly || app.allowedToStartCancellationRequest}"
+                      th:if="${app.allowedToCancelInAnyWay}"
                     >
                       <svg th:replace="~{icon/trash-2::svg(className='w-4 h-4 shrink-0')}"></svg>
                       <span

--- a/src/main/resources/templates/person/overview/section-application.html
+++ b/src/main/resources/templates/person/overview/section-application.html
@@ -206,7 +206,7 @@
               <div class="opacity-100! flex items-center justify-end">
                 <span data-grid-ref="action-buttons" class="flex flex-row gap-1">
                   <a
-                    th:if="${app.allowedToRevoke || app.allowedToCancel || app.allowedToCancelDirectly || app.allowedToStartCancellationRequest}"
+                    th:if="${app.allowedToCancelInAnyWay}"
                     class="button flex-1 justify-center"
                     th:href="@{/web/application/{app} (app=${app.id}, action='cancel', redirect=|/web/person/${person.id}/overview?year=${selectedYear}|)}"
                   >

--- a/src/main/resources/templates/sicknote/sick_note_detail.html
+++ b/src/main/resources/templates/sicknote/sick_note_detail.html
@@ -38,7 +38,7 @@
           </th:block>
           <th:block th:ref="sicknote-heading-actions">
             <div class="flex flex-row gap-2">
-              <th:block th:if="${canAcceptSickNote || canAcceptSickNoteExtension}">
+              <th:block th:if="${canAcceptSickNoteOrExtension}">
                 <button
                   type="button"
                   class="icon-link bg-transparent"
@@ -104,7 +104,7 @@
         </th:block>
 
         <div class="actions" th:with="redirectTo=${redirect}">
-          <th:block th:if="${canAcceptSickNote || canAcceptSickNoteExtension}">
+          <th:block th:if="${canAcceptSickNoteOrExtension}">
             <form
               id="allow"
               class="alert alert-success"

--- a/src/main/resources/templates/sicknote/sick_note_detail.html
+++ b/src/main/resources/templates/sicknote/sick_note_detail.html
@@ -285,12 +285,12 @@
               <h2 th:text="#{sicknote.extend.submitted.extension-title}">Krankmeldung verlängern</h2>
             </div>
           </div>
-          <th:block th:if="${#bools.isTrue(canAcceptSubmittedExtension)}">
+          <th:block th:if="${canAcceptSickNoteExtension}">
             <p class="mt-4" th:text="#{sicknote.extend.submitted.wants-to-extend.hint(${sickNote.person.niceName})}">
               Max Muster möchte die Krankmeldung erweitern.
             </p>
           </th:block>
-          <th:block th:if="${#bools.isFalse(canAcceptSubmittedExtension)}">
+          <th:block th:unless="${canAcceptSickNoteExtension}">
             <p class="mt-4" th:text="#{sicknote.extend.submitted.has-to-be-accepted.hint}">
               Eine berechtigte Person muss die geänderte Krankmeldung akzeptieren.
             </p>

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewControllerTest.java
@@ -277,69 +277,34 @@ class ApplicationForLeaveDetailsViewControllerTest {
     }
 
     @Test
-    void showApplicationDetailSignedInUserIsBoss() throws Exception {
+    void showApplicationDetailPersonIsAllowedToStartCancellationRequestOfOwnAllowedApplication() throws Exception {
 
         final Locale locale = GERMAN;
         final MessageSource messageSource = messageSourceForVacationType("message-key", "label", locale);
         final VacationType<?> vacationType = ProvidedVacationType.builder(messageSource)
+            .id(1L)
             .messageKey("message-key")
             .requiresApprovalToApply(true)
             .requiresApprovalToCancel(true)
             .category(HOLIDAY)
             .build();
 
-        final Person person = new Person();
+        final Person person = new Person("user", "user", "user", "user@example.org");
         person.setId(1L);
+        person.setPermissions(List.of(USER));
 
         final Application application = applicationOfPerson(person, vacationType);
+        application.setStatus(ApplicationStatus.ALLOWED);
 
         when(commentService.getCommentsByApplication(any())).thenReturn(List.of(anyApplicationComment()));
         when(applicationService.getApplicationById(APPLICATION_ID)).thenReturn(Optional.of(application));
         when(departmentService.isSignedInUserAllowedToAccessPersonData(any(), any())).thenReturn(true);
+        when(personService.getSignedInUser()).thenReturn(person);
 
-        final Person boss = new Person("boss", "boss", "boss", "boss@example.org");
-        boss.setPermissions(List.of(USER, BOSS));
-        when(personService.getSignedInUser()).thenReturn(boss);
-
-        perform(
-            get("/web/application/" + APPLICATION_ID)
-                .locale(locale)
-        )
+        perform(get("/web/application/" + APPLICATION_ID).locale(locale))
             .andExpect(view().name("application/application-detail"))
-            .andExpect(model().attribute("isBoss", true));
-    }
-
-    @Test
-    void showApplicationDetailSignedInUserIsOffice() throws Exception {
-
-        final Locale locale = GERMAN;
-        final MessageSource messageSource = messageSourceForVacationType("message-key", "label", locale);
-        final VacationType<?> vacationType = ProvidedVacationType.builder(messageSource)
-            .messageKey("message-key")
-            .requiresApprovalToApply(true)
-            .requiresApprovalToCancel(true)
-            .category(HOLIDAY)
-            .build();
-
-        final Person person = new Person();
-        person.setId(1L);
-
-        final Application application = applicationOfPerson(person, vacationType);
-
-        when(commentService.getCommentsByApplication(any())).thenReturn(List.of(anyApplicationComment()));
-        when(applicationService.getApplicationById(APPLICATION_ID)).thenReturn(Optional.of(application));
-        when(departmentService.isSignedInUserAllowedToAccessPersonData(any(), any())).thenReturn(true);
-
-        final Person office = new Person("office", "office", "office", "office@example.org");
-        office.setPermissions(List.of(USER, OFFICE));
-        when(personService.getSignedInUser()).thenReturn(office);
-
-        perform(
-            get("/web/application/" + APPLICATION_ID)
-                .locale(locale)
-        )
-            .andExpect(view().name("application/application-detail"))
-            .andExpect(model().attribute("isOffice", true));
+            .andExpect(model().attribute("isAllowedToStartCancellationRequest", true))
+            .andExpect(model().attribute("isAllowedToCancelApplication", false));
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewControllerTest.java
@@ -343,71 +343,71 @@ class ApplicationForLeaveDetailsViewControllerTest {
     }
 
     @Test
-    void showApplicationDetailSignedInUserIsDepartmentHeadOfPerson() throws Exception {
+    void showApplicationDetailDepartmentHeadOfPersonIsAllowedToAllowTemporarily() throws Exception {
+
+        final Person person = new Person();
+        person.setId(1L);
 
         final Locale locale = GERMAN;
         final MessageSource messageSource = messageSourceForVacationType("message-key", "label", locale);
         final VacationType<?> vacationType = ProvidedVacationType.builder(messageSource)
+            .id(1L)
             .messageKey("message-key")
             .requiresApprovalToApply(true)
             .requiresApprovalToCancel(true)
             .category(HOLIDAY)
             .build();
 
-        final Person person = new Person();
-        person.setId(1L);
-
         final Application application = applicationOfPerson(person, vacationType);
+        application.setTwoStageApproval(true);
 
         when(commentService.getCommentsByApplication(any())).thenReturn(List.of(anyApplicationComment()));
         when(applicationService.getApplicationById(APPLICATION_ID)).thenReturn(Optional.of(application));
         when(departmentService.isSignedInUserAllowedToAccessPersonData(any(), any())).thenReturn(true);
 
         final Person departmentHead = new Person("departmentHead", "departmentHead", "departmentHead", "departmentHead@example.org");
+        departmentHead.setId(2L);
         departmentHead.setPermissions(List.of(USER, DEPARTMENT_HEAD));
         when(personService.getSignedInUser()).thenReturn(departmentHead);
-        when(departmentService.isDepartmentHeadAllowedToManagePerson(eq(departmentHead), any(Person.class))).thenReturn(true);
+        when(departmentService.isDepartmentHeadAllowedToManagePerson(departmentHead, person)).thenReturn(true);
 
-        perform(
-            get("/web/application/" + APPLICATION_ID)
-                .locale(locale)
-        )
+        perform(get("/web/application/" + APPLICATION_ID).locale(locale))
             .andExpect(view().name("application/application-detail"))
-            .andExpect(model().attribute("isDepartmentHeadOfPerson", true));
+            .andExpect(model().attribute("isAllowedToAllowTemporarilyApplication", true));
     }
 
     @Test
-    void showApplicationDetailSignedInUserIsSecondStageAuthorityOfPerson() throws Exception {
+    void showApplicationDetailBossIsNotAllowedToAllowTemporarilyAlthoughDepartmentHeadOfPerson() throws Exception {
+
+        final Person person = new Person();
+        person.setId(1L);
 
         final Locale locale = GERMAN;
         final MessageSource messageSource = messageSourceForVacationType("message-key", "label", locale);
         final VacationType<?> vacationType = ProvidedVacationType.builder(messageSource)
+            .id(1L)
             .messageKey("message-key")
             .requiresApprovalToApply(true)
             .requiresApprovalToCancel(true)
             .category(HOLIDAY)
             .build();
 
-        final Person person = new Person();
-        person.setId(1L);
-
         final Application application = applicationOfPerson(person, vacationType);
+        application.setTwoStageApproval(true);
 
         when(commentService.getCommentsByApplication(any())).thenReturn(List.of(anyApplicationComment()));
         when(applicationService.getApplicationById(APPLICATION_ID)).thenReturn(Optional.of(application));
         when(departmentService.isSignedInUserAllowedToAccessPersonData(any(), any())).thenReturn(true);
 
-        final Person ssa = new Person("ssa", "ssa", "ssa", "ssa@example.org");
-        ssa.setPermissions(List.of(USER, DEPARTMENT_HEAD));
-        when(personService.getSignedInUser()).thenReturn(ssa);
-        when(departmentService.isSecondStageAuthorityAllowedToManagePerson(eq(ssa), any(Person.class))).thenReturn(true);
+        final Person boss = new Person("boss", "boss", "boss", "boss@example.org");
+        boss.setId(2L);
+        boss.setPermissions(List.of(USER, BOSS, DEPARTMENT_HEAD));
+        when(personService.getSignedInUser()).thenReturn(boss);
+        when(departmentService.isDepartmentHeadAllowedToManagePerson(boss, person)).thenReturn(true);
 
-        perform(
-            get("/web/application/" + APPLICATION_ID)
-                .locale(locale)
-        )
+        perform(get("/web/application/" + APPLICATION_ID).locale(locale))
             .andExpect(view().name("application/application-detail"))
-            .andExpect(model().attribute("isSecondStageAuthorityOfPerson", true));
+            .andExpect(model().attribute("isAllowedToAllowTemporarilyApplication", false));
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeaveDetailsViewControllerTest.java
@@ -304,7 +304,8 @@ class ApplicationForLeaveDetailsViewControllerTest {
         perform(get("/web/application/" + APPLICATION_ID).locale(locale))
             .andExpect(view().name("application/application-detail"))
             .andExpect(model().attribute("isAllowedToStartCancellationRequest", true))
-            .andExpect(model().attribute("isAllowedToCancelApplication", false));
+            .andExpect(model().attribute("isAllowedToCancelApplicationRightAway", false))
+            .andExpect(model().attribute("isAllowedToCancelApplicationInAnyWay", true));
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissionEvaluatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissionEvaluatorTest.java
@@ -161,6 +161,30 @@ class ApplicationForLeavePermissionEvaluatorTest {
     }
 
     @Nested
+    class AllowInAnyWay {
+
+        @Test
+        void ensureManagerMayAllowAWaitingApplication() {
+            assertThat(permissionsOnManagedPerson(WAITING, SECOND_STAGE_AUTHORITY).isAllowedToAllowInAnyWay()).isTrue();
+        }
+
+        @Test
+        void ensureManagerMayAllowATemporaryAllowedApplication() {
+            assertThat(permissionsOnManagedPerson(TEMPORARY_ALLOWED, SECOND_STAGE_AUTHORITY).isAllowedToAllowInAnyWay()).isTrue();
+        }
+
+        @Test
+        void ensureNobodyAllowsAnAlreadyAllowedApplication() {
+            assertThat(permissionsOnManagedPerson(ALLOWED, SECOND_STAGE_AUTHORITY).isAllowedToAllowInAnyWay()).isFalse();
+        }
+
+        @Test
+        void ensureUnrelatedUserMayNotAllow() {
+            assertThat(permissionsOnUnmanagedPerson(WAITING, USER).isAllowedToAllowInAnyWay()).isFalse();
+        }
+    }
+
+    @Nested
     class Reject {
 
         @ParameterizedTest

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissionEvaluatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissionEvaluatorTest.java
@@ -407,6 +407,29 @@ class ApplicationForLeavePermissionEvaluatorTest {
     }
 
     @Nested
+    class CommentMandatoryToCancel {
+
+        @Test
+        void ensureNoCommentIsNeededToCancelAnOwnApplicationDirectly() {
+            final Person person = person(SIGNED_IN_USER_ID, USER);
+            assertThat(sut.of(person, application(person, ALLOWED)).isCommentMandatoryToCancel()).isFalse();
+        }
+
+        @Test
+        void ensureCommentIsNeededToRequestCancellationOfAnOwnApplication() {
+            final Person person = person(SIGNED_IN_USER_ID, USER);
+            assertThat(sut.of(person, applicationRequiringApprovalToCancel(person, ALLOWED)).isCommentMandatoryToCancel()).isTrue();
+        }
+
+        @Test
+        void ensureCommentIsNeededToCancelTheApplicationOfSomebodyElse() {
+            final Person office = person(SIGNED_IN_USER_ID, OFFICE);
+            final Application application = applicationRequiringApprovalToCancel(person(OTHER_PERSON_ID, USER), ALLOWED);
+            assertThat(sut.of(office, application).isCommentMandatoryToCancel()).isTrue();
+        }
+    }
+
+    @Nested
     class DeclineCancellationRequest {
 
         @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissionEvaluatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissionEvaluatorTest.java
@@ -407,6 +407,36 @@ class ApplicationForLeavePermissionEvaluatorTest {
     }
 
     @Nested
+    class CancelInAnyWay {
+
+        @Test
+        void ensurePersonMayCancelOwnWaitingApplicationRightAway() {
+            final Person person = person(SIGNED_IN_USER_ID, USER);
+            final ApplicationForLeavePermissions permissions = sut.of(person, applicationRequiringApprovalToCancel(person, WAITING));
+            assertThat(permissions.isAllowedToCancelRightAway()).isTrue();
+            assertThat(permissions.isAllowedToCancelInAnyWay()).isTrue();
+        }
+
+        @Test
+        void ensurePersonAskingForCancellationMayNotCancelRightAway() {
+            final Person person = person(SIGNED_IN_USER_ID, USER);
+            final ApplicationForLeavePermissions permissions = sut.of(person, applicationRequiringApprovalToCancel(person, ALLOWED));
+            assertThat(permissions.isAllowedToCancelRightAway()).isFalse();
+            assertThat(permissions.isAllowedToCancelInAnyWay()).isTrue();
+        }
+
+        @Test
+        void ensureUnrelatedUserMayNotCancelAtAll() {
+            final Person signedInUser = person(SIGNED_IN_USER_ID, USER);
+            final Application application = applicationRequiringApprovalToCancel(person(OTHER_PERSON_ID, USER), ALLOWED);
+
+            final ApplicationForLeavePermissions permissions = sut.of(signedInUser, application);
+            assertThat(permissions.isAllowedToCancelRightAway()).isFalse();
+            assertThat(permissions.isAllowedToCancelInAnyWay()).isFalse();
+        }
+    }
+
+    @Nested
     class CommentMandatoryToCancel {
 
         @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissionEvaluatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/application/ApplicationForLeavePermissionEvaluatorTest.java
@@ -150,6 +150,24 @@ class ApplicationForLeavePermissionEvaluatorTest {
         }
 
         @Test
+        void ensureNothingIsAllowedTemporarilyButAWaitingApplication() {
+
+            final Person departmentHead = person(SIGNED_IN_USER_ID, DEPARTMENT_HEAD);
+            final Person member = person(OTHER_PERSON_ID, USER);
+            when(departmentService.isDepartmentHeadAllowedToManagePerson(departmentHead, member)).thenReturn(true);
+
+            // the temporary approval is the first of two stages - there is nothing to approve temporarily about an
+            // application that is not waiting for its first approval any more
+            for (ApplicationStatus status : List.of(TEMPORARY_ALLOWED, ALLOWED, ALLOWED_CANCELLATION_REQUESTED, REJECTED)) {
+                final Application application = application(member, status);
+                application.setTwoStageApproval(true);
+                assertThat(sut.of(departmentHead, application).isAllowedToAllowTemporarily())
+                    .describedAs("status %s", status)
+                    .isFalse();
+            }
+        }
+
+        @Test
         void ensureBossNeverAllowsTemporarilyOnly() {
 
             final Person boss = person(SIGNED_IN_USER_ID, BOSS);

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewControllerTest.java
@@ -962,7 +962,8 @@ class SickNoteViewControllerTest {
         perform(get("/web/sicknote/15"))
             .andExpect(status().isOk())
             .andExpect(model().attribute("canAcceptSickNote", false))
-            .andExpect(model().attribute("canAcceptSickNoteExtension", false));
+            .andExpect(model().attribute("canAcceptSickNoteExtension", false))
+            .andExpect(model().attribute("canAcceptSickNoteOrExtension", false));
     }
 
     @Test
@@ -994,7 +995,8 @@ class SickNoteViewControllerTest {
             .andExpect(status().isOk())
             .andExpect(model().attribute("extensionRequested", true))
             .andExpect(model().attribute("canAcceptSickNote", false))
-            .andExpect(model().attribute("canAcceptSickNoteExtension", true));
+            .andExpect(model().attribute("canAcceptSickNoteExtension", true))
+            .andExpect(model().attribute("canAcceptSickNoteOrExtension", true));
     }
 
     @Test


### PR DESCRIPTION
Berechtigungen für Anträge und Krankmeldungen werden von `ApplicationForLeavePermissions` und `SickNotePermissions` beantwortet – an einigen Stellen leiteten die Templates sie jedoch selbst her. Diese Regeln wandern zurück in die Permissions, ein Commit pro Fall.

closes #6583
closes #6584
closes #6585

## Regeln, die das Template selbst hergeleitet hat (#6584)

* **Vorläufig genehmigen** – `action-allow.html` baute `isAllowedToAllowTemporarily` aus Abteilungszugehörigkeit und `twoStageApproval` nach, ohne dessen `!hasRole(BOSS)`. Ein BOSS, der zugleich Abteilungsleitung ist, bekam in einer Abteilung mit zweistufiger Genehmigung "vorläufig genehmigen" angeboten, während der Antrag endgültig genehmigt wurde.
* **Löschen oder Löschung anfragen** – `action-cancel.html` baute `isAllowedToStartCancellationRequest` aus Status und Rollen nach, kannte den Status `ALLOWED_CANCELLATION_REQUESTED` nicht und ließ die blanke Rolle `APPLICATION_CANCEL` zum Stornieren genügen. Das war zugleich die einzige Stelle, an der ein Template eine Rolle der angemeldeten Person selbst abfragte.
* **Kommentarpflicht beim Stornieren** – Label und POST-Handler entschieden nach verschiedenen Regeln; beim eigenen genehmigten Antrag einer Abwesenheitsart ohne Genehmigungspflicht zum Stornieren war der Kommentar als Pflichtfeld beschriftet und als optional validiert. Neu: `ApplicationForLeavePermissions#isCommentMandatoryToCancel`, den beide fragen.
* **Kommentarpflicht beim Ablehnen einer Stornierungsanfrage** – fest als Pflichtfeld ausgezeichnet, wie der Handler es validiert.

Damit braucht kein Template mehr `isDepartmentHeadOfPerson`, `isSecondStageAuthorityOfPerson`, `isBoss` oder `isOffice`; die vier Attribute sind aus dem Model verschwunden.

## Hinweis zur Verlängerung einer Krankmeldung (#6583)

`sick_note_detail.html` verzweigte über `canAcceptSubmittedExtension`, ein Attribut, das kein Controller ins Model legt. `#bools.isTrue(null)` ist `false` und `#bools.isFalse(null)` ist `true`, also erschien der Hinweis "möchte die Krankmeldung erweitern" nie und "eine berechtigte Person muss die Verlängerung annehmen" immer – auch für die Person, die sie annehmen darf. Abgefragt wird jetzt `canAcceptSickNoteExtension`, das direkt darunter schon das Annahme-Formular steuert.

## Zusammengesetzte Fragen (#6585)

Neu in `ApplicationForLeavePermissions`: `isAllowedToCancelRightAway` (widerrufen, stornieren, direkt stornieren) und `isAllowedToCancelInAnyWay` (zusätzlich die Stornierungsanfrage) sowie `isAllowedToAllowInAnyWay`. Sie ersetzen dieselbe Oder-Verknüpfung in der Detailseite, im Storno-Abschnitt, in beiden Antragslisten, in den POST-Guards und in der Dto-Abbildung der Antragsübersicht. Für die Krankmeldung beantwortet der `SickNoteViewController`, ob Krankmeldung oder Verlängerung angenommen werden dürfen, für die Tab-Leiste der Antragsübersicht der `ApplicationForLeaveViewController`.

Die Listen tragen die Antwort als `allowedToCancelInAnyWay` in ihrem Dto. Die vier Einzelflags sind dort bewusst geblieben, weil die Controller-Tests sie einzeln prüfen.

## Tests

* `ApplicationForLeavePermissionEvaluatorTest` um `AllowInAnyWay`, `CancelInAnyWay` und `CommentMandatoryToCancel` ergänzt
* `ApplicationForLeaveDetailsViewControllerTest`: die Tests auf die reinen Fakten (`isBoss`, `isOffice`, `isDepartmentHeadOfPerson`, `isSecondStageAuthorityOfPerson`) sind durch Tests auf die Berechtigungen ersetzt, inklusive des BOSS-als-Abteilungsleitung-Falls
* `SickNoteViewControllerTest` prüft `canAcceptSickNoteOrExtension` mit
* Unit-Tests grün (5212), `ApplicationForLeaveUIIT` (6) und `SickNoteUIIT` (2) grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)
