### PR TITLE
Stichtag "Stand: …" in Überstunden- und Abwesenheitsstatistik anzeigen

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/absence/statistics/AbsenceStatisticsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/absence/statistics/AbsenceStatisticsViewController.java
@@ -17,6 +17,7 @@ import org.synyx.urlaubsverwaltung.search.PersonSuggestionUrlStrategy;
 
 import java.math.BigDecimal;
 import java.time.Clock;
+import java.time.LocalDate;
 import java.time.Year;
 import java.util.List;
 import java.util.Locale;
@@ -80,6 +81,8 @@ class AbsenceStatisticsViewController implements HasLaunchpad, HasPersonSearch {
 
         model.addAttribute("absenceGraphStatistic", toGraphDto(selectedYearStatistics, locale));
         model.addAttribute("currentYear", Year.now(clock).getValue());
+        // says when these figures were calculated, therefore today - independent of the selected year
+        model.addAttribute("asOfDate", LocalDate.now(clock));
 
         return "absences/absence_statistics";
     }

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsViewController.java
@@ -15,6 +15,7 @@ import org.synyx.urlaubsverwaltung.util.DurationFormatter;
 import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.Year;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -74,6 +75,8 @@ class OvertimeStatisticsViewController implements HasLaunchpad {
 
         model.addAttribute("selectedYear", selectedYear.getValue());
         model.addAttribute("currentYear", currentYear.getValue());
+        // says when these figures were calculated, therefore today - independent of the selected year
+        model.addAttribute("asOfDate", LocalDate.now(clock));
         model.addAttribute("overtimeGraph", toGraphDto(statistics, previousStatistics, locale));
         model.addAttribute("overtimeYearSummary", toYearSummaryDto(statistics, locale));
         model.addAttribute("overtimeBalanceGraph", toBalanceGraphDto(statistics, previousStatistics, locale));

--- a/src/main/resources/templates/absences/absence_statistics.html
+++ b/src/main/resources/templates/absences/absence_statistics.html
@@ -57,7 +57,9 @@
             th:replace="~{fragments/year-selector::year-selector(id='year-selection', currentYear=${currentYear}, hrefPrefix=|/web/absence/statistics?year=|, selectedYear=${selectedYearStatistics.year.value})}"
           ></div>
         </th:block>
-        <th:block th:ref="absence-statistics-heading-actions"> </th:block>
+        <th:block th:ref="absence-statistics-heading-actions">
+          <div th:replace="~{fragments/as-of-date::as-of-date(${asOfDate})}"></div>
+        </th:block>
       </div>
 
       <div class="absence-statistics-info-anchor">

--- a/src/main/resources/templates/fragments/as-of-date.html
+++ b/src/main/resources/templates/fragments/as-of-date.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <title>as-of-date</title>
+  </head>
+  <body>
+    <!--
+      Says when the figures of a statistic were calculated. Shown on every statistics page in the actions slot of the
+      page heading, so that an exported or printed page still tells the reader how current its numbers are.
+    -->
+    <div th:fragment="as-of-date(date)" class="text-sm">
+      <th:block th:text="#{filter.validity}">Stand</th:block>
+      <th:block th:text="${#temporals.format(date, 'dd.MM.yyyy')}">01.09.2026</th:block>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/templates/overtime/overtime_statistics.html
+++ b/src/main/resources/templates/overtime/overtime_statistics.html
@@ -77,7 +77,9 @@
           <th:block th:ref="overtime-statistics-heading-body">
             <h1 th:text="#{overtime.statistics.title}">Überstundenstatistik</h1>
           </th:block>
-          <th:block th:ref="overtime-statistics-heading-actions"> </th:block>
+          <th:block th:ref="overtime-statistics-heading-actions">
+            <div th:replace="~{fragments/as-of-date::as-of-date(${asOfDate})}"></div>
+          </th:block>
         </div>
         <div class="statistic-summary-container">
           <h2 class="statistic-summary-container-title text-base" th:text="#{overtime.statistics.totals.title}">

--- a/src/main/resources/templates/sicknote/sick_notes_statistics.html
+++ b/src/main/resources/templates/sicknote/sick_notes_statistics.html
@@ -65,17 +65,13 @@
             th:replace="~{fragments/year-selector::year-selector(id='year-selection', currentYear=${currentYear}, hrefPrefix=|/web/sicknote/statistics?year=|, selectedYear=${selectedYearStatistics.year})}"
           ></div>
         </th:block>
-        <th:block th:ref="absences-statistics-heading-actions"> </th:block>
+        <th:block th:ref="absences-statistics-heading-actions">
+          <div th:replace="~{fragments/as-of-date::as-of-date(${selectedYearStatistics.asOfDate})}"></div>
+        </th:block>
       </div>
 
       <div>
-        <div class="mt-8 flex flex-col @3xl/main:flex-row justify-between gap-1">
-          <h2 class="font-bold text-base" th:text="#{sicknotes.statistics.chart.title}">Krankheitstage</h2>
-          <div class="text-sm @3xl/main:font-bold @3xl/main:text-right @3xl/main:px-3">
-            <th:block th:text="#{filter.validity}"></th:block>
-            <th:block th:text="${#temporals.format(selectedYearStatistics.asOfDate, 'dd.MM.yyyy')}"></th:block>
-          </div>
-        </div>
+        <h2 class="mt-8 font-bold text-base" th:text="#{sicknotes.statistics.chart.title}">Krankheitstage</h2>
 
         <div class="mt-4 sicknote-statistics-chart-container">
           <div id="sicknote-statistic-chart" class="sicknote-statistics-chart"></div>

--- a/src/test/java/org/synyx/urlaubsverwaltung/absence/statistics/AbsenceStatisticsViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/absence/statistics/AbsenceStatisticsViewControllerTest.java
@@ -19,12 +19,15 @@ import org.synyx.urlaubsverwaltung.search.PersonSuggestionUrlStrategy;
 
 import java.math.BigDecimal;
 import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.time.Year;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
 import static java.math.BigDecimal.ZERO;
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -54,7 +57,7 @@ class AbsenceStatisticsViewControllerTest {
     @Mock
     private PersonSearchUiFragmentSupplier personSearchUiFragmentSupplier;
 
-    private final Clock clock = Clock.systemUTC();
+    private final Clock clock = Clock.fixed(Instant.parse("2026-07-31T10:15:00Z"), UTC);
 
     private static List<BigDecimal> zeroMonths() {
         return List.of(ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO);
@@ -122,6 +125,43 @@ class AbsenceStatisticsViewControllerTest {
             .andExpect(model().attribute("selectedYearStatistics", selectedYearStatistics))
             .andExpect(model().attribute("currentYear", year.getValue()))
             .andExpect(view().name("absences/absence_statistics"));
+    }
+
+    @Test
+    void ensureAsOfDateIsTodayForTheCurrentYear() throws Exception {
+
+        final Year year = Year.now(clock);
+
+        final Person person = new Person();
+        when(personService.getSignedInUser()).thenReturn(person);
+
+        final VacationDaysTakenResult vacationDaysTaken = new VacationDaysTakenResult(ZERO, ZERO, ZERO, ZERO);
+        when(absenceStatisticsService.createStatistics(year, person))
+            .thenReturn(new AbsenceStatistics(year, Map.of(), vacationDaysTaken));
+
+        perform(get("/web/absence/statistics"))
+            .andExpect(status().isOk())
+            .andExpect(model().attribute("asOfDate", LocalDate.of(2026, 7, 31)));
+    }
+
+    @Test
+    void ensureAsOfDateIsTodayForAPastYear() throws Exception {
+
+        // the date says when the figures were calculated, not which period they cover, therefore it stays today
+        // even when an already finished year is shown
+
+        final Year year = Year.of(2024);
+
+        final Person person = new Person();
+        when(personService.getSignedInUser()).thenReturn(person);
+
+        final VacationDaysTakenResult vacationDaysTaken = new VacationDaysTakenResult(ZERO, ZERO, ZERO, ZERO);
+        when(absenceStatisticsService.createStatistics(year, person))
+            .thenReturn(new AbsenceStatistics(year, Map.of(), vacationDaysTaken));
+
+        perform(get("/web/absence/statistics").param("year", "2024"))
+            .andExpect(status().isOk())
+            .andExpect(model().attribute("asOfDate", LocalDate.of(2026, 7, 31)));
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsViewControllerTest.java
@@ -16,6 +16,7 @@ import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.Year;
 import java.util.List;
 
@@ -86,6 +87,31 @@ class OvertimeStatisticsViewControllerTest {
             .andExpect(model().attribute("selectedYear", 2024))
             .andExpect(model().attribute("currentYear", 2026))
             .andExpect(view().name("overtime/overtime_statistics"));
+    }
+
+    @Test
+    void ensureAsOfDateIsTodayForTheCurrentYear() throws Exception {
+
+        overtimeFeature(true);
+        statisticsOf(Year.of(2026), months(ZERO), months(ZERO));
+
+        perform(get("/web/overtime/statistics"))
+            .andExpect(status().isOk())
+            .andExpect(model().attribute("asOfDate", LocalDate.of(2026, 7, 31)));
+    }
+
+    @Test
+    void ensureAsOfDateIsTodayForAPastYear() throws Exception {
+
+        // the date says when the figures were calculated, not which period they cover, therefore it stays today
+        // even when an already finished year is shown
+
+        overtimeFeature(true);
+        statisticsOf(Year.of(2024), months(ZERO), months(ZERO));
+
+        perform(get("/web/overtime/statistics").param("year", "2024"))
+            .andExpect(status().isOk())
+            .andExpect(model().attribute("asOfDate", LocalDate.of(2026, 7, 31)));
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/web/AsOfDateFragmentTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/web/AsOfDateFragmentTest.java
@@ -1,0 +1,74 @@
+package org.synyx.urlaubsverwaltung.web;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.ResourceBundleMessageSource;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+import org.thymeleaf.templateresolver.StringTemplateResolver;
+
+import java.time.LocalDate;
+import java.util.Locale;
+import java.util.Set;
+
+import static java.time.Month.SEPTEMBER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Renders the as-of-date fragment the statistics pages share, so that its label and its date format stay the same
+ * on all of them.
+ */
+class AsOfDateFragmentTest {
+
+    private static final String USAGE = "<div th:replace=\"~{fragments/as-of-date::as-of-date(${asOfDate})}\"></div>";
+
+    private static SpringTemplateEngine templateEngine;
+
+    @BeforeAll
+    static void setUpTemplateEngine() {
+
+        final StringTemplateResolver inlineResolver = new StringTemplateResolver();
+        inlineResolver.setTemplateMode(TemplateMode.HTML);
+        inlineResolver.setResolvablePatterns(Set.of("<*"));
+        inlineResolver.setOrder(1);
+
+        final ClassLoaderTemplateResolver templateResolver = new ClassLoaderTemplateResolver();
+        templateResolver.setPrefix("templates/");
+        templateResolver.setSuffix(".html");
+        templateResolver.setTemplateMode(TemplateMode.HTML);
+        templateResolver.setCharacterEncoding("UTF-8");
+        templateResolver.setOrder(2);
+
+        final ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
+        messageSource.setBasename("messages");
+        messageSource.setDefaultEncoding("UTF-8");
+        messageSource.setFallbackToSystemLocale(false);
+
+        templateEngine = new SpringTemplateEngine();
+        templateEngine.addTemplateResolver(inlineResolver);
+        templateEngine.addTemplateResolver(templateResolver);
+        templateEngine.setTemplateEngineMessageSource(messageSource);
+    }
+
+    @Test
+    void ensureLabelAndDateAreRendered() {
+
+        final Context context = new Context(Locale.GERMAN);
+        context.setVariable("asOfDate", LocalDate.of(2026, SEPTEMBER, 1));
+
+        assertThat(templateEngine.process(USAGE, context)).contains("Stand", "01.09.2026");
+    }
+
+    @Test
+    void ensureDateFormatDoesNotFollowTheLocale() {
+
+        // the day-first format is part of the agreed output, an english page shows the same date as a german one
+
+        final Context context = new Context(Locale.ENGLISH);
+        context.setVariable("asOfDate", LocalDate.of(2026, SEPTEMBER, 1));
+
+        assertThat(templateEngine.process(USAGE, context)).contains("Status", "01.09.2026");
+    }
+}


### PR DESCRIPTION
Die Überstunden- und die Abwesenheitsstatistik zeigen zwölf Monate, die Zahlen des laufenden Jahres reichen aber nur bis heute. Wer die Seite exportiert, ausdruckt oder in einer Besprechung zeigt, sah bisher nicht, wann der Stand erhoben wurde. Beide Seiten weisen den Stichtag nun wie die Krankmeldungsstatistik aus.

## Platzierung

Die Angabe steht auf allen drei Seiten im `heading-actions`-Slot der Seitenüberschrift — damit sie nicht auf jeder Seite woanders steht. Bei der Krankmeldungsstatistik wandert sie dafür aus der Zeile des Diagrammtitels nach oben. Das neue Fragment `fragments/as-of-date` hält Text (`filter.validity`) und Datumsformat (`dd.MM.yyyy`) auf allen drei Seiten gleich.

## Abweichung von der Beschreibung im Issue

Das Issue verlangt für abgeschlossene Jahre den 31.12. als Stichtag und verweist dabei auf `SickNoteStatistics#getAsOfDate()`. Diese Annahme trifft nicht zu: dort wird `LocalDate.now(clock)` ungeklammert durchgereicht, `/web/sicknote/statistics?year=2024` zeigte also auch vorher schon das heutige Datum.

Nach Rücksprache bleibt es dabei — der Stichtag sagt aus, **wann die Zahlen berechnet wurden**, nicht welchen Zeitraum sie abdecken. Er bleibt daher heute, auch wenn ein abgeschlossenes Jahr betrachtet wird. Beide Controller-Tests prüfen genau das für ein vergangenes Jahr.

Damit ist auch die Platzierung in der obersten Überschrift der Überstundenstatistik unkritisch, obwohl direkt darunter der jahresunabhängige Gesamtbestand steht.

## Tests

- `AsOfDateFragmentTest` rendert das Fragment durch eine echte Thymeleaf-Engine (de + en) — die Controller-Tests nutzen `standaloneSetup` und sehen die Templates nie.
- Je zwei Tests in `OvertimeStatisticsViewControllerTest` und `AbsenceStatisticsViewControllerTest` für laufendes und vergangenes Jahr.
- Manuell mit dem `demodata`-Profil geprüft: alle drei Seiten sowie `?year=2024`, bei 1280px und 420px Breite.

closes #6591
