### PR TITLE
Add the global person search to the overtime statistics

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsViewController.java
@@ -9,6 +9,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.server.ResponseStatusException;
+import org.synyx.urlaubsverwaltung.search.HasPersonSearch;
+import org.synyx.urlaubsverwaltung.search.PersonSearchUiFragmentSupplier;
+import org.synyx.urlaubsverwaltung.search.PersonSuggestionUrlStrategy;
 import org.synyx.urlaubsverwaltung.settings.SettingsService;
 import org.synyx.urlaubsverwaltung.util.DurationFormatter;
 
@@ -33,7 +36,7 @@ import static org.synyx.urlaubsverwaltung.security.SecurityRules.IS_BOSS_OR_OFFI
 @Controller
 @RequestMapping("/web/overtime/statistics")
 @PreAuthorize(IS_BOSS_OR_OFFICE)
-class OvertimeStatisticsViewController implements HasLaunchpad {
+class OvertimeStatisticsViewController implements HasLaunchpad, HasPersonSearch {
 
     private static final int MINUTES_PER_HOUR = 60;
     private static final int DECIMAL_HOUR_SCALE = 2;
@@ -41,18 +44,38 @@ class OvertimeStatisticsViewController implements HasLaunchpad {
     private final OvertimeStatisticsService overtimeStatisticsService;
     private final SettingsService settingsService;
     private final MessageSource messageSource;
+    private final PersonSuggestionUrlStrategy defaultPersonSuggestionUrlStrategy;
+    private final PersonSearchUiFragmentSupplier personSearchUiFragmentSupplier;
     private final Clock clock;
 
     OvertimeStatisticsViewController(
         OvertimeStatisticsService overtimeStatisticsService,
         SettingsService settingsService,
         MessageSource messageSource,
+        PersonSuggestionUrlStrategy defaultPersonSuggestionUrlStrategy,
+        PersonSearchUiFragmentSupplier personSearchUiFragmentSupplier,
         Clock clock
     ) {
         this.overtimeStatisticsService = overtimeStatisticsService;
         this.settingsService = settingsService;
         this.messageSource = messageSource;
+        this.defaultPersonSuggestionUrlStrategy = defaultPersonSuggestionUrlStrategy;
+        this.personSearchUiFragmentSupplier = personSearchUiFragmentSupplier;
         this.clock = clock;
+    }
+
+    /**
+     * The page shows company wide figures and has no rows of its own a suggestion could point at, therefore a
+     * suggestion links to the person overview like on every other page without person rows.
+     */
+    @Override
+    public PersonSuggestionUrlStrategy personSuggestionUrlStrategy() {
+        return defaultPersonSuggestionUrlStrategy;
+    }
+
+    @Override
+    public PersonSearchUiFragmentSupplier personSearchUiFragmentSupplier() {
+        return personSearchUiFragmentSupplier;
     }
 
     @GetMapping

--- a/src/test/java/org/synyx/urlaubsverwaltung/GlobalPersonSearchArchTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/GlobalPersonSearchArchTest.java
@@ -1,0 +1,40 @@
+package org.synyx.urlaubsverwaltung;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import de.focus_shift.launchpad.api.HasLaunchpad;
+import org.springframework.stereotype.Controller;
+import org.synyx.urlaubsverwaltung.search.HasPersonSearch;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+@AnalyzeClasses(packages = "org.synyx.urlaubsverwaltung")
+class GlobalPersonSearchArchTest {
+
+    /**
+     * The global person search is an opt-in: only a {@link HasPersonSearch} controller gets the search box rendered
+     * into the page header. That opt-in is easy to forget when a new page is added, and a missing one is invisible
+     * until someone looks for the search box (see gh-6622).
+     *
+     * <p>
+     * A controller that renders a full page already opts into the launchpad, which sits in the very same header, so
+     * {@link HasLaunchpad} is the marker of "this controller renders a page" and both opt-ins belong together.
+     */
+    @ArchTest
+    void ensureControllersRenderingAPageOptIntoTheGlobalPersonSearch(JavaClasses classes) {
+
+        classes()
+            .that().areAnnotatedWith(Controller.class)
+            .and().implement(HasLaunchpad.class)
+            // csv download, no page is rendered
+            .and().doNotHaveFullyQualifiedName("org.synyx.urlaubsverwaltung.application.export.ApplicationForLeaveExportViewController")
+            // only redirects and turbo frame fragments of a page rendered elsewhere
+            .and().doNotHaveFullyQualifiedName("org.synyx.urlaubsverwaltung.person.web.PersonDeleteViewController")
+            // only redirects to the first settings page
+            .and().doNotHaveFullyQualifiedName("org.synyx.urlaubsverwaltung.settings.SettingsViewController")
+            .should().implement(HasPersonSearch.class)
+            .as("Controllers rendering a page must implement HasPersonSearch, otherwise their page has no global person search.")
+            .check(classes);
+    }
+}

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsViewControllerTest.java
@@ -1,6 +1,7 @@
 package org.synyx.urlaubsverwaltung.overtime.statistics;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -9,6 +10,8 @@ import org.springframework.context.support.StaticMessageSource;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.synyx.urlaubsverwaltung.search.PersonSearchUiFragmentSupplier;
+import org.synyx.urlaubsverwaltung.search.PersonSuggestionUrlStrategy;
 import org.synyx.urlaubsverwaltung.settings.Settings;
 import org.synyx.urlaubsverwaltung.settings.SettingsService;
 
@@ -44,6 +47,10 @@ class OvertimeStatisticsViewControllerTest {
     private OvertimeStatisticsService statisticsService;
     @Mock
     private SettingsService settingsService;
+    @Mock
+    private PersonSuggestionUrlStrategy defaultPersonSuggestionUrlStrategy;
+    @Mock
+    private PersonSearchUiFragmentSupplier personSearchUiFragmentSupplier;
 
     private final Clock clock = Clock.fixed(Instant.parse("2026-07-31T10:15:00Z"), UTC);
 
@@ -54,13 +61,28 @@ class OvertimeStatisticsViewControllerTest {
         messageSource.addMessage("minutes.abbr", GERMAN, "Min.");
         messageSource.addMessage("overtime.person.zero", GERMAN, "keine");
 
-        sut = new OvertimeStatisticsViewController(statisticsService, settingsService, messageSource, clock);
+        sut = new OvertimeStatisticsViewController(statisticsService, settingsService, messageSource,
+            defaultPersonSuggestionUrlStrategy, personSearchUiFragmentSupplier, clock);
 
         // most tests are about the selected year, so an empty company wide history is the default
         lenient().when(statisticsService.getTotals()).thenReturn(OvertimeTotals.empty());
         // every request also loads the previous year for the comparison curve
         lenient().when(statisticsService.getStatistics(any()))
             .thenAnswer(invocation -> OvertimeStatistics.empty(invocation.getArgument(0)));
+    }
+
+    @Nested
+    class PersonSearch {
+
+        @Test
+        void returnsInjectedFragmentSupplier() {
+            assertThat(sut.personSearchUiFragmentSupplier()).isSameAs(personSearchUiFragmentSupplier);
+        }
+
+        @Test
+        void returnsInjectedStrategy() {
+            assertThat(sut.personSuggestionUrlStrategy()).isSameAs(defaultPersonSuggestionUrlStrategy);
+        }
     }
 
     @Test


### PR DESCRIPTION
The search box is only rendered for controllers implementing HasPersonSearch. The overtime statistics page was built after the global search had been introduced and never got that opt-in, which made it the only controller rendering a page without a search box.

The page shows company wide figures and has no person rows of its own, therefore a suggestion links to the person overview - the same as on the absence statistics.

An ArchUnit rule now guards the opt-in. A controller carrying the launchpad renders a full page, and the launchpad sits in the very same header as the search, so both opt-ins belong together. The three controllers that only serve downloads, redirects or turbo frame fragments are excluded by name.

closes #6622

<!--

Thanks for contributing to the Urlaubsverwaltung.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please open a report of a security vulnerability via
[Report a security vulnerability](https://github.com/urlaubsverwaltung/urlaubsverwaltung/security/advisories/new)


# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
