### PR TITLE
build(deps): bump tomcat from 11.0.24 to 11.0.25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <excluded.groups>a11y</excluded.groups>
     <java.version>25</java.version>
     <uv-extension-api.version>3.3.3</uv-extension-api.version>
+    <tomcat.version>11.0.25</tomcat.version>
 
     <docker-publish-registry>registry.example.com</docker-publish-registry>
     <docker-publish-registry-path>path/example</docker-publish-registry-path>


### PR DESCRIPTION
Hebt den embedded Tomcat von 11.0.24 auf 11.0.25 (18.08.2026).

Spring Boot 4.1.1 verwaltet noch 11.0.24, deshalb wird die Version übergangsweise per `tomcat.version`-Property im `pom.xml` gesetzt. Sobald Spring Boot selbst auf 11.0.25 oder höher zeigt, kann das Property wieder raus – wie damals in 5dc239a53.

Mit 11.0.25 sind elf Sicherheitslücken geschlossen worden, vier davon als *Important* eingestuft (`CVE-2026-65182`, `CVE-2026-65927`, `CVE-2026-68569`, `CVE-2026-68763`). Die vollständige Liste inklusive Einschätzung, warum die Urlaubsverwaltung nach aktuellem Stand von keinem der Punkte akut betroffen ist, steht in #6605.

Verifikation:
* `./mvnw dependency:tree` löst `tomcat-embed-core`, `tomcat-embed-websocket` und `tomcat-embed-el` auf `11.0.25` auf
* `./mvnw test -DskipITs`: 5213 Tests, 0 Failures

closes #6605
