### PR TITLE
Load print.css on every page again

### DIFF
--- a/src/main/css/bundles/print.css
+++ b/src/main/css/bundles/print.css
@@ -101,6 +101,15 @@
     overflow: visible !important;
   }
 
+  /* on top of that body is the app shell's grid (topbar cells, navigation and
+     content in their own grid areas) - Firefox does not fragment a grid
+     container across pages, it pushes the whole content row to the next page
+     and leaves the first one blank. The chrome around the content is hidden
+     for print anyway, so plain block layout is all that is left to do. */
+  body {
+    display: block !important;
+  }
+
   #main {
     overflow: visible !important;
     margin-top: 0 !important;

--- a/src/main/resources/templates/_layout.html
+++ b/src/main/resources/templates/_layout.html
@@ -105,6 +105,7 @@
     <meta name="msapplication-TileColor" content="#5bbad5" />
     <meta name="theme-color" content="#ffffff" />
 
+    <link rel="stylesheet" type="text/css" th:href="@{/css/print.css}" media="print" />
     <link rel="stylesheet" type="text/css" th:href="@{/css/common.css}" />
     <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}" />
     <th:block th:replace="${styles}"></th:block>

--- a/src/main/resources/templates/absences/absences-overview.html
+++ b/src/main/resources/templates/absences/absences-overview.html
@@ -12,7 +12,6 @@
   >
     <title th:replace="~{fragments/page-title::page-title(#{absences.overview.header.title})}"></title>
     <th:block th:fragment="styles">
-      <link rel="stylesheet" type="text/css" th:href="@{/css/print.css}" media="print" />
       <link rel="stylesheet" type="text/css" th:href="@{/css/absences-overview.css}" />
     </th:block>
     <th:block th:fragment="preload">


### PR DESCRIPTION
The print stylesheet was only linked from the absences overview, so every other page printed with the app shell intact: body is fixed to one viewport (height: 100vh; overflow: hidden) with #main as the only scroll container, and the navigation, info banner, topbar cells and footer took up the first sheet. Firefox additionally clips everything past the first page to that fixed height.

Move the link back into the layout so the rules that release the shell and hide the chrome apply everywhere. print.css itself is unchanged, and the absences overview keeps its page specific print styling in absences-overview.css.

relates to #6599

closes #6599

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
