### PR TITLE
Manuelle Überstundenerfassung durch Office bei aktiver Synchronisation

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimePermissionEvaluator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimePermissionEvaluator.java
@@ -22,6 +22,9 @@ import static org.synyx.urlaubsverwaltung.person.Role.SECOND_STAGE_AUTHORITY;
  * {@code overtimeWritePrivilegedOnly} is switched off, everyone maintains their own overtime and nobody else's. When it
  * is switched on, a privileged user maintains their own and - as {@code BOSS} everyone's, as a manager the overtime of
  * the members they are responsible for. {@code OFFICE} always maintains the overtime of everyone.
+ *
+ * <p>While overtime is synchronised from an external system the records come from there, so recording overtime by hand
+ * is reserved to {@code OFFICE}.
  */
 @Component
 public class OvertimePermissionEvaluator {
@@ -57,15 +60,15 @@ public class OvertimePermissionEvaluator {
      * Whether the given user may record overtime for somebody else at all. In contrast to
      * {@link OvertimePermissions#isAllowedToAdd()} this permission is not bound to a single person - it decides whether
      * the overtime form offers a person to pick, for which persons overtime may be recorded is decided per person.
-     * Like every write permission it is also gated on overtime being active and not synchronised from an external
-     * system.
+     * Like every write permission it is also gated on overtime being active and, while it is synchronised from an
+     * external system, on the user being {@code OFFICE}.
      *
      * @param signedInUser user asking for permissions
      * @return {@code true} if the user may record overtime for at least one other person, {@code false} otherwise
      */
     public boolean isAllowedToCreateOvertimeForOtherPersons(Person signedInUser) {
         final OvertimeSettings overtimeSettings = settingsService.getSettings().getOvertimeSettings();
-        return isWritable(overtimeSettings)
+        return isWritableBy(signedInUser, overtimeSettings)
             && (signedInUser.hasRole(OFFICE) || (signedInUser.isPrivileged() && overtimeSettings.isOvertimeWritePrivilegedOnly()));
     }
 
@@ -78,7 +81,7 @@ public class OvertimePermissionEvaluator {
      */
     public boolean isAllowedToCreateOvertimeForAnyPerson(Person signedInUser) {
         final OvertimeSettings overtimeSettings = settingsService.getSettings().getOvertimeSettings();
-        return isWritable(overtimeSettings)
+        return isWritableBy(signedInUser, overtimeSettings)
             && (!overtimeSettings.isOvertimeWritePrivilegedOnly() || signedInUser.isPrivileged());
     }
 
@@ -107,10 +110,11 @@ public class OvertimePermissionEvaluator {
     }
 
     /**
-     * Whether overtime may be written at all, no matter by whom - it has to be switched on and must not be
-     * synchronised from an external system.
+     * Whether the given user may write overtime at all - it has to be switched on and, while it is synchronised from an
+     * external system, only {@code OFFICE} writes records by hand.
      */
-    private static boolean isWritable(OvertimeSettings overtimeSettings) {
-        return overtimeSettings.isOvertimeActive() && !overtimeSettings.isOvertimeSyncActive();
+    private static boolean isWritableBy(Person signedInUser, OvertimeSettings overtimeSettings) {
+        return overtimeSettings.isOvertimeActive()
+            && (signedInUser.hasRole(OFFICE) || !overtimeSettings.isOvertimeSyncActive());
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimePermissionEvaluator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimePermissionEvaluator.java
@@ -23,8 +23,8 @@ import static org.synyx.urlaubsverwaltung.person.Role.SECOND_STAGE_AUTHORITY;
  * is switched on, a privileged user maintains their own and - as {@code BOSS} everyone's, as a manager the overtime of
  * the members they are responsible for. {@code OFFICE} always maintains the overtime of everyone.
  *
- * <p>While overtime is synchronised from an external system the records come from there, so recording overtime by hand
- * is reserved to {@code OFFICE}.
+ * <p>While overtime is synchronised from an external system the records come from there, so recording and editing
+ * overtime by hand is reserved to {@code OFFICE}.
  */
 @Component
 public class OvertimePermissionEvaluator {

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimePermissions.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimePermissions.java
@@ -52,13 +52,14 @@ public final class OvertimePermissions {
     }
 
     /**
-     * Whether the user may record overtime for the person. Not possible while overtime is synchronised from an external
-     * system - the records come from there.
+     * Whether the user may record overtime for the person. While overtime is synchronised from an external system the
+     * records come from there - only {@link org.synyx.urlaubsverwaltung.person.Role#OFFICE} still records overtime by
+     * hand, to onboard a person or to pay overtime out for example.
      *
      * @return {@code true} if the user may record overtime for the person, {@code false} otherwise
      */
     public boolean isAllowedToAdd() {
-        return isAllowedToMaintain() && !overtimeSyncActive;
+        return isAllowedToMaintain() && (signedInUser.hasRole(OFFICE) || !overtimeSyncActive);
     }
 
     /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimePermissions.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimePermissions.java
@@ -52,14 +52,12 @@ public final class OvertimePermissions {
     }
 
     /**
-     * Whether the user may record overtime for the person. While overtime is synchronised from an external system the
-     * records come from there - only {@link org.synyx.urlaubsverwaltung.person.Role#OFFICE} still records overtime by
-     * hand, to onboard a person or to pay overtime out for example.
+     * Whether the user may record overtime for the person.
      *
      * @return {@code true} if the user may record overtime for the person, {@code false} otherwise
      */
     public boolean isAllowedToAdd() {
-        return isAllowedToMaintain() && (signedInUser.hasRole(OFFICE) || !overtimeSyncActive);
+        return isAllowedToMaintainManualRecord();
     }
 
     /**
@@ -71,7 +69,7 @@ public final class OvertimePermissions {
      * @return {@code true} if the user may edit the given overtime, {@code false} otherwise
      */
     public boolean isAllowedToEdit(Overtime overtime) {
-        return isAllowedToMaintain() && !EXTERNAL.equals(overtime.type());
+        return isAllowedToMaintainManualRecord() && !EXTERNAL.equals(overtime.type());
     }
 
     /**
@@ -93,6 +91,15 @@ public final class OvertimePermissions {
             || (overtimeWritePrivilegedOnly
             ? signedInUser.isPrivileged() && (isSamePerson() || signedInUser.hasRole(BOSS) || isManagerOfPerson())
             : isSamePerson()));
+    }
+
+    /**
+     * Whether the user may maintain a manual overtime record of the person. While overtime is synchronised from an
+     * external system the records come from there - only {@link org.synyx.urlaubsverwaltung.person.Role#OFFICE} still
+     * records and edits overtime by hand, to onboard a person or to pay overtime out for example.
+     */
+    private boolean isAllowedToMaintainManualRecord() {
+        return isAllowedToMaintain() && (signedInUser.hasRole(OFFICE) || !overtimeSyncActive);
     }
 
     private boolean isManagerOfPerson() {

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimePermissionEvaluatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimePermissionEvaluatorTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.synyx.urlaubsverwaltung.absence.DateRange;
@@ -100,9 +101,28 @@ class OvertimePermissionEvaluatorTest {
             assertThat(permissionsOn(OTHER_PERSON_ID, false, false, OFFICE, false, false).isAllowedToAdd()).isFalse();
         }
 
-        @Test
-        void ensureNobodyMayAddWhenOvertimeSyncIsActive() {
-            assertThat(permissionsOn(OTHER_PERSON_ID, false, false, OFFICE, true, true).isAllowedToAdd()).isFalse();
+        @ParameterizedTest
+        @ValueSource(booleans = {true, false})
+        void ensureOfficeMayAddForEveryoneWhenOvertimeSyncIsActive(boolean writePrivilegedOnly) {
+            assertThat(permissionsOn(OTHER_PERSON_ID, false, false, OFFICE, true, true, writePrivilegedOnly).isAllowedToAdd()).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(booleans = {true, false})
+        void ensureOfficeMayAddOwnOvertimeWhenOvertimeSyncIsActive(boolean writePrivilegedOnly) {
+            assertThat(permissionsOn(SIGNED_IN_USER_ID, false, false, OFFICE, true, true, writePrivilegedOnly).isAllowedToAdd()).isTrue();
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Role.class, names = {"DEPARTMENT_HEAD", "SECOND_STAGE_AUTHORITY", "BOSS", "USER"})
+        void ensureNobodyButOfficeMayAddForManagedMemberWhenOvertimeSyncIsActive(Role role) {
+            assertThat(permissionsOn(OTHER_PERSON_ID, true, true, role, true, true, true).isAllowedToAdd()).isFalse();
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Role.class, names = {"DEPARTMENT_HEAD", "SECOND_STAGE_AUTHORITY", "BOSS", "USER"})
+        void ensureNobodyButOfficeMayAddOwnOvertimeWhenOvertimeSyncIsActive(Role role) {
+            assertThat(permissionsOn(SIGNED_IN_USER_ID, false, false, role, true, true, false).isAllowedToAdd()).isFalse();
         }
 
         @Test
@@ -288,9 +308,16 @@ class OvertimePermissionEvaluatorTest {
         }
 
         @Test
-        void ensureNobodyMayCreateForOthersWhenOvertimeSyncIsActive() {
+        void ensureOfficeMayCreateForOthersWhenOvertimeSyncIsActive() {
             settings(true, true, true);
-            assertThat(sut.isAllowedToCreateOvertimeForOtherPersons(person(SIGNED_IN_USER_ID, USER, OFFICE))).isFalse();
+            assertThat(sut.isAllowedToCreateOvertimeForOtherPersons(person(SIGNED_IN_USER_ID, USER, OFFICE))).isTrue();
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Role.class, names = {"USER", "DEPARTMENT_HEAD", "SECOND_STAGE_AUTHORITY", "BOSS"})
+        void ensureNobodyButOfficeMayCreateForOthersWhenOvertimeSyncIsActive(Role role) {
+            settings(true, true, true);
+            assertThat(sut.isAllowedToCreateOvertimeForOtherPersons(person(SIGNED_IN_USER_ID, USER, role))).isFalse();
         }
     }
 
@@ -322,10 +349,18 @@ class OvertimePermissionEvaluatorTest {
             assertThat(sut.isAllowedToCreateOvertimeForAnyPerson(person(SIGNED_IN_USER_ID, USER, OFFICE))).isFalse();
         }
 
-        @Test
-        void ensureNobodyMayCreateOvertimeWhenOvertimeSyncIsActive() {
+        @ParameterizedTest
+        @ValueSource(booleans = {true, false})
+        void ensureOfficeMayCreateOvertimeWhenOvertimeSyncIsActive(boolean writePrivilegedOnly) {
+            settings(true, true, writePrivilegedOnly);
+            assertThat(sut.isAllowedToCreateOvertimeForAnyPerson(person(SIGNED_IN_USER_ID, USER, OFFICE))).isTrue();
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Role.class, names = {"USER", "DEPARTMENT_HEAD", "SECOND_STAGE_AUTHORITY", "BOSS"})
+        void ensureNobodyButOfficeMayCreateOvertimeWhenOvertimeSyncIsActive(Role role) {
             settings(true, true, false);
-            assertThat(sut.isAllowedToCreateOvertimeForAnyPerson(person(SIGNED_IN_USER_ID, USER, OFFICE))).isFalse();
+            assertThat(sut.isAllowedToCreateOvertimeForAnyPerson(person(SIGNED_IN_USER_ID, USER, role))).isFalse();
         }
     }
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimePermissionEvaluatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimePermissionEvaluatorTest.java
@@ -182,9 +182,28 @@ class OvertimePermissionEvaluatorTest {
             assertThat(permissionsOn(OTHER_PERSON_ID, false, false, OFFICE).isAllowedToEdit(overtime(EXTERNAL))).isFalse();
         }
 
-        @Test
-        void ensureEditIsAllowedWhenOvertimeSyncIsActive() {
-            assertThat(permissionsOn(OTHER_PERSON_ID, false, false, OFFICE, true, true).isAllowedToEdit(overtime(UV_INTERNAL))).isTrue();
+        @ParameterizedTest
+        @ValueSource(booleans = {true, false})
+        void ensureOfficeMayEditForEveryoneWhenOvertimeSyncIsActive(boolean writePrivilegedOnly) {
+            assertThat(permissionsOn(OTHER_PERSON_ID, false, false, OFFICE, true, true, writePrivilegedOnly).isAllowedToEdit(overtime(UV_INTERNAL))).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(booleans = {true, false})
+        void ensureOfficeMayEditOwnOvertimeWhenOvertimeSyncIsActive(boolean writePrivilegedOnly) {
+            assertThat(permissionsOn(SIGNED_IN_USER_ID, false, false, OFFICE, true, true, writePrivilegedOnly).isAllowedToEdit(overtime(UV_INTERNAL))).isTrue();
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Role.class, names = {"DEPARTMENT_HEAD", "SECOND_STAGE_AUTHORITY", "BOSS", "USER"})
+        void ensureNobodyButOfficeMayEditForManagedMemberWhenOvertimeSyncIsActive(Role role) {
+            assertThat(permissionsOn(OTHER_PERSON_ID, true, true, role, true, true, true).isAllowedToEdit(overtime(UV_INTERNAL))).isFalse();
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Role.class, names = {"DEPARTMENT_HEAD", "SECOND_STAGE_AUTHORITY", "BOSS", "USER"})
+        void ensureNobodyButOfficeMayEditOwnOvertimeWhenOvertimeSyncIsActive(Role role) {
+            assertThat(permissionsOn(SIGNED_IN_USER_ID, false, false, role, true, true, false).isAllowedToEdit(overtime(UV_INTERNAL))).isFalse();
         }
 
         @Test


### PR DESCRIPTION
Closes #5832

## Kontext

Bei aktiver `OvertimeSettings#overtimeSyncActive` war das Erfassen (und implizit Bearbeiten) von Überstundeneinträgen bisher für **alle** Rollen gesperrt, inklusive OFFICE. Damit war z.B. das Onboarding oder das manuelle Auszahlen von Überstunden nicht mehr möglich, sobald die Synchronisation aus der Zeiterfassung aktiviert wurde.

Der Branch ist auf den `OvertimePermissionEvaluator` aus #6611 rebased. Die Regeln liegen deshalb nicht mehr im `OvertimeServiceImpl`, sondern dort, wo die Überstunden-Berechtigungen inzwischen beantwortet werden.

## Änderungen

- `OvertimePermissions#isAllowedToAdd`: OFFICE darf weiterhin manuelle Überstundeneinträge erfassen, wenn Sync aktiv ist - für beliebige Personen, auch für sich selbst. Alle anderen Rollen bleiben komplett ausgeschlossen, unabhängig von `overtimeWritePrivilegedOnly`.
- `OvertimePermissions#isAllowedToEdit`: konsistent zur Erfassungsregel darf bei aktiver Sync nur noch OFFICE manuelle (`UV_INTERNAL`) Einträge bearbeiten. Das schließt eine bestehende Inkonsistenz: vorher konnten privilegierte Rollen bzw. die betroffene Person ihre eigenen manuellen Einträge auch bei aktiver Sync noch bearbeiten. Bereits synchronisierte (`EXTERNAL`) Einträge bleiben unverändert für niemanden editierbar.
- Beide Fragen laufen über das neue private `OvertimePermissions#isAllowedToMaintainManualRecord`, die Sync-Ausnahme steht damit an einer Stelle.
- `OvertimePermissionEvaluator#isWritable` wird zu `isWritableBy(Person, OvertimeSettings)`: die gleiche Ausnahme für die nicht personenbezogenen Fragen, damit OFFICE bei aktiver Sync den Navigationspunkt "Überstunden erfassen" (`isAllowedToCreateOvertimeForAnyPerson`) und die Personenauswahl im Formular (`isAllowedToCreateOvertimeForOtherPersons`) behält.

## Nicht betroffen

- `OvertimePermissions#isAllowedToComment`: unverändert, war nie an `overtimeSyncActive` gekoppelt.
- Lese-Berechtigungen (`isAllowedToView`, `isAllowedToViewOvertimeOfAllPersons`, `isAllowedToViewOvertimeOfOtherPersons`): unverändert, Einträge bleiben sichtbar.
- Negative Dauer (Auszahlen/Reduzieren) läuft weiterhin über das bestehende Setting `overtimeReductionWithoutApplicationActive`, keine Änderung nötig.
- Benachrichtigungsmails: greifen automatisch weiter, da Mails nur bei `type == EXTERNAL` unterdrückt werden.
- Eine Löschfunktion für Überstundeneinträge existiert im Code nicht, daher kein Akzeptanzkriterium/Änderung dazu.

## Tests

Alles in `OvertimePermissionEvaluatorTest` - die Fälle sind mit dem Rebase aus `OvertimeServiceImplTest` und `FrameDataProviderTest` dorthin gewandert, wo die Regeln jetzt leben.

- `Add` und `Edit`: OFFICE bleibt bei aktiver Sync erlaubt, für eigene und fremde Einträge und für beide Werte von `overtimeWritePrivilegedOnly`. Alle anderen Rollen sind blockiert - auch privilegierte, auch für eigene Einträge und auch dann, wenn sie als Abteilungsleitung bzw. Freigabe-Verantwortliche für die Person zuständig sind.
- `CreateForAnyPerson` und `CreateForOtherPersons`: dieselbe Ausnahme für Navigationspunkt und Personenauswahl.
- Drei Tests, die auf `main` die alte Regel "bei aktiver Sync darf niemand schreiben" festgehalten haben, sind entsprechend umgedreht. `ensureEditIsAllowedWhenOvertimeSyncIsActive` heißt jetzt nach der Rolle, für die es gilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
