### PR TITLE
Benutzereinstellungen: unbekanntes Theme führt zu Fallback auf SYSTEM

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/user/ThemePropertyEditor.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/user/ThemePropertyEditor.java
@@ -1,0 +1,47 @@
+package org.synyx.urlaubsverwaltung.user;
+
+import org.slf4j.Logger;
+
+import java.beans.PropertyEditorSupport;
+
+import static java.lang.invoke.MethodHandles.lookup;
+import static org.slf4j.LoggerFactory.getLogger;
+import static org.synyx.urlaubsverwaltung.user.Theme.SYSTEM;
+
+/**
+ * Converts a {@link String} to {@link Theme} and vice versa.
+ *
+ * <p>A theme is a display preference. A name that cannot be mapped is no reason to reject the request, therefore
+ * anything unknown becomes {@link Theme#SYSTEM}.
+ */
+public class ThemePropertyEditor extends PropertyEditorSupport {
+
+    private static final Logger LOG = getLogger(lookup().lookupClass());
+
+    // Theme to String
+    @Override
+    public String getAsText() {
+        return this.getValue() == null ? "" : ((Theme) this.getValue()).name();
+    }
+
+    // String to Theme
+    @Override
+    public void setAsText(String text) {
+        this.setValue(toTheme(text));
+    }
+
+    private static Theme toTheme(String themeName) {
+
+        if (themeName == null || themeName.isBlank()) {
+            LOG.info("no theme given, falling back to Theme.{}.", SYSTEM);
+            return SYSTEM;
+        }
+
+        try {
+            return Theme.valueOf(themeName.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            LOG.info("tried to map unknown name={} to Theme, falling back to Theme.{}.", themeName, SYSTEM);
+            return SYSTEM;
+        }
+    }
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/user/UserSettingsDto.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/user/UserSettingsDto.java
@@ -2,18 +2,20 @@ package org.synyx.urlaubsverwaltung.user;
 
 import java.util.Locale;
 
+import static org.synyx.urlaubsverwaltung.user.Theme.SYSTEM;
+
 public class UserSettingsDto {
 
-    private String theme;
+    private Theme theme = SYSTEM;
 
     private Locale locale;
 
-    public String getTheme() {
+    public Theme getTheme() {
         return theme;
     }
 
-    public void setTheme(String theme) {
-        this.theme = theme;
+    public void setTheme(Theme theme) {
+        this.theme = theme == null ? SYSTEM : theme;
     }
 
     public Locale getLocale() {

--- a/src/main/java/org/synyx/urlaubsverwaltung/user/UserSettingsDtoValidator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/user/UserSettingsDtoValidator.java
@@ -21,11 +21,6 @@ class UserSettingsDtoValidator implements Validator {
     public void validate(@NonNull Object target, @NonNull Errors errors) {
         final UserSettingsDto userSettingsDto = (UserSettingsDto) target;
 
-        final String theme = userSettingsDto.getTheme();
-        if (availableThemesDoesNotContain(theme)) {
-            errors.reject("Theme is not available");
-        }
-
         final Locale locale = userSettingsDto.getLocale();
         if (locale != null && supportedLocaleDoesNotContain(locale)) {
             errors.reject("Locale is not available");
@@ -34,9 +29,5 @@ class UserSettingsDtoValidator implements Validator {
 
     private static boolean supportedLocaleDoesNotContain(Locale locale) {
         return stream(SupportedLocale.values()).noneMatch(supportedLocale -> supportedLocale.getLocale().equals(locale));
-    }
-
-    private static boolean availableThemesDoesNotContain(String theme) {
-        return stream(Theme.values()).noneMatch(availableTheme -> availableTheme.name().equals(theme));
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/user/UserSettingsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/user/UserSettingsViewController.java
@@ -3,7 +3,6 @@ package org.synyx.urlaubsverwaltung.user;
 import de.focus_shift.launchpad.api.HasLaunchpad;
 import org.slf4j.Logger;
 import org.springframework.context.MessageSource;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.Errors;
@@ -32,6 +31,8 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 class UserSettingsViewController implements HasLaunchpad, HasPersonSearch {
 
     private static final Logger LOG = getLogger(lookup().lookupClass());
+
+    private static final Theme DEFAULT_THEME = Theme.SYSTEM;
 
     private final PersonService personService;
     private final UserSettingsService userSettingsService;
@@ -132,11 +133,16 @@ class UserSettingsViewController implements HasLaunchpad, HasPersonSearch {
     }
 
     private Theme themeNameToTheme(String themeName) {
+        if (themeName == null) {
+            LOG.info("no theme given, falling back to Theme.{}.", DEFAULT_THEME);
+            return DEFAULT_THEME;
+        }
+
         try {
             return Theme.valueOf(themeName.toUpperCase());
         } catch (IllegalArgumentException e) {
-            LOG.error("tried to map unknown name={} to Theme.", themeName, e);
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "theme does not exist.");
+            LOG.info("tried to map unknown name={} to Theme, falling back to Theme.{}.", themeName, DEFAULT_THEME);
+            return DEFAULT_THEME;
         }
     }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/user/UserSettingsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/user/UserSettingsViewController.java
@@ -1,12 +1,13 @@
 package org.synyx.urlaubsverwaltung.user;
 
 import de.focus_shift.launchpad.api.HasLaunchpad;
-import org.slf4j.Logger;
 import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.DataBinder;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,18 +22,12 @@ import org.synyx.urlaubsverwaltung.search.PersonSuggestionUrlStrategy;
 import java.util.List;
 import java.util.Locale;
 
-import static java.lang.invoke.MethodHandles.lookup;
 import static java.util.Comparator.comparing;
-import static org.slf4j.LoggerFactory.getLogger;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Controller
 @RequestMapping("/web")
 class UserSettingsViewController implements HasLaunchpad, HasPersonSearch {
-
-    private static final Logger LOG = getLogger(lookup().lookupClass());
-
-    private static final Theme DEFAULT_THEME = Theme.SYSTEM;
 
     private final PersonService personService;
     private final UserSettingsService userSettingsService;
@@ -58,6 +53,11 @@ class UserSettingsViewController implements HasLaunchpad, HasPersonSearch {
         this.defaultPersonSuggestionUrlStrategy = defaultPersonSuggestionUrlStrategy;
         this.personSearchUiFragmentSupplier = personSearchUiFragmentSupplier;
         this.messageSource = messageSource;
+    }
+
+    @InitBinder
+    public void initBinder(DataBinder binder) {
+        binder.registerCustomEditor(Theme.class, new ThemePropertyEditor());
     }
 
     @Override
@@ -103,9 +103,7 @@ class UserSettingsViewController implements HasLaunchpad, HasPersonSearch {
             return "user/user-settings";
         }
 
-        final Theme theme = themeNameToTheme(userSettingsDto.getTheme());
-        final Locale userLocale = userSettingsDto.getLocale();
-        userSettingsService.updateUserPreference(signedInUser, theme, userLocale);
+        userSettingsService.updateUserPreference(signedInUser, userSettingsDto.getTheme(), userSettingsDto.getLocale());
 
         return "redirect:/web/person/%s/settings".formatted(personId);
     }
@@ -118,7 +116,7 @@ class UserSettingsViewController implements HasLaunchpad, HasPersonSearch {
 
     private UserSettingsDto userSettingsToDto(UserSettings userSettings) {
         final UserSettingsDto userSettingsDto = new UserSettingsDto();
-        userSettingsDto.setTheme(userSettings.theme().name());
+        userSettingsDto.setTheme(userSettings.theme());
         userSettings.locale().ifPresent(userSettingsDto::setLocale);
 
         return userSettingsDto;
@@ -130,20 +128,6 @@ class UserSettingsViewController implements HasLaunchpad, HasPersonSearch {
             themeToThemeDto(Theme.LIGHT, locale),
             themeToThemeDto(Theme.DARK, locale)
         );
-    }
-
-    private Theme themeNameToTheme(String themeName) {
-        if (themeName == null) {
-            LOG.info("no theme given, falling back to Theme.{}.", DEFAULT_THEME);
-            return DEFAULT_THEME;
-        }
-
-        try {
-            return Theme.valueOf(themeName.toUpperCase());
-        } catch (IllegalArgumentException e) {
-            LOG.info("tried to map unknown name={} to Theme, falling back to Theme.{}.", themeName, DEFAULT_THEME);
-            return DEFAULT_THEME;
-        }
     }
 
     private ThemeDto themeToThemeDto(Theme theme, Locale locale) {

--- a/src/main/resources/templates/user/user-settings.html
+++ b/src/main/resources/templates/user/user-settings.html
@@ -141,7 +141,7 @@
                       type="radio"
                       name="theme"
                       th:value="${selectableTheme.value}"
-                      th:checked="${userSettings.theme eq selectableTheme.value}"
+                      th:checked="${userSettings.theme.name() eq selectableTheme.value}"
                     />
                     <span th:text="${selectableTheme.label}" class="font-bold">Theme Name</span>
                   </span>

--- a/src/test/java/org/synyx/urlaubsverwaltung/user/ThemePropertyEditorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/user/ThemePropertyEditorTest.java
@@ -1,0 +1,55 @@
+package org.synyx.urlaubsverwaltung.user;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ThemePropertyEditorTest {
+
+    private ThemePropertyEditor sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = new ThemePropertyEditor();
+    }
+
+    @ParameterizedTest
+    @EnumSource(Theme.class)
+    void ensureThemeNameIsMappedToTheme(Theme givenTheme) {
+        sut.setAsText(givenTheme.name());
+        assertThat(sut.getValue()).isEqualTo(givenTheme);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"dark", "Dark", "dArK"})
+    void ensureThemeNameIsMappedCaseInsensitive(String givenThemeName) {
+        sut.setAsText(givenThemeName);
+        assertThat(sut.getValue()).isEqualTo(Theme.DARK);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", "   ", "UNKNOWN_THEME", "someTheme"})
+    void ensureUnknownThemeNameFallsBackToSystem(String givenThemeName) {
+        sut.setAsText(givenThemeName);
+        assertThat(sut.getValue()).isEqualTo(Theme.SYSTEM);
+    }
+
+    @ParameterizedTest
+    @EnumSource(Theme.class)
+    void ensureThemeIsMappedToItsName(Theme givenTheme) {
+        sut.setValue(givenTheme);
+        assertThat(sut.getAsText()).isEqualTo(givenTheme.name());
+    }
+
+    @Test
+    void ensureNullThemeIsMappedToEmptyText() {
+        sut.setValue(null);
+        assertThat(sut.getAsText()).isEmpty();
+    }
+}

--- a/src/test/java/org/synyx/urlaubsverwaltung/user/UserSettingsDtoValidatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/user/UserSettingsDtoValidatorTest.java
@@ -28,7 +28,7 @@ class UserSettingsDtoValidatorTest {
     @Test
     void ensureValidIfLocaleIsNotProvided() {
         final UserSettingsDto userSettingsDto = new UserSettingsDto();
-        userSettingsDto.setTheme(Theme.SYSTEM.name());
+        userSettingsDto.setTheme(Theme.SYSTEM);
         sut.validate(userSettingsDto, errors);
         verifyNoInteractions(errors);
     }
@@ -36,7 +36,7 @@ class UserSettingsDtoValidatorTest {
     @Test
     void ensureThrowsErrorIfLocaleIsNotSupported() {
         final UserSettingsDto userSettingsDto = new UserSettingsDto();
-        userSettingsDto.setTheme(Theme.SYSTEM.name());
+        userSettingsDto.setTheme(Theme.SYSTEM);
         userSettingsDto.setLocale(Locale.ITALIAN);
         sut.validate(userSettingsDto, errors);
         verify(errors).reject("Locale is not available");
@@ -46,15 +46,6 @@ class UserSettingsDtoValidatorTest {
     void ensureValidIfThemeIsNotProvided() {
         final UserSettingsDto userSettingsDto = new UserSettingsDto();
         userSettingsDto.setLocale(Locale.GERMAN);
-        sut.validate(userSettingsDto, errors);
-        verifyNoInteractions(errors);
-    }
-
-    @Test
-    void ensureValidIfThemeIsNotSupported() {
-        final UserSettingsDto userSettingsDto = new UserSettingsDto();
-        userSettingsDto.setLocale(Locale.GERMAN);
-        userSettingsDto.setTheme("someTheme");
         sut.validate(userSettingsDto, errors);
         verifyNoInteractions(errors);
     }

--- a/src/test/java/org/synyx/urlaubsverwaltung/user/UserSettingsDtoValidatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/user/UserSettingsDtoValidatorTest.java
@@ -43,19 +43,19 @@ class UserSettingsDtoValidatorTest {
     }
 
     @Test
-    void ensureThrowsErrorIfThemeIsNotProvided() {
+    void ensureValidIfThemeIsNotProvided() {
         final UserSettingsDto userSettingsDto = new UserSettingsDto();
         userSettingsDto.setLocale(Locale.GERMAN);
         sut.validate(userSettingsDto, errors);
-        verify(errors).reject("Theme is not available");
+        verifyNoInteractions(errors);
     }
 
     @Test
-    void ensureThrowsErrorIfThemeIsNotSupported() {
+    void ensureValidIfThemeIsNotSupported() {
         final UserSettingsDto userSettingsDto = new UserSettingsDto();
         userSettingsDto.setLocale(Locale.GERMAN);
         userSettingsDto.setTheme("someTheme");
         sut.validate(userSettingsDto, errors);
-        verify(errors).reject("Theme is not available");
+        verifyNoInteractions(errors);
     }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/user/UserSettingsViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/user/UserSettingsViewControllerTest.java
@@ -114,7 +114,7 @@ class UserSettingsViewControllerTest {
                 )
             ))
             .andExpect(model().attribute("userSettings",
-                hasProperty("theme", is("DARK"))
+                hasProperty("theme", is(Theme.DARK))
             ))
             .andExpect(model().attribute("supportedThemes", contains(
                 allOf(hasProperty("value", is("SYSTEM")), hasProperty("label", is("system-label"))),
@@ -153,7 +153,7 @@ class UserSettingsViewControllerTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"UNKNOWN_THEME", ""})
+    @ValueSource(strings = {"UNKNOWN_THEME", "", "someTheme"})
     void ensureUpdateUserSettingsFallsBackToSystemThemeWhenThemeNameIsUnknown(String givenThemeName) throws Exception {
 
         final Person signedInPerson = new Person();
@@ -223,6 +223,7 @@ class UserSettingsViewControllerTest {
             .locale(Locale.ITALIAN)
         )
             .andExpect(status().isOk())
+            .andExpect(model().attribute("userSettings", hasProperty("theme", is(Theme.SYSTEM))))
             .andExpect(model().attribute("supportedThemes", contains(
                 hasProperty("value", is("SYSTEM")),
                 hasProperty("value", is("LIGHT")),

--- a/src/test/java/org/synyx/urlaubsverwaltung/user/UserSettingsViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/user/UserSettingsViewControllerTest.java
@@ -6,13 +6,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.MessageSource;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.validation.Errors;
-import org.springframework.web.server.ResponseStatusException;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
 import org.synyx.urlaubsverwaltung.search.PersonSearchUiFragmentSupplier;
@@ -28,7 +28,6 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
@@ -153,8 +152,9 @@ class UserSettingsViewControllerTest {
             .andExpect(redirectedUrl("/web/person/42/settings"));
     }
 
-    @Test
-    void ensureUpdateUserSettingsThrowsWhenThemeNameIsUnknown() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"UNKNOWN_THEME", ""})
+    void ensureUpdateUserSettingsFallsBackToSystemThemeWhenThemeNameIsUnknown(String givenThemeName) throws Exception {
 
         final Person signedInPerson = new Person();
         signedInPerson.setId(42L);
@@ -162,11 +162,30 @@ class UserSettingsViewControllerTest {
         when(personService.getSignedInUser()).thenReturn(signedInPerson);
 
         perform(post("/web/person/42/settings")
-            .param("theme", "UNKNOWN_THEME")
+            .param("theme", givenThemeName)
             .locale(Locale.GERMANY)
         )
-            .andExpect(status().isBadRequest())
-            .andExpect(result -> assertInstanceOf(ResponseStatusException.class, result.getResolvedException()));
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/web/person/42/settings"));
+
+        verify(userSettingsService).updateUserPreference(signedInPerson, Theme.SYSTEM, null);
+    }
+
+    @Test
+    void ensureUpdateUserSettingsFallsBackToSystemThemeWhenThemeIsNotGiven() throws Exception {
+
+        final Person signedInPerson = new Person();
+        signedInPerson.setId(42L);
+
+        when(personService.getSignedInUser()).thenReturn(signedInPerson);
+
+        perform(post("/web/person/42/settings")
+            .locale(Locale.GERMANY)
+        )
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/web/person/42/settings"));
+
+        verify(userSettingsService).updateUserPreference(signedInPerson, Theme.SYSTEM, null);
     }
 
     @Test


### PR DESCRIPTION
Ein unbekanntes Theme führt beim Speichern der Benutzereinstellungen nicht mehr zu einem Fehler, sondern zu einem Fallback auf `Theme.SYSTEM`.

## Bisheriges Verhalten

`UserSettingsDtoValidator` hat jedes Theme abgelehnt, das nicht exakt einem Namen des Enums `Theme` entspricht. Das Formular wurde daraufhin erneut gerendert – ohne Meldung, da `user/user-settings.html` gar keine Fehler ausgibt. Für die Person sah es so aus, als sei nichts passiert, und auch die Sprache wurde nicht gespeichert.

Die `ResponseStatusException` mit `400 Bad Request` in `UserSettingsViewController#themeNameToTheme` war dadurch in der Praxis unerreichbar – sie ist nur im Test aufgetreten, in dem der Validator gemockt ist.

## Neues Verhalten

Ein Theme ist eine reine Darstellungspräferenz. Ein unbekannter Wert ist kein Grund, die Anfrage abzubrechen oder die übrigen Einstellungen zu verwerfen:

* keine `ResponseStatusException` mehr, stattdessen `Theme.SYSTEM`
* die Einstellungen werden gespeichert und es wird wie gewohnt weitergeleitet (`302`)
* gilt ebenso für ein fehlendes (`null`) oder leeres Theme
* der Fallback wird auf `INFO` protokolliert statt auf `ERROR`
* Groß-/Kleinschreibung wird weiterhin ignoriert (`dark` → `Theme.DARK`)

Der Validator prüft das Theme nicht mehr, die Prüfung der Sprache (`Locale`) bleibt unverändert.

## Umsetzung

Die Abbildung passiert beim Binden des Requests und nicht erst im Controller:

* `ThemePropertyEditor` bildet den Namen auf `Theme` ab und liefert bei allem Unbekannten `Theme.SYSTEM`. Registriert über `@InitBinder` – analog zu `PersonPropertyEditor`, `TimePropertyEditor` und `DecimalNumberPropertyEditor`.
* `UserSettingsDto#theme` ist damit ein `Theme` statt eines `String` und mit `SYSTEM` vorbelegt, da für einen fehlenden Parameter kein Editor aufgerufen wird. Ein nicht abbildbarer Wert existiert hinter dem Rand des Requests also nicht mehr.
* `UserSettingsViewController` reicht das Theme nur noch durch, die defensive Abbildung inklusive `try`/`catch` entfällt.

Da `ThemeDto#value` weiterhin ein `String` ist, vergleicht das Template jetzt über `${userSettings.theme.name()}`.

## Tests

71 Tests im Package `user` grün, inklusive der ITs.

* `ThemePropertyEditorTest` (neu) deckt beide Richtungen für jede Enum-Konstante ab, die Groß-/Kleinschreibung sowie den Fallback für `null`, `""`, `"   "` und unbekannte Namen.
* `UserSettingsViewControllerTest` prüft den Fallback über die Bindung end-to-end.
* Die beiden Theme-Fälle in `UserSettingsDtoValidatorTest` sind entfallen, sie liegen jetzt beim Editor.

closes #6603
