### PR TITLE
Remove data labels from sick days chart

### DIFF
--- a/src/main/javascript/bundles/__tests__/sick-notes-statistics.spec.js
+++ b/src/main/javascript/bundles/__tests__/sick-notes-statistics.spec.js
@@ -182,6 +182,13 @@ describe("sick-notes-statistics", function () {
       expect(options.states.active.filter.type).toBe("none");
     });
 
+    it("does not label every single bar segment", async function () {
+      setSicknoteStatistic();
+      await loadModule();
+
+      expect(barChart().options.dataLabels.enabled).toBe(false);
+    });
+
     it("configures the tooltip as shared, non-intersecting and cursor-following", async function () {
       setSicknoteStatistic();
       await loadModule();

--- a/src/main/javascript/bundles/sick-notes-statistics.js
+++ b/src/main/javascript/bundles/sick-notes-statistics.js
@@ -163,8 +163,10 @@ const options = {
     width: 2,
     colors: ["transparent"],
   },
+  // four stacked series across twelve months would put up to 48 numbers into the plot, which is
+  // unreadable - the exact values are available in the tooltip instead
   dataLabels: {
-    enabled: true,
+    enabled: false,
   },
   xaxis: {
     categories: xaxisLabels,


### PR DESCRIPTION
The sick days chart was the only one of the six statistics charts that printed the values onto the bars. With four stacked series across twelve months that puts up to 48 numbers into the plot - by the same measure the other five charts already apply, this is the densest case after the absence chart.

The exact values remain available in the tooltip.

closes #6592

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
