### PR TITLE
Show the overtime statistics to department heads and second stage authorities

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/application/export/ApplicationForLeaveExportService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/export/ApplicationForLeaveExportService.java
@@ -151,6 +151,6 @@ class ApplicationForLeaveExportService {
             return personService.getActivePersons(pageRequest, pageableSearchQuery.getQuery());
         }
 
-        return departmentService.getManagedMembersOfPerson(person, pageRequest, pageableSearchQuery.getQuery());
+        return departmentService.getManagedActiveMembersOfPerson(person, pageRequest, pageableSearchQuery.getQuery());
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsServiceImpl.java
@@ -182,7 +182,7 @@ public class ApplicationForLeaveStatisticsServiceImpl implements ApplicationForL
         }
 
         if (person.isDepartmentPrivileged()) {
-            return departmentService.getManagedMembersOfPerson(person, pageRequest, query);
+            return departmentService.getManagedActiveMembersOfPerson(person, pageRequest, query);
         }
 
         return new PageImpl<>(List.of(person), pageRequest.toPageable(), 1);

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentMembership.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentMembership.java
@@ -28,6 +28,16 @@ public record DepartmentMembership(
     }
 
     /**
+     * Checks if the membership is still valid, which is the case when it has no end date. A membership that has
+     * ended is history: the person is not part of the department any more.
+     *
+     * @return {@code true} if the membership has not ended, {@code false} otherwise
+     */
+    public boolean isCurrent() {
+        return validTo.isEmpty();
+    }
+
+    /**
      * Checks if the membership is a management membership.
      *
      * @return {@code true} if the membership is a management membership, {@code false} otherwise

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentService.java
@@ -230,7 +230,7 @@ public interface DepartmentService {
      * @param query          query for firstname, lastname
      * @return all managed and active members for the person
      */
-    Page<Person> getManagedMembersOfPersonAndDepartment(Person person, Long departmentId, PersonPageable personPageable, String query);
+    Page<Person> getManagedActiveMembersOfPersonAndDepartment(Person person, Long departmentId, PersonPageable personPageable, String query);
 
     /**
      * Check the role of the given person and return a {@link Page} of all managed and inactive {@link Person}s for the

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentService.java
@@ -195,7 +195,7 @@ public interface DepartmentService {
      * @param query          query firstname, lastname
      * @return all managed and active members for the person
      */
-    Page<Person> getManagedMembersOfPerson(Person person, PersonPageable personPageable, String query);
+    Page<Person> getManagedActiveMembersOfPerson(Person person, PersonPageable personPageable, String query);
 
     /**
      * Check the role of the given person and return a {@link List} of all managed and active {@link Person}s.

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentService.java
@@ -173,6 +173,10 @@ public interface DepartmentService {
      * Members must have been added to the department in or before the given year.
      * (Requesting members for 2024 will not return members that were added in 2025.)
      *
+     * <p>
+     * Members must also still be part of the department. Somebody who was a member during the given year but has
+     * left the department since is not returned - the membership is over, so the person is not managed any more.
+     *
      * @param person person to get managed members for
      * @param year   to restrict the result set
      * @return empty list when person has no authority to manage other person, otherwise all managed members for the person

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentService.java
@@ -174,8 +174,10 @@ public interface DepartmentService {
      * (Requesting members for 2024 will not return members that were added in 2025.)
      *
      * <p>
-     * Members must also still be part of the department. Somebody who was a member during the given year but has
-     * left the department since is not returned - the membership is over, so the person is not managed any more.
+     * Both sides of the relationship must also still exist. A member who was part of the department during the given
+     * year but has left it since is not returned, and a department head or second stage authority who has handed a
+     * department over gets none of its members - not even for the years in which they led it. A membership that has
+     * ended is history and grants nothing.
      *
      * @param person person to get managed members for
      * @param year   to restrict the result set

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImpl.java
@@ -79,7 +79,7 @@ class DepartmentServiceImpl implements DepartmentService {
     public List<Person> getManagedMembersOfPerson(Person person, Year year) {
 
         final Map<PersonId, List<DepartmentMembership>> activeMembershipsOfYear = departmentMembershipService.getActiveMembershipsOfYear(year);
-        final Set<DepartmentMembership> onlyMembers = extractMemberMemberships(activeMembershipsOfYear);
+        final Set<DepartmentMembership> onlyMembers = extractCurrentMemberMemberships(activeMembershipsOfYear);
 
         if (onlyMembers.isEmpty()) {
             return List.of();
@@ -106,11 +106,17 @@ class DepartmentServiceImpl implements DepartmentService {
         return personService.getAllPersonsByIds(managedPersonIds);
     }
 
-    private static Set<DepartmentMembership> extractMemberMemberships(Map<PersonId, List<DepartmentMembership>> membershipsByPersonId) {
+    /**
+     * The memberships of everybody who was a member of a department in the given year and still is. A membership that
+     * has ended in the meantime is history and does not make somebody a managed member any more, even though the
+     * person was part of the department during that year.
+     */
+    private static Set<DepartmentMembership> extractCurrentMemberMemberships(Map<PersonId, List<DepartmentMembership>> membershipsByPersonId) {
         return membershipsByPersonId.values()
             .stream()
             .flatMap(Collection::stream)
-            .filter(m -> m.membershipKind().equals(DepartmentMembershipKind.MEMBER))
+            .filter(DepartmentMembership::isMemberMembership)
+            .filter(DepartmentMembership::isCurrent)
             .collect(toSet());
     }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImpl.java
@@ -143,8 +143,8 @@ class DepartmentServiceImpl implements DepartmentService {
     }
 
     @Override
-    public Page<Person> getManagedMembersOfPersonAndDepartment(Person person, Long departmentId, PersonPageable pageable, String query) {
-        final Predicate<Person> filter = nameContains(query).and(not(Person::isInactive));
+    public Page<Person> getManagedActiveMembersOfPersonAndDepartment(Person person, Long departmentId, PersonPageable pageable, String query) {
+        final Predicate<Person> filter = nameContains(query).and(Person::isActive);
         return managedMembersOfPersonAndDepartment(person, departmentId, pageable, filter);
     }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImpl.java
@@ -92,7 +92,9 @@ class DepartmentServiceImpl implements DepartmentService {
             managedPersonIds = onlyMembers.stream().map(DepartmentMembership::personId).collect(toSet());
         } else {
             // otherwise we have to collect departments where the person is a department head or second stage authority
-            final Set<Long> managedDepartmentIds = activeMembershipsOfYear.get(person.getIdAsPersonId()).stream()
+            // a manager can have no membership at all in the requested year - the year is a freely chosen request
+            // parameter, so this is a normal case and not a broken state
+            final Set<Long> managedDepartmentIds = activeMembershipsOfYear.getOrDefault(person.getIdAsPersonId(), List.of()).stream()
                 .filter(DepartmentMembership::isManagementMembership)
                 .map(DepartmentMembership::departmentId)
                 .collect(toSet());

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImpl.java
@@ -91,11 +91,14 @@ class DepartmentServiceImpl implements DepartmentService {
             // office or boss is allowed to manage all other persons
             managedPersonIds = onlyMembers.stream().map(DepartmentMembership::personId).collect(toSet());
         } else {
-            // otherwise we have to collect departments where the person is a department head or second stage authority
-            // a manager can have no membership at all in the requested year - the year is a freely chosen request
-            // parameter, so this is a normal case and not a broken state
+            // otherwise we have to collect the departments the person led in the given year and still leads - somebody
+            // who has handed a department over is not responsible for its members any more, not even for the years
+            // they led it.
+            // A manager can have no membership at all in the requested year - the year is a freely chosen request
+            // parameter, so this is a normal case and not a broken state.
             final Set<Long> managedDepartmentIds = activeMembershipsOfYear.getOrDefault(person.getIdAsPersonId(), List.of()).stream()
                 .filter(DepartmentMembership::isManagementMembership)
+                .filter(DepartmentMembership::isCurrent)
                 .map(DepartmentMembership::departmentId)
                 .collect(toSet());
             managedPersonIds = onlyMembers.stream()

--- a/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImpl.java
@@ -124,9 +124,9 @@ class DepartmentServiceImpl implements DepartmentService {
     }
 
     @Override
-    public Page<Person> getManagedMembersOfPerson(Person person, PersonPageable pageable, String query) {
+    public Page<Person> getManagedActiveMembersOfPerson(Person person, PersonPageable pageable, String query) {
         final PersonId personId = person.getIdAsPersonId();
-        return managedMembersOfPerson(personId, pageable, query, not(Person::isInactive));
+        return managedMembersOfPerson(personId, pageable, query, Person::isActive);
     }
 
     @Override

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimePermissionEvaluator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimePermissionEvaluator.java
@@ -6,7 +6,9 @@ import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.settings.SettingsService;
 
 import static org.synyx.urlaubsverwaltung.person.Role.BOSS;
+import static org.synyx.urlaubsverwaltung.person.Role.DEPARTMENT_HEAD;
 import static org.synyx.urlaubsverwaltung.person.Role.OFFICE;
+import static org.synyx.urlaubsverwaltung.person.Role.SECOND_STAGE_AUTHORITY;
 
 /**
  * Single source of truth for the question "who may interact with overtime?".
@@ -81,7 +83,7 @@ public class OvertimePermissionEvaluator {
     }
 
     /**
-     * Whether the given user may see the overtime of every person, which guards the company wide overtime statistics.
+     * Whether the given user may see the overtime of every person, no matter whether the user is responsible for them.
      *
      * @param signedInUser user asking for permissions
      * @return {@code true} if the user may see the overtime of all persons, {@code false} otherwise
@@ -89,6 +91,20 @@ public class OvertimePermissionEvaluator {
     public boolean isAllowedToViewOvertimeOfAllPersons(Person signedInUser) {
         return settingsService.getSettings().getOvertimeSettings().isOvertimeActive()
             && signedInUser.hasAnyRole(OFFICE, BOSS);
+    }
+
+    /**
+     * Whether the given user may see the overtime of any other person - either because the user is responsible for
+     * members or because the user may see the overtime of everyone. Guards the overtime statistics and its navigation
+     * entry; which persons the figures are aggregated over is decided when the statistics are loaded.
+     *
+     * @param signedInUser user asking for permissions
+     * @return {@code true} if the user may see the overtime of at least one other person, {@code false} otherwise
+     */
+    public boolean isAllowedToViewOvertimeOfOtherPersons(Person signedInUser) {
+        return isAllowedToViewOvertimeOfAllPersons(signedInUser)
+            || (settingsService.getSettings().getOvertimeSettings().isOvertimeActive()
+            && signedInUser.hasAnyRole(DEPARTMENT_HEAD, SECOND_STAGE_AUTHORITY));
     }
 
     /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimePermissionEvaluator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/OvertimePermissionEvaluator.java
@@ -102,9 +102,8 @@ public class OvertimePermissionEvaluator {
      * @return {@code true} if the user may see the overtime of at least one other person, {@code false} otherwise
      */
     public boolean isAllowedToViewOvertimeOfOtherPersons(Person signedInUser) {
-        return isAllowedToViewOvertimeOfAllPersons(signedInUser)
-            || (settingsService.getSettings().getOvertimeSettings().isOvertimeActive()
-            && signedInUser.hasAnyRole(DEPARTMENT_HEAD, SECOND_STAGE_AUTHORITY));
+        return settingsService.getSettings().getOvertimeSettings().isOvertimeActive()
+            && signedInUser.hasAnyRole(OFFICE, BOSS, DEPARTMENT_HEAD, SECOND_STAGE_AUTHORITY);
     }
 
     /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatistics.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatistics.java
@@ -10,7 +10,7 @@ import static java.time.Duration.ZERO;
 import static java.util.Collections.nCopies;
 
 /**
- * Company wide overtime figures of a single year, broken down by month.
+ * Overtime figures of a single year, broken down by month, aggregated over a set of persons.
  *
  * <p>
  * Accrual and reduction are kept apart on purpose: a month with ten hours accrued and ten hours reduced is not the

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsPersons.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsPersons.java
@@ -36,8 +36,8 @@ class OvertimeStatisticsPersons {
     /**
      * The persons of a single year. For office and boss everyone who had an account in that year, which keeps past
      * years stable: someone who left the company stays part of the years they worked in. A manager gets the members
-     * of the departments they were responsible for in that year, as far as those members are still part of the
-     * department - see {@link DepartmentService#getManagedMembersOfPerson(Person, Year)}.
+     * of the departments they were responsible for in that year and still are, as far as those members are still
+     * part of the department - see {@link DepartmentService#getManagedMembersOfPerson(Person, Year)}.
      *
      * @param signedInUser person requesting the statistics
      * @param year         year to resolve the persons for

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsPersons.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsPersons.java
@@ -34,10 +34,10 @@ class OvertimeStatisticsPersons {
     }
 
     /**
-     * The persons of a single year. Everyone who had an account in that year, respectively the members managed in that
-     * year - using the cohort of the year instead of the current one keeps past years stable: someone who left stays
-     * part of the years they worked in, and a manager keeps the members of the departments they were responsible for
-     * back then.
+     * The persons of a single year. For office and boss everyone who had an account in that year, which keeps past
+     * years stable: someone who left the company stays part of the years they worked in. A manager gets the members
+     * of the departments they were responsible for in that year, as far as those members are still part of the
+     * department - see {@link DepartmentService#getManagedMembersOfPerson(Person, Year)}.
      *
      * @param signedInUser person requesting the statistics
      * @param year         year to resolve the persons for

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsPersons.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsPersons.java
@@ -1,0 +1,79 @@
+package org.synyx.urlaubsverwaltung.overtime.statistics;
+
+import org.springframework.stereotype.Service;
+import org.synyx.urlaubsverwaltung.department.DepartmentService;
+import org.synyx.urlaubsverwaltung.person.Person;
+import org.synyx.urlaubsverwaltung.person.PersonService;
+import org.synyx.urlaubsverwaltung.person.Role;
+
+import java.time.Year;
+import java.util.List;
+
+import static org.synyx.urlaubsverwaltung.person.Role.BOSS;
+import static org.synyx.urlaubsverwaltung.person.Role.DEPARTMENT_HEAD;
+import static org.synyx.urlaubsverwaltung.person.Role.OFFICE;
+import static org.synyx.urlaubsverwaltung.person.Role.SECOND_STAGE_AUTHORITY;
+
+/**
+ * Resolves the persons that the overtime statistics are aggregated over, from the perspective of a signed-in person.
+ *
+ * <p>
+ * {@link Role#OFFICE} and {@link Role#BOSS} get everyone, {@link Role#DEPARTMENT_HEAD} and
+ * {@link Role#SECOND_STAGE_AUTHORITY} get the members they manage, everyone else gets nobody. Which of the two
+ * methods applies depends on the question a block of the page asks, not on the role.
+ */
+@Service
+class OvertimeStatisticsPersons {
+
+    private final PersonService personService;
+    private final DepartmentService departmentService;
+
+    OvertimeStatisticsPersons(PersonService personService, DepartmentService departmentService) {
+        this.personService = personService;
+        this.departmentService = departmentService;
+    }
+
+    /**
+     * The persons of a single year. Everyone who had an account in that year, respectively the members managed in that
+     * year - using the cohort of the year instead of the current one keeps past years stable: someone who left stays
+     * part of the years they worked in, and a manager keeps the members of the departments they were responsible for
+     * back then.
+     *
+     * @param signedInUser person requesting the statistics
+     * @param year         year to resolve the persons for
+     * @return persons relevant for the given year, empty if the signed-in person is responsible for nobody
+     */
+    List<Person> relevantPersonsOfYear(Person signedInUser, Year year) {
+
+        if (signedInUser.hasAnyRole(OFFICE, BOSS)) {
+            return personService.getAllPersonsHavingAccountInYear(year);
+        }
+
+        if (signedInUser.hasAnyRole(DEPARTMENT_HEAD, SECOND_STAGE_AUTHORITY)) {
+            return departmentService.getManagedMembersOfPerson(signedInUser, year);
+        }
+
+        return List.of();
+    }
+
+    /**
+     * The persons of the whole history, without any reference to a year. The persons currently employed, respectively
+     * the members currently managed - someone who left is not part of the overtime that is still open, which is
+     * exactly the question those figures answer.
+     *
+     * @param signedInUser person requesting the statistics
+     * @return persons relevant over the whole history, empty if the signed-in person is responsible for nobody
+     */
+    List<Person> relevantPersonsOfWholeHistory(Person signedInUser) {
+
+        if (signedInUser.hasAnyRole(OFFICE, BOSS)) {
+            return personService.getActivePersons();
+        }
+
+        if (signedInUser.hasAnyRole(DEPARTMENT_HEAD, SECOND_STAGE_AUTHORITY)) {
+            return departmentService.getManagedActiveMembersOfPerson(signedInUser);
+        }
+
+        return List.of();
+    }
+}

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsService.java
@@ -9,7 +9,6 @@ import org.synyx.urlaubsverwaltung.overtime.Overtime;
 import org.synyx.urlaubsverwaltung.overtime.OvertimeService;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonId;
-import org.synyx.urlaubsverwaltung.person.PersonService;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeCalendar;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeCalendarService;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeCalendarSupplier;
@@ -34,48 +33,49 @@ import static org.synyx.urlaubsverwaltung.application.vacationtype.VacationCateg
 import static org.synyx.urlaubsverwaltung.overtime.statistics.OvertimeStatistics.MONTHS_PER_YEAR;
 
 /**
- * Creates the company wide {@link OvertimeStatistics}.
+ * Creates the {@link OvertimeStatistics} of the persons a signed-in person is responsible for.
  */
 @Service
 @Transactional(readOnly = true)
 class OvertimeStatisticsService {
 
     private final OvertimeService overtimeService;
-    private final PersonService personService;
+    private final OvertimeStatisticsPersons overtimeStatisticsPersons;
     private final ApplicationService applicationService;
     private final WorkingTimeCalendarService workingTimeCalendarService;
 
     OvertimeStatisticsService(
         OvertimeService overtimeService,
-        PersonService personService,
+        OvertimeStatisticsPersons overtimeStatisticsPersons,
         ApplicationService applicationService,
         WorkingTimeCalendarService workingTimeCalendarService
     ) {
         this.overtimeService = overtimeService;
-        this.personService = personService;
+        this.overtimeStatisticsPersons = overtimeStatisticsPersons;
         this.applicationService = applicationService;
         this.workingTimeCalendarService = workingTimeCalendarService;
     }
 
     /**
-     * Creates the company wide overtime figures of the given year.
+     * Creates the overtime figures of the given year for everyone the signed-in person is responsible for.
      *
      * <p>
-     * Aggregated over everyone who had an account in that year. Using the cohort of the year instead of the currently
-     * active persons keeps past years stable: someone who left stays part of the years they worked in, and drops out
-     * of the years afterwards.
+     * Aggregated over the persons {@link OvertimeStatisticsPersons#relevantPersonsOfYear(Person, Year)} resolves -
+     * the cohort of the year, not the currently active persons, which keeps past years stable: someone who left stays
+     * part of the years they worked in, and drops out of the years afterwards.
      *
      * <p>
      * Reduction covers both ways it can happen in this application: a negative overtime record and an application of
-     * category overtime. Leaving the applications out would make the company balance disagree with what every person
-     * sees as their own remaining overtime.
+     * category overtime. Leaving the applications out would make the balance disagree with what every person sees as
+     * their own remaining overtime.
      *
-     * @param year to create the statistics for
-     * @return company wide overtime figures of the given year
+     * @param year         to create the statistics for
+     * @param signedInUser person requesting the statistics
+     * @return overtime figures of the given year, all zero when the signed-in person is responsible for nobody
      */
-    public OvertimeStatistics getStatistics(Year year) {
+    public OvertimeStatistics getStatistics(Year year, Person signedInUser) {
 
-        final List<Person> persons = personService.getAllPersonsHavingAccountInYear(year);
+        final List<Person> persons = overtimeStatisticsPersons.relevantPersonsOfYear(signedInUser, year);
         if (persons.isEmpty()) {
             return OvertimeStatistics.empty(year);
         }
@@ -90,21 +90,24 @@ class OvertimeStatisticsService {
     }
 
     /**
-     * Creates the company wide overtime figures over the whole history, without any reference to a year.
+     * Creates the overtime figures over the whole history, without any reference to a year, for everyone the
+     * signed-in person is responsible for.
      *
      * <p>
-     * Aggregated over the persons currently employed. Someone who left is not part of the overtime the company still
-     * has open, which is exactly the question these figures answer.
+     * Aggregated over the persons {@link OvertimeStatisticsPersons#relevantPersonsOfWholeHistory(Person)} resolves.
+     * Someone who left is not part of the overtime that is still open, which is exactly the question these figures
+     * answer.
      *
      * <p>
      * Without a date boundary nothing has to be spread pro rata, so this needs neither the monthly split nor the
      * working time calendars - the reduction of an application counts as a whole, no matter which year it falls into.
      *
-     * @return company wide overtime figures over the whole history
+     * @param signedInUser person requesting the statistics
+     * @return overtime figures over the whole history, all zero when the signed-in person is responsible for nobody
      */
-    public OvertimeTotals getTotals() {
+    public OvertimeTotals getTotals(Person signedInUser) {
 
-        final List<Person> persons = personService.getActivePersons();
+        final List<Person> persons = overtimeStatisticsPersons.relevantPersonsOfWholeHistory(signedInUser);
         if (persons.isEmpty()) {
             return OvertimeTotals.empty();
         }

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsViewController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.server.ResponseStatusException;
+import org.synyx.urlaubsverwaltung.person.Person;
+import org.synyx.urlaubsverwaltung.person.PersonService;
 import org.synyx.urlaubsverwaltung.search.HasPersonSearch;
 import org.synyx.urlaubsverwaltung.search.PersonSearchUiFragmentSupplier;
 import org.synyx.urlaubsverwaltung.search.PersonSuggestionUrlStrategy;
@@ -42,6 +44,7 @@ class OvertimeStatisticsViewController implements HasLaunchpad, HasPersonSearch 
     private static final int DECIMAL_HOUR_SCALE = 2;
 
     private final OvertimeStatisticsService overtimeStatisticsService;
+    private final PersonService personService;
     private final SettingsService settingsService;
     private final MessageSource messageSource;
     private final PersonSuggestionUrlStrategy defaultPersonSuggestionUrlStrategy;
@@ -50,6 +53,7 @@ class OvertimeStatisticsViewController implements HasLaunchpad, HasPersonSearch 
 
     OvertimeStatisticsViewController(
         OvertimeStatisticsService overtimeStatisticsService,
+        PersonService personService,
         SettingsService settingsService,
         MessageSource messageSource,
         PersonSuggestionUrlStrategy defaultPersonSuggestionUrlStrategy,
@@ -57,6 +61,7 @@ class OvertimeStatisticsViewController implements HasLaunchpad, HasPersonSearch 
         Clock clock
     ) {
         this.overtimeStatisticsService = overtimeStatisticsService;
+        this.personService = personService;
         this.settingsService = settingsService;
         this.messageSource = messageSource;
         this.defaultPersonSuggestionUrlStrategy = defaultPersonSuggestionUrlStrategy;
@@ -92,9 +97,11 @@ class OvertimeStatisticsViewController implements HasLaunchpad, HasPersonSearch 
         final Year currentYear = Year.now(clock);
         final Year selectedYear = requestedYear.flatMap(OvertimeStatisticsViewController::toYear).orElse(currentYear);
 
-        final OvertimeStatistics statistics = overtimeStatisticsService.getStatistics(selectedYear);
+        final Person signedInUser = personService.getSignedInUser();
 
-        final OvertimeStatistics previousStatistics = overtimeStatisticsService.getStatistics(selectedYear.minusYears(1));
+        final OvertimeStatistics statistics = overtimeStatisticsService.getStatistics(selectedYear, signedInUser);
+
+        final OvertimeStatistics previousStatistics = overtimeStatisticsService.getStatistics(selectedYear.minusYears(1), signedInUser);
 
         model.addAttribute("selectedYear", selectedYear.getValue());
         model.addAttribute("currentYear", currentYear.getValue());
@@ -105,7 +112,7 @@ class OvertimeStatisticsViewController implements HasLaunchpad, HasPersonSearch 
         model.addAttribute("overtimeBalanceGraph", toBalanceGraphDto(statistics, previousStatistics, locale));
 
         // deliberately without the selected year, these figures cover the whole history
-        final OvertimeTotals totals = overtimeStatisticsService.getTotals();
+        final OvertimeTotals totals = overtimeStatisticsService.getTotals(signedInUser);
         model.addAttribute("overtimeTotals", toTotalsDto(totals, locale));
 
         return "overtime/overtime_statistics";
@@ -252,8 +259,8 @@ class OvertimeStatisticsViewController implements HasLaunchpad, HasPersonSearch 
      * Figures over the whole history, formatted for humans.
      *
      * <p>
-     * These are shown above the year selector and do not react to it. The balance is the overtime the company still
-     * has open, which is the same figure every person sees as their own remaining overtime, summed up.
+     * These are shown above the year selector and do not react to it. The balance is the overtime that is still
+     * open, which is the same figure every person sees as their own remaining overtime, summed up.
      *
      * @param accrued   accrued overtime over the whole history
      * @param reduction reduced overtime over the whole history, without sign

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsViewController.java
@@ -30,14 +30,16 @@ import java.util.Optional;
 
 import static java.math.RoundingMode.HALF_UP;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static org.synyx.urlaubsverwaltung.security.SecurityRules.IS_BOSS_OR_OFFICE;
+import static org.synyx.urlaubsverwaltung.security.SecurityRules.IS_PRIVILEGED_USER;
 
 /**
- * Controller for the company wide overtime statistics.
+ * Controller for the overtime statistics. Office and boss see the figures of everyone, a department head or second
+ * stage authority the figures of the members they manage - which persons that are is decided by
+ * {@link OvertimeStatisticsPersons}, the page itself looks the same for everyone.
  */
 @Controller
 @RequestMapping("/web/overtime/statistics")
-@PreAuthorize(IS_BOSS_OR_OFFICE)
+@PreAuthorize(IS_PRIVILEGED_USER)
 class OvertimeStatisticsViewController implements HasLaunchpad, HasPersonSearch {
 
     private static final int MINUTES_PER_HOUR = 60;
@@ -70,7 +72,7 @@ class OvertimeStatisticsViewController implements HasLaunchpad, HasPersonSearch 
     }
 
     /**
-     * The page shows company wide figures and has no rows of its own a suggestion could point at, therefore a
+     * The page shows aggregated figures and has no rows of its own a suggestion could point at, therefore a
      * suggestion links to the person overview like on every other page without person rows.
      */
     @Override

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeTotals.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeTotals.java
@@ -8,8 +8,8 @@ import static java.time.Duration.ZERO;
  * Overtime figures over the whole history, without any reference to a year, aggregated over a set of persons.
  *
  * <p>
- * The balance answers "how much overtime is still open right now" and is by construction the same figure
- * every person sees as their own remaining overtime, summed up.
+ * The balance answers "how much overtime is still open right now" and is by construction the same figure every
+ * person sees as their own remaining overtime, summed up.
  *
  * @param accrued   accrued overtime over the whole history, never negative
  * @param reduction reduced overtime over the whole history, given as a positive amount

--- a/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeTotals.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeTotals.java
@@ -5,10 +5,10 @@ import java.time.Duration;
 import static java.time.Duration.ZERO;
 
 /**
- * Company wide overtime figures over the whole history, without any reference to a year.
+ * Overtime figures over the whole history, without any reference to a year, aggregated over a set of persons.
  *
  * <p>
- * The balance answers "how much overtime does the company have open right now" and is by construction the same figure
+ * The balance answers "how much overtime is still open right now" and is by construction the same figure
  * every person sees as their own remaining overtime, summed up.
  *
  * @param accrued   accrued overtime over the whole history, never negative

--- a/src/main/java/org/synyx/urlaubsverwaltung/person/web/PersonsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/person/web/PersonsViewController.java
@@ -148,7 +148,7 @@ public class PersonsViewController implements HasLaunchpad, HasPersonSearch {
             if (departmentService.isPersonAllowedToManageDepartment(signedInUser, department)) {
                 model.addAttribute("department", department);
                 personPage = active
-                    ? departmentService.getManagedMembersOfPersonAndDepartment(signedInUser, departmentId, personPageRequest, query)
+                    ? departmentService.getManagedActiveMembersOfPersonAndDepartment(signedInUser, departmentId, personPageRequest, query)
                     : departmentService.getManagedInactiveMembersOfPersonAndDepartment(signedInUser, departmentId, personPageRequest, query);
             }
         }

--- a/src/main/java/org/synyx/urlaubsverwaltung/person/web/PersonsViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/person/web/PersonsViewController.java
@@ -210,7 +210,7 @@ public class PersonsViewController implements HasLaunchpad, HasPersonSearch {
         if (signedInUser.hasRole(BOSS) || signedInUser.hasRole(OFFICE)) {
             return personService.getActivePersons(personPageRequest, query);
         } else {
-            return departmentService.getManagedMembersOfPerson(signedInUser, personPageRequest, query);
+            return departmentService.getManagedActiveMembersOfPerson(signedInUser, personPageRequest, query);
         }
     }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/search/PersonSearchSuggestionsProvider.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/search/PersonSearchSuggestionsProvider.java
@@ -63,7 +63,7 @@ class PersonSearchSuggestionsProvider {
         }
 
         if (person.isDepartmentPrivileged()) {
-            return departmentService.getManagedMembersOfPerson(person, pageRequest, query);
+            return departmentService.getManagedActiveMembersOfPerson(person, pageRequest, query);
         }
 
         return new PageImpl<>(List.of(person), pageRequest.toPageable(), 1);

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sickdays/SickDaysStatisticsService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sickdays/SickDaysStatisticsService.java
@@ -119,6 +119,6 @@ public class SickDaysStatisticsService {
             return personService.getActivePersons(pageRequest, pageableSearchQuery.getQuery());
         }
 
-        return departmentService.getManagedMembersOfPerson(person, pageRequest, pageableSearchQuery.getQuery());
+        return departmentService.getManagedActiveMembersOfPerson(person, pageRequest, pageableSearchQuery.getQuery());
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/web/FrameDataProvider.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/web/FrameDataProvider.java
@@ -216,7 +216,7 @@ public class FrameDataProvider implements DataProviderInterface {
             )));
         }
 
-        final boolean canViewOvertimes = overtimePermissionEvaluator.isAllowedToViewOvertimeOfAllPersons(user);
+        final boolean canViewOvertimes = overtimePermissionEvaluator.isAllowedToViewOvertimeOfOtherPersons(user);
         if (canViewOvertimes) {
             final String overtimeStatistics = "/web/overtime/statistics";
             elements.add(new NavigationItemDto("company-overtime-link", overtimeStatistics, "nav.company.overtimes", "clock-arrow-up", url.equals(overtimeStatistics)));

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/export/ApplicationForLeaveExportServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/export/ApplicationForLeaveExportServiceTest.java
@@ -126,7 +126,7 @@ class ApplicationForLeaveExportServiceTest {
         final List<Person> personsForExport = List.of(departmentMember);
 
         final PersonPageRequest personPageRequest = PersonPageRequest.of(0, 10);
-        when(departmentService.getManagedMembersOfPerson(person, personPageRequest, ""))
+        when(departmentService.getManagedActiveMembersOfPerson(person, personPageRequest, ""))
             .thenReturn(new PageImpl<>(List.of(departmentMember)));
 
         final LocalDate from = LocalDate.of(2023, JANUARY, 1);
@@ -161,7 +161,7 @@ class ApplicationForLeaveExportServiceTest {
         person.setPermissions(List.of(USER));
 
         final PersonPageRequest personPageRequest = PersonPageRequest.of(0, 10, Sort.unsorted());
-        when(departmentService.getManagedMembersOfPerson(person, personPageRequest, ""))
+        when(departmentService.getManagedActiveMembersOfPerson(person, personPageRequest, ""))
             .thenReturn(new PageImpl<>(List.of()));
 
         final PageableSearchQuery personSearchQuery = new PageableSearchQuery(PageRequest.of(0, 10), "");

--- a/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/application/statistics/ApplicationForLeaveStatisticsServiceImplTest.java
@@ -122,7 +122,7 @@ class ApplicationForLeaveStatisticsServiceImplTest {
             member.setPermissions(List.of(USER));
 
             final PersonPageRequest personPageRequest = PersonPageRequest.of(0, 10, Sort.by("firstName"));
-            when(departmentService.getManagedMembersOfPerson(personRequestingStatistics, personPageRequest, ""))
+            when(departmentService.getManagedActiveMembersOfPerson(personRequestingStatistics, personPageRequest, ""))
                 .thenReturn(new PageImpl<>(List.of(member)));
 
             final VacationType<?> vacationType = ProvidedVacationType.builder(new StaticMessageSource()).build();
@@ -432,7 +432,7 @@ class ApplicationForLeaveStatisticsServiceImplTest {
             departmentMemberTwo.setPermissions(List.of(USER));
             departmentMemberTwo.setFirstName("Bernd");
 
-            when(departmentService.getManagedMembersOfPerson(eq(departmentManagement), any(PersonPageRequest.PersonPageRequestUnpaged.class), eq("")))
+            when(departmentService.getManagedActiveMembersOfPerson(eq(departmentManagement), any(PersonPageRequest.PersonPageRequestUnpaged.class), eq("")))
                 // note different sorting of persons to requested statistics sorting
                 // departmentMember must be second in the expected result
                 .thenReturn(new PageImpl<>(List.of(departmentMember, departmentMemberTwo)));

--- a/src/test/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImplTest.java
@@ -180,6 +180,106 @@ class DepartmentServiceImplTest {
         }
 
         @Test
+        void ensureGetManagedMembersOfPersonYearExcludesMembersThatHaveLeftTheDepartment() {
+
+            final PersonId departmentHeadId = new PersonId(1L);
+            final Person departmentHead = new Person();
+            departmentHead.setId(departmentHeadId.value());
+            departmentHead.setPermissions(List.of(USER, DEPARTMENT_HEAD));
+
+            final PersonId stillMemberId = new PersonId(2L);
+            final Person stillMember = new Person();
+            stillMember.setId(stillMemberId.value());
+
+            final PersonId leftMemberId = new PersonId(3L);
+
+            final Year lastYear = Year.now(clock).minusYears(1);
+            final Instant joinedLastYear = lastYear.atDay(42).atStartOfDay().toInstant(UTC);
+            final Instant leftLastYear = lastYear.atDay(300).atStartOfDay().toInstant(UTC);
+
+            when(departmentMembershipService.getActiveMembershipsOfYear(lastYear))
+                .thenReturn(Map.of(
+                    departmentHeadId, List.of(
+                        new DepartmentMembership(departmentHeadId, 1L, DepartmentMembershipKind.DEPARTMENT_HEAD, joinedLastYear)
+                    ),
+                    stillMemberId, List.of(
+                        new DepartmentMembership(stillMemberId, 1L, DepartmentMembershipKind.MEMBER, joinedLastYear)
+                    ),
+                    // was a member during the year, but the membership has ended in the meantime
+                    leftMemberId, List.of(
+                        new DepartmentMembership(leftMemberId, 1L, DepartmentMembershipKind.MEMBER, joinedLastYear, Optional.of(leftLastYear))
+                    )
+                ));
+
+            when(personService.getAllPersonsByIds(Set.of(stillMemberId))).thenReturn(List.of(stillMember));
+
+            final List<Person> actual = sut.getManagedMembersOfPerson(departmentHead, lastYear);
+            assertThat(actual).containsExactly(stillMember);
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Role.class, names = {"BOSS", "OFFICE"}, mode = INCLUDE)
+        void ensureGetManagedMembersOfPersonYearExcludesMembersThatHaveLeftTheDepartmentFor(Role role) {
+
+            final Person bossOrOfficePerson = new Person();
+            bossOrOfficePerson.setId(1L);
+            bossOrOfficePerson.setPermissions(List.of(USER, role));
+
+            final PersonId stillMemberId = new PersonId(2L);
+            final Person stillMember = new Person();
+            stillMember.setId(stillMemberId.value());
+
+            final PersonId leftMemberId = new PersonId(3L);
+
+            final Year lastYear = Year.now(clock).minusYears(1);
+            final Instant joinedLastYear = lastYear.atDay(42).atStartOfDay().toInstant(UTC);
+            final Instant leftLastYear = lastYear.atDay(300).atStartOfDay().toInstant(UTC);
+
+            when(departmentMembershipService.getActiveMembershipsOfYear(lastYear))
+                .thenReturn(Map.of(
+                    stillMemberId, List.of(
+                        new DepartmentMembership(stillMemberId, 1L, DepartmentMembershipKind.MEMBER, joinedLastYear)
+                    ),
+                    leftMemberId, List.of(
+                        new DepartmentMembership(leftMemberId, 1L, DepartmentMembershipKind.MEMBER, joinedLastYear, Optional.of(leftLastYear))
+                    )
+                ));
+
+            when(personService.getAllPersonsByIds(Set.of(stillMemberId))).thenReturn(List.of(stillMember));
+
+            final List<Person> actual = sut.getManagedMembersOfPerson(bossOrOfficePerson, lastYear);
+            assertThat(actual).containsExactly(stillMember);
+        }
+
+        @Test
+        void ensureGetManagedMembersOfPersonYearIsEmptyWhenEveryMemberHasLeftTheDepartment() {
+
+            final PersonId departmentHeadId = new PersonId(1L);
+            final Person departmentHead = new Person();
+            departmentHead.setId(departmentHeadId.value());
+            departmentHead.setPermissions(List.of(USER, DEPARTMENT_HEAD));
+
+            final PersonId leftMemberId = new PersonId(3L);
+
+            final Year lastYear = Year.now(clock).minusYears(1);
+            final Instant joinedLastYear = lastYear.atDay(42).atStartOfDay().toInstant(UTC);
+            final Instant leftLastYear = lastYear.atDay(300).atStartOfDay().toInstant(UTC);
+
+            when(departmentMembershipService.getActiveMembershipsOfYear(lastYear))
+                .thenReturn(Map.of(
+                    departmentHeadId, List.of(
+                        new DepartmentMembership(departmentHeadId, 1L, DepartmentMembershipKind.DEPARTMENT_HEAD, joinedLastYear)
+                    ),
+                    leftMemberId, List.of(
+                        new DepartmentMembership(leftMemberId, 1L, DepartmentMembershipKind.MEMBER, joinedLastYear, Optional.of(leftLastYear))
+                    )
+                ));
+
+            final List<Person> actual = sut.getManagedMembersOfPerson(departmentHead, lastYear);
+            assertThat(actual).isEmpty();
+        }
+
+        @Test
         void ensureGetManagedMembersOfPersonYearIsEmptyForManagerWithoutMembershipInThatYear() {
 
             final PersonId departmentHeadId = new PersonId(1L);

--- a/src/test/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImplTest.java
@@ -532,7 +532,7 @@ class DepartmentServiceImplTest {
         when(personService.getAllPersonsByIds(Set.of(janeId, maxId, inactivePersonId)))
             .thenReturn(List.of(jane, max, inactivePerson));
 
-        final Page<Person> actual = sut.getManagedMembersOfPerson(person, defaultPersonPageable(), "");
+        final Page<Person> actual = sut.getManagedActiveMembersOfPerson(person, defaultPersonPageable(), "");
         assertThat(actual.getContent()).containsExactly(jane, max);
     }
 
@@ -596,7 +596,7 @@ class DepartmentServiceImplTest {
         when(personService.getAllPersonsByIds(Set.of(janeId, maxId, inactivePersonId)))
             .thenReturn(List.of(jane, max, inactivePerson));
 
-        final Page<Person> actual = sut.getManagedMembersOfPerson(person, defaultPersonPageable(), "");
+        final Page<Person> actual = sut.getManagedActiveMembersOfPerson(person, defaultPersonPageable(), "");
         assertThat(actual.getContent()).containsExactly(jane, max);
     }
 
@@ -660,7 +660,7 @@ class DepartmentServiceImplTest {
         when(personService.getAllPersonsByIds(Set.of(janeId, maxId, inactivePersonId)))
             .thenReturn(List.of(jane, max, inactivePerson));
 
-        final Page<Person> actual = sut.getManagedMembersOfPerson(person, defaultPersonPageable(), "");
+        final Page<Person> actual = sut.getManagedActiveMembersOfPerson(person, defaultPersonPageable(), "");
         assertThat(actual.getContent()).containsExactly(jane, max);
     }
 
@@ -671,7 +671,7 @@ class DepartmentServiceImplTest {
         person.setId(1L);
         person.setPermissions(List.of());
 
-        final Page<Person> actual = sut.getManagedMembersOfPerson(person, defaultPersonPageable(), "");
+        final Page<Person> actual = sut.getManagedActiveMembersOfPerson(person, defaultPersonPageable(), "");
 
         assertThat(actual.getContent()).isEmpty();
         verifyNoInteractions(departmentRepository);
@@ -1126,7 +1126,7 @@ class DepartmentServiceImplTest {
         final PersonPageRequest personPageRequest = PersonPageRequest.of(1, 2,
             Sort.by("lastName").and(Sort.by("firstName")));
 
-        final Page<Person> actual = sut.getManagedMembersOfPerson(person, personPageRequest, "");
+        final Page<Person> actual = sut.getManagedActiveMembersOfPerson(person, personPageRequest, "");
         assertThat(actual.getTotalPages()).isEqualTo(2);
         assertThat(actual.getPageable().getPageNumber()).isEqualTo(1);
         assertThat(actual.getContent()).containsExactly(max);

--- a/src/test/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImplTest.java
@@ -180,6 +180,77 @@ class DepartmentServiceImplTest {
         }
 
         @Test
+        void ensureGetManagedMembersOfPersonYearIsEmptyWhenTheManagementMembershipHasEnded() {
+
+            final PersonId departmentHeadId = new PersonId(1L);
+            final Person departmentHead = new Person();
+            departmentHead.setId(departmentHeadId.value());
+            departmentHead.setPermissions(List.of(USER, DEPARTMENT_HEAD));
+
+            final PersonId memberId = new PersonId(2L);
+
+            final Year lastYear = Year.now(clock).minusYears(1);
+            final Instant joinedLastYear = lastYear.atDay(42).atStartOfDay().toInstant(UTC);
+            final Instant leftLastYear = lastYear.atDay(300).atStartOfDay().toInstant(UTC);
+
+            when(departmentMembershipService.getActiveMembershipsOfYear(lastYear))
+                .thenReturn(Map.of(
+                    // led the department during the year, but does not lead it any more
+                    departmentHeadId, List.of(
+                        new DepartmentMembership(departmentHeadId, 1L, DepartmentMembershipKind.DEPARTMENT_HEAD, joinedLastYear, Optional.of(leftLastYear))
+                    ),
+                    // the member is still part of the department, the manager is just not responsible for them any more
+                    memberId, List.of(
+                        new DepartmentMembership(memberId, 1L, DepartmentMembershipKind.MEMBER, joinedLastYear)
+                    )
+                ));
+
+            final List<Person> actual = sut.getManagedMembersOfPerson(departmentHead, lastYear);
+            assertThat(actual).isEmpty();
+            // pins that no person is asked for at all - an unstubbed mock would return an empty list either way
+            verify(personService).getAllPersonsByIds(Set.of());
+        }
+
+        @Test
+        void ensureGetManagedMembersOfPersonYearOnlyCoversDepartmentsTheManagerStillManages() {
+
+            final PersonId secondStageId = new PersonId(1L);
+            final Person secondStageAuthority = new Person();
+            secondStageAuthority.setId(secondStageId.value());
+            secondStageAuthority.setPermissions(List.of(USER, SECOND_STAGE_AUTHORITY));
+
+            final PersonId stillManagedId = new PersonId(2L);
+            final Person stillManaged = new Person();
+            stillManaged.setId(stillManagedId.value());
+
+            final PersonId formerlyManagedId = new PersonId(3L);
+
+            final Year lastYear = Year.now(clock).minusYears(1);
+            final Instant joinedLastYear = lastYear.atDay(42).atStartOfDay().toInstant(UTC);
+            final Instant leftLastYear = lastYear.atDay(300).atStartOfDay().toInstant(UTC);
+
+            when(departmentMembershipService.getActiveMembershipsOfYear(lastYear))
+                .thenReturn(Map.of(
+                    secondStageId, List.of(
+                        // still responsible for department 1, no longer for department 2
+                        new DepartmentMembership(secondStageId, 1L, DepartmentMembershipKind.SECOND_STAGE_AUTHORITY, joinedLastYear),
+                        new DepartmentMembership(secondStageId, 2L, DepartmentMembershipKind.SECOND_STAGE_AUTHORITY, joinedLastYear, Optional.of(leftLastYear))
+                    ),
+                    stillManagedId, List.of(
+                        new DepartmentMembership(stillManagedId, 1L, DepartmentMembershipKind.MEMBER, joinedLastYear)
+                    ),
+                    formerlyManagedId, List.of(
+                        new DepartmentMembership(formerlyManagedId, 2L, DepartmentMembershipKind.MEMBER, joinedLastYear)
+                    )
+                ));
+
+            when(personService.getAllPersonsByIds(Set.of(stillManagedId))).thenReturn(List.of(stillManaged));
+
+            final List<Person> actual = sut.getManagedMembersOfPerson(secondStageAuthority, lastYear);
+            assertThat(actual).containsExactly(stillManaged);
+        }
+
+        @Test
         void ensureGetManagedMembersOfPersonYearExcludesMembersThatHaveLeftTheDepartment() {
 
             final PersonId departmentHeadId = new PersonId(1L);
@@ -277,6 +348,8 @@ class DepartmentServiceImplTest {
 
             final List<Person> actual = sut.getManagedMembersOfPerson(departmentHead, lastYear);
             assertThat(actual).isEmpty();
+            // pins the early return - an unstubbed mock would return an empty list either way
+            verifyNoInteractions(personService);
         }
 
         @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImplTest.java
@@ -1216,7 +1216,7 @@ class DepartmentServiceImplTest {
         when(personService.getAllPersonsByIds(Set.of(memberId, inactiveId))).thenReturn(List.of(member, inactive));
 
         final PersonPageRequest personPageRequest = PersonPageRequest.of(0, 10);
-        final Page<Person> actual = sut.getManagedMembersOfPersonAndDepartment(person, 1L, personPageRequest, "");
+        final Page<Person> actual = sut.getManagedActiveMembersOfPersonAndDepartment(person, 1L, personPageRequest, "");
 
         assertThat(actual.getTotalPages()).isEqualTo(1);
         assertThat(actual.getPageable().getPageNumber()).isZero();
@@ -1383,7 +1383,7 @@ class DepartmentServiceImplTest {
         final PersonPageRequest personPageRequest = PersonPageRequest.of(1, 2,
             Sort.by("lastName").and(Sort.by("firstName")));
 
-        final Page<Person> actual = sut.getManagedMembersOfPersonAndDepartment(person, 1L, personPageRequest, "");
+        final Page<Person> actual = sut.getManagedActiveMembersOfPersonAndDepartment(person, 1L, personPageRequest, "");
 
         assertThat(actual.getTotalPages()).isEqualTo(2);
         assertThat(actual.getPageable().getPageNumber()).isEqualTo(1);
@@ -1418,7 +1418,7 @@ class DepartmentServiceImplTest {
         when(departmentMembershipService.getDepartmentStaff(1L)).thenReturn(staff);
 
         final PersonPageRequest personPageRequest = PersonPageRequest.of(1, 10);
-        final Page<Person> actual = sut.getManagedMembersOfPersonAndDepartment(person, 1L, personPageRequest, "");
+        final Page<Person> actual = sut.getManagedActiveMembersOfPersonAndDepartment(person, 1L, personPageRequest, "");
 
         // membership is missing (neither department head nor second stage authority)
         assertThat(actual).isEqualTo(Page.empty());
@@ -1492,7 +1492,7 @@ class DepartmentServiceImplTest {
             .thenReturn(List.of(max, inactive));
 
         final PersonPageRequest personPageRequest = PersonPageRequest.of(0, 10);
-        final Page<Person> actual = sut.getManagedMembersOfPersonAndDepartment(person, 1L, personPageRequest, "");
+        final Page<Person> actual = sut.getManagedActiveMembersOfPersonAndDepartment(person, 1L, personPageRequest, "");
 
         assertThat(actual.getTotalPages()).isEqualTo(1);
         assertThat(actual.getPageable().getPageNumber()).isZero();
@@ -1529,7 +1529,7 @@ class DepartmentServiceImplTest {
             .thenReturn(List.of(max, inactive));
 
         final PersonPageRequest personPageRequest = PersonPageRequest.of(0, 10);
-        final Page<Person> actual = sut.getManagedMembersOfPersonAndDepartment(person, 1L, personPageRequest, "");
+        final Page<Person> actual = sut.getManagedActiveMembersOfPersonAndDepartment(person, 1L, personPageRequest, "");
 
         assertThat(actual.getTotalPages()).isEqualTo(1);
         assertThat(actual.getPageable().getPageNumber()).isZero();
@@ -1557,7 +1557,7 @@ class DepartmentServiceImplTest {
         when(departmentMembershipService.getDepartmentStaff(1L)).thenReturn(staff);
 
         final PersonPageRequest personPageRequest = PersonPageRequest.of(0, 10);
-        final Page<Person> actual = sut.getManagedMembersOfPersonAndDepartment(person, 1L, personPageRequest, "");
+        final Page<Person> actual = sut.getManagedActiveMembersOfPersonAndDepartment(person, 1L, personPageRequest, "");
 
         assertThat(actual).isEqualTo(Page.empty());
         verifyNoInteractions(personService);

--- a/src/test/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/department/DepartmentServiceImplTest.java
@@ -180,6 +180,32 @@ class DepartmentServiceImplTest {
         }
 
         @Test
+        void ensureGetManagedMembersOfPersonYearIsEmptyForManagerWithoutMembershipInThatYear() {
+
+            final PersonId departmentHeadId = new PersonId(1L);
+            final Person departmentHead = new Person();
+            departmentHead.setId(departmentHeadId.value());
+            departmentHead.setPermissions(List.of(USER, DEPARTMENT_HEAD));
+
+            final PersonId personId2 = new PersonId(2L);
+
+            final Year lastYear = Year.now(clock).minusYears(1);
+            final Instant joinedLastYear = lastYear.atDay(42).atStartOfDay().toInstant(UTC);
+
+            // somebody is a member of a department, but the department head has no membership of that year at all -
+            // reachable via the year selector for any year before the manager joined
+            when(departmentMembershipService.getActiveMembershipsOfYear(lastYear))
+                .thenReturn(Map.of(
+                    personId2, List.of(
+                        new DepartmentMembership(personId2, 1L, DepartmentMembershipKind.MEMBER, joinedLastYear)
+                    )
+                ));
+
+            final List<Person> actual = sut.getManagedMembersOfPerson(departmentHead, lastYear);
+            assertThat(actual).isEmpty();
+        }
+
+        @Test
         void ensureGetManagedMembersOfPersonYearForSecondStageAuthority() {
 
             final PersonId secondStageId = new PersonId(1L);

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimePermissionEvaluatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/OvertimePermissionEvaluatorTest.java
@@ -354,6 +354,30 @@ class OvertimePermissionEvaluatorTest {
     }
 
     @Nested
+    class ViewOvertimeOfOtherPersons {
+
+        @ParameterizedTest
+        @EnumSource(value = Role.class, names = {"OFFICE", "BOSS", "DEPARTMENT_HEAD", "SECOND_STAGE_AUTHORITY"})
+        void ensurePrivilegedMayViewOvertimeOfOtherPersons(Role role) {
+            settings(true, false, false);
+            assertThat(sut.isAllowedToViewOvertimeOfOtherPersons(person(SIGNED_IN_USER_ID, USER, role))).isTrue();
+        }
+
+        @Test
+        void ensureUserMayNotViewOvertimeOfOtherPersons() {
+            settings(true, false, false);
+            assertThat(sut.isAllowedToViewOvertimeOfOtherPersons(person(SIGNED_IN_USER_ID, USER))).isFalse();
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Role.class, names = {"OFFICE", "BOSS", "DEPARTMENT_HEAD", "SECOND_STAGE_AUTHORITY"})
+        void ensureNobodyMayViewOvertimeOfOtherPersonsWhenOvertimeIsNotActive(Role role) {
+            settings(false, false, false);
+            assertThat(sut.isAllowedToViewOvertimeOfOtherPersons(person(SIGNED_IN_USER_ID, USER, role))).isFalse();
+        }
+    }
+
+    @Nested
     class DepartmentLookups {
 
         @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsPersonsTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsPersonsTest.java
@@ -1,0 +1,156 @@
+package org.synyx.urlaubsverwaltung.overtime.statistics;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.synyx.urlaubsverwaltung.department.DepartmentService;
+import org.synyx.urlaubsverwaltung.person.Person;
+import org.synyx.urlaubsverwaltung.person.PersonService;
+import org.synyx.urlaubsverwaltung.person.Role;
+
+import java.time.Year;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.synyx.urlaubsverwaltung.person.Role.DEPARTMENT_HEAD;
+import static org.synyx.urlaubsverwaltung.person.Role.OFFICE;
+import static org.synyx.urlaubsverwaltung.person.Role.USER;
+
+/**
+ * Truth table of "whose overtime is part of the figures of this signed-in person?".
+ */
+@ExtendWith(MockitoExtension.class)
+class OvertimeStatisticsPersonsTest {
+
+    private static final Year YEAR = Year.of(2026);
+
+    private OvertimeStatisticsPersons sut;
+
+    @Mock
+    private PersonService personService;
+    @Mock
+    private DepartmentService departmentService;
+
+    @BeforeEach
+    void setUp() {
+        sut = new OvertimeStatisticsPersons(personService, departmentService);
+    }
+
+    @Nested
+    class RelevantPersonsOfYear {
+
+        @ParameterizedTest
+        @EnumSource(value = Role.class, names = {"OFFICE", "BOSS"})
+        void ensureOfficeAndBossGetTheWholeCohortOfTheYear(Role role) {
+
+            final Person signedInUser = person(1L, USER, role);
+            final Person marie = person(2L, USER);
+            final Person klaus = person(3L, USER);
+
+            when(personService.getAllPersonsHavingAccountInYear(YEAR)).thenReturn(List.of(marie, klaus));
+
+            assertThat(sut.relevantPersonsOfYear(signedInUser, YEAR)).containsExactly(marie, klaus);
+            verifyNoInteractions(departmentService);
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Role.class, names = {"DEPARTMENT_HEAD", "SECOND_STAGE_AUTHORITY"})
+        void ensureManagerGetsTheManagedMembersOfThatYear(Role role) {
+
+            final Person signedInUser = person(1L, USER, role);
+            final Person marie = person(2L, USER);
+
+            when(departmentService.getManagedMembersOfPerson(signedInUser, YEAR)).thenReturn(List.of(marie));
+
+            assertThat(sut.relevantPersonsOfYear(signedInUser, YEAR)).containsExactly(marie);
+            verifyNoInteractions(personService);
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Role.class, names = {"USER", "INACTIVE"})
+        void ensureNobodyElseGetsAnyPerson(Role role) {
+
+            assertThat(sut.relevantPersonsOfYear(person(1L, role), YEAR)).isEmpty();
+
+            verifyNoInteractions(personService);
+            verifyNoInteractions(departmentService);
+        }
+
+        @Test
+        void ensureManagerWithoutManagedMembersGetsAnEmptyList() {
+
+            final Person signedInUser = person(1L, USER, DEPARTMENT_HEAD);
+
+            when(departmentService.getManagedMembersOfPerson(signedInUser, YEAR)).thenReturn(List.of());
+
+            assertThat(sut.relevantPersonsOfYear(signedInUser, YEAR)).isEmpty();
+        }
+
+        @Test
+        void ensureOfficeWinsOverAManagementRole() {
+
+            final Person signedInUser = person(1L, USER, OFFICE, DEPARTMENT_HEAD);
+            final Person marie = person(2L, USER);
+
+            when(personService.getAllPersonsHavingAccountInYear(YEAR)).thenReturn(List.of(marie));
+
+            assertThat(sut.relevantPersonsOfYear(signedInUser, YEAR)).containsExactly(marie);
+            verifyNoInteractions(departmentService);
+        }
+    }
+
+    @Nested
+    class RelevantPersonsOfWholeHistory {
+
+        @ParameterizedTest
+        @EnumSource(value = Role.class, names = {"OFFICE", "BOSS"})
+        void ensureOfficeAndBossGetEveryActivePerson(Role role) {
+
+            final Person signedInUser = person(1L, USER, role);
+            final Person marie = person(2L, USER);
+            final Person klaus = person(3L, USER);
+
+            when(personService.getActivePersons()).thenReturn(List.of(marie, klaus));
+
+            assertThat(sut.relevantPersonsOfWholeHistory(signedInUser)).containsExactly(marie, klaus);
+            verifyNoInteractions(departmentService);
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Role.class, names = {"DEPARTMENT_HEAD", "SECOND_STAGE_AUTHORITY"})
+        void ensureManagerGetsTheManagedActiveMembers(Role role) {
+
+            final Person signedInUser = person(1L, USER, role);
+            final Person marie = person(2L, USER);
+
+            when(departmentService.getManagedActiveMembersOfPerson(signedInUser)).thenReturn(List.of(marie));
+
+            assertThat(sut.relevantPersonsOfWholeHistory(signedInUser)).containsExactly(marie);
+            verifyNoInteractions(personService);
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Role.class, names = {"USER", "INACTIVE"})
+        void ensureNobodyElseGetsAnyPerson(Role role) {
+
+            assertThat(sut.relevantPersonsOfWholeHistory(person(1L, role))).isEmpty();
+
+            verifyNoInteractions(personService);
+            verifyNoInteractions(departmentService);
+        }
+    }
+
+    private static Person person(long id, Role... roles) {
+        final Person person = new Person("user-" + id, "Reichenbach", "Marie", "person%d@example.org".formatted(id));
+        person.setId(id);
+        person.setPermissions(List.of(roles));
+        return person;
+    }
+}

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsServiceIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsServiceIT.java
@@ -13,6 +13,7 @@ import org.synyx.urlaubsverwaltung.application.vacationtype.VacationTypeService;
 import org.synyx.urlaubsverwaltung.overtime.OvertimeService;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonService;
+import org.synyx.urlaubsverwaltung.person.Role;
 
 import java.time.Duration;
 import java.time.LocalDate;
@@ -25,8 +26,8 @@ import static org.synyx.urlaubsverwaltung.application.vacationtype.VacationCateg
 import static org.synyx.urlaubsverwaltung.period.DayLength.FULL;
 
 /**
- * The company wide balance has to be the same figure every person sees as their own remaining overtime. Both sides are
- * calculated by completely different code, so the identity is verified against a real database instead of mocks.
+ * The balance has to be the same figure every person sees as their own remaining overtime. Both sides are calculated
+ * by completely different code, so the identity is verified against a real database instead of mocks.
  */
 @SpringBootTest
 @Transactional
@@ -46,6 +47,7 @@ class OvertimeStatisticsServiceIT extends SingleTenantTestContainersBase {
     @Test
     void ensureBalanceEqualsTheSummedRemainingOvertimeOfEveryPerson() {
 
+        final Person office = officePerson();
         final Person marie = personService.create("marie", "Marie", "Reichenbach", "marie@example.org");
         final Person klaus = personService.create("klaus", "Klaus", "Mustermann", "klaus@example.org");
 
@@ -58,19 +60,20 @@ class OvertimeStatisticsServiceIT extends SingleTenantTestContainersBase {
             .map(overtimeService::getLeftOvertimeForPerson)
             .reduce(ZERO, Duration::plus);
 
-        assertThat(sut.getTotals().balance()).isEqualTo(summedPersonalBalances);
+        assertThat(sut.getTotals(office).balance()).isEqualTo(summedPersonalBalances);
     }
 
     @Test
     void ensureAccrualAndReductionAddUpToTheBalance() {
 
+        final Person office = officePerson();
         final Person marie = personService.create("marie", "Marie", "Reichenbach", "marie@example.org");
 
         overtime(marie, "2024-02-01", Duration.ofHours(12));
         overtime(marie, "2024-06-01", Duration.ofHours(5).negated());
         overtimeReductionApplication(marie, "2025-03-03", Duration.ofHours(6));
 
-        final OvertimeTotals totals = sut.getTotals();
+        final OvertimeTotals totals = sut.getTotals(office);
 
         assertThat(totals.accrued()).isEqualTo(Duration.ofHours(12));
         assertThat(totals.reduction()).isEqualTo(Duration.ofHours(11));
@@ -78,8 +81,14 @@ class OvertimeStatisticsServiceIT extends SingleTenantTestContainersBase {
     }
 
     @Test
-    void ensureAnEmptyCompanyDoesNotFail() {
-        assertThat(sut.getTotals().balance()).isEqualTo(ZERO);
+    void ensureNobodyWithOvertimeDoesNotFail() {
+        // the requesting office person is the only person in the database and has no overtime
+        assertThat(sut.getTotals(officePerson()).balance()).isEqualTo(ZERO);
+    }
+
+    private Person officePerson() {
+        return personService.create("office", "Ossi", "Office", "office@example.org",
+            List.of(), List.of(Role.USER, Role.OFFICE));
     }
 
     private void overtime(Person person, String date, Duration duration) {

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsServiceTest.java
@@ -17,7 +17,6 @@ import org.synyx.urlaubsverwaltung.overtime.OvertimeId;
 import org.synyx.urlaubsverwaltung.overtime.OvertimeService;
 import org.synyx.urlaubsverwaltung.person.Person;
 import org.synyx.urlaubsverwaltung.person.PersonId;
-import org.synyx.urlaubsverwaltung.person.PersonService;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeCalendarService;
 
 import java.time.Duration;
@@ -54,13 +53,14 @@ import static org.synyx.urlaubsverwaltung.workingtime.WorkingTimeCalendarFactory
 class OvertimeStatisticsServiceTest {
 
     private static final Year YEAR = Year.of(2026);
+    private static final Person SIGNED_IN_USER = person(99L);
 
     private OvertimeStatisticsService sut;
 
     @Mock
     private OvertimeService overtimeService;
     @Mock
-    private PersonService personService;
+    private OvertimeStatisticsPersons overtimeStatisticsPersons;
     @Mock
     private ApplicationService applicationService;
     @Mock
@@ -68,18 +68,18 @@ class OvertimeStatisticsServiceTest {
 
     @BeforeEach
     void setUp() {
-        sut = new OvertimeStatisticsService(overtimeService, personService, applicationService, workingTimeCalendarService);
+        sut = new OvertimeStatisticsService(overtimeService, overtimeStatisticsPersons, applicationService, workingTimeCalendarService);
 
         // most tests are about the overtime records, so "no reduction applications" is the default
         lenient().when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of());
     }
 
     @Test
-    void ensureAccruedOvertimeIsSummedPerMonthOverAllPersons() {
+    void ensureAccruedOvertimeIsSummedPerMonthOverAllRelevantPersons() {
 
         final Person marie = person(1L);
         final Person klaus = person(2L);
-        when(personService.getAllPersonsHavingAccountInYear(YEAR)).thenReturn(List.of(marie, klaus));
+        when(overtimeStatisticsPersons.relevantPersonsOfYear(SIGNED_IN_USER, YEAR)).thenReturn(List.of(marie, klaus));
 
         when(overtimeService.getOvertimeForPersonsInDateRange(any(), any(), any())).thenReturn(Map.of(
             marie.getIdAsPersonId(), List.of(overtime(marie, "2026-01-05", "2026-01-05", Duration.ofHours(3))),
@@ -89,7 +89,7 @@ class OvertimeStatisticsServiceTest {
             )
         ));
 
-        final OvertimeStatistics statistics = sut.getStatistics(YEAR);
+        final OvertimeStatistics statistics = sut.getStatistics(YEAR, SIGNED_IN_USER);
 
         assertThat(statistics.accruedByMonth()).hasSize(12);
         assertThat(statistics.accruedByMonth().get(JANUARY.getValue() - 1)).isEqualTo(Duration.ofHours(5));
@@ -101,7 +101,7 @@ class OvertimeStatisticsServiceTest {
     void ensureNegativeOvertimeRecordsCountAsReductionAndNotAsAccrual() {
 
         final Person marie = person(1L);
-        when(personService.getAllPersonsHavingAccountInYear(YEAR)).thenReturn(List.of(marie));
+        when(overtimeStatisticsPersons.relevantPersonsOfYear(SIGNED_IN_USER, YEAR)).thenReturn(List.of(marie));
 
         when(overtimeService.getOvertimeForPersonsInDateRange(any(), any(), any())).thenReturn(Map.of(
             marie.getIdAsPersonId(), List.of(
@@ -110,7 +110,7 @@ class OvertimeStatisticsServiceTest {
             )
         ));
 
-        final OvertimeStatistics statistics = sut.getStatistics(YEAR);
+        final OvertimeStatistics statistics = sut.getStatistics(YEAR, SIGNED_IN_USER);
 
         assertThat(statistics.accruedByMonth().get(0)).isEqualTo(Duration.ofHours(6));
         assertThat(statistics.reductionByMonth().get(0)).isEqualTo(Duration.ofHours(2));
@@ -120,13 +120,13 @@ class OvertimeStatisticsServiceTest {
     void ensureReductionIsReportedAsPositiveAmount() {
 
         final Person marie = person(1L);
-        when(personService.getAllPersonsHavingAccountInYear(YEAR)).thenReturn(List.of(marie));
+        when(overtimeStatisticsPersons.relevantPersonsOfYear(SIGNED_IN_USER, YEAR)).thenReturn(List.of(marie));
 
         when(overtimeService.getOvertimeForPersonsInDateRange(any(), any(), any())).thenReturn(Map.of(
             marie.getIdAsPersonId(), List.of(overtime(marie, "2026-02-02", "2026-02-02", Duration.ofHours(3).negated()))
         ));
 
-        final OvertimeStatistics statistics = sut.getStatistics(YEAR);
+        final OvertimeStatistics statistics = sut.getStatistics(YEAR, SIGNED_IN_USER);
 
         assertThat(statistics.reductionByMonth().get(1)).isEqualTo(Duration.ofHours(3));
         assertThat(statistics.reductionByMonth().get(1).isNegative()).isFalse();
@@ -136,14 +136,14 @@ class OvertimeStatisticsServiceTest {
     void ensureOvertimeSpanningTwoMonthsIsSplitProRata() {
 
         final Person marie = person(1L);
-        when(personService.getAllPersonsHavingAccountInYear(YEAR)).thenReturn(List.of(marie));
+        when(overtimeStatisticsPersons.relevantPersonsOfYear(SIGNED_IN_USER, YEAR)).thenReturn(List.of(marie));
 
         // 30.01. - 02.02. are four days, two in january and two in february
         when(overtimeService.getOvertimeForPersonsInDateRange(any(), any(), any())).thenReturn(Map.of(
             marie.getIdAsPersonId(), List.of(overtime(marie, "2026-01-30", "2026-02-02", Duration.ofHours(4)))
         ));
 
-        final OvertimeStatistics statistics = sut.getStatistics(YEAR);
+        final OvertimeStatistics statistics = sut.getStatistics(YEAR, SIGNED_IN_USER);
 
         assertThat(statistics.accruedByMonth().get(0)).isEqualTo(Duration.ofHours(2));
         assertThat(statistics.accruedByMonth().get(1)).isEqualTo(Duration.ofHours(2));
@@ -153,27 +153,27 @@ class OvertimeStatisticsServiceTest {
     void ensureOvertimeSpanningTheYearBoundaryOnlyCountsItsShareOfTheSelectedYear() {
 
         final Person marie = person(1L);
-        when(personService.getAllPersonsHavingAccountInYear(YEAR)).thenReturn(List.of(marie));
+        when(overtimeStatisticsPersons.relevantPersonsOfYear(SIGNED_IN_USER, YEAR)).thenReturn(List.of(marie));
 
         // 30.12.2025 - 02.01.2026 are four days, only the two days in 2026 belong to the selected year
         when(overtimeService.getOvertimeForPersonsInDateRange(any(), any(), any())).thenReturn(Map.of(
             marie.getIdAsPersonId(), List.of(overtime(marie, "2025-12-30", "2026-01-02", Duration.ofHours(8)))
         ));
 
-        final OvertimeStatistics statistics = sut.getStatistics(YEAR);
+        final OvertimeStatistics statistics = sut.getStatistics(YEAR, SIGNED_IN_USER);
 
         assertThat(statistics.accruedByMonth().get(0)).isEqualTo(Duration.ofHours(4));
         assertThat(statistics.accrued()).isEqualTo(Duration.ofHours(4));
     }
 
     @Test
-    void ensureOnlyPersonsHavingAnAccountInTheSelectedYearAreConsidered() {
+    void ensureOnlyTheRelevantPersonsOfTheSelectedYearAreConsidered() {
 
         final Person marie = person(1L);
-        when(personService.getAllPersonsHavingAccountInYear(YEAR)).thenReturn(List.of(marie));
+        when(overtimeStatisticsPersons.relevantPersonsOfYear(SIGNED_IN_USER, YEAR)).thenReturn(List.of(marie));
         when(overtimeService.getOvertimeForPersonsInDateRange(any(), any(), any())).thenReturn(Map.of());
 
-        sut.getStatistics(YEAR);
+        sut.getStatistics(YEAR, SIGNED_IN_USER);
 
         final ArgumentCaptor<Collection<PersonId>> captor = ArgumentCaptor.captor();
         verify(overtimeService).getOvertimeForPersonsInDateRange(captor.capture(), any(), any());
@@ -184,10 +184,10 @@ class OvertimeStatisticsServiceTest {
     void ensureOvertimeIsRequestedForTheWholeSelectedYear() {
 
         final Person marie = person(1L);
-        when(personService.getAllPersonsHavingAccountInYear(YEAR)).thenReturn(List.of(marie));
+        when(overtimeStatisticsPersons.relevantPersonsOfYear(SIGNED_IN_USER, YEAR)).thenReturn(List.of(marie));
         when(overtimeService.getOvertimeForPersonsInDateRange(any(), any(), any())).thenReturn(Map.of());
 
-        sut.getStatistics(YEAR);
+        sut.getStatistics(YEAR, SIGNED_IN_USER);
 
         verify(overtimeService).getOvertimeForPersonsInDateRange(
             any(),
@@ -199,9 +199,9 @@ class OvertimeStatisticsServiceTest {
     @Test
     void ensureNoPersonsResultsInZeroForEveryMonthWithoutQueryingOvertime() {
 
-        when(personService.getAllPersonsHavingAccountInYear(YEAR)).thenReturn(List.of());
+        when(overtimeStatisticsPersons.relevantPersonsOfYear(SIGNED_IN_USER, YEAR)).thenReturn(List.of());
 
-        final OvertimeStatistics statistics = sut.getStatistics(YEAR);
+        final OvertimeStatistics statistics = sut.getStatistics(YEAR, SIGNED_IN_USER);
 
         assertThat(statistics.accruedByMonth()).hasSize(12).containsOnly(ZERO);
         assertThat(statistics.reductionByMonth()).hasSize(12).containsOnly(ZERO);
@@ -216,7 +216,7 @@ class OvertimeStatisticsServiceTest {
     void ensureTotalsAndBalance() {
 
         final Person marie = person(1L);
-        when(personService.getAllPersonsHavingAccountInYear(YEAR)).thenReturn(List.of(marie));
+        when(overtimeStatisticsPersons.relevantPersonsOfYear(SIGNED_IN_USER, YEAR)).thenReturn(List.of(marie));
 
         when(overtimeService.getOvertimeForPersonsInDateRange(any(), any(), any())).thenReturn(Map.of(
             marie.getIdAsPersonId(), List.of(
@@ -225,7 +225,7 @@ class OvertimeStatisticsServiceTest {
             )
         ));
 
-        final OvertimeStatistics statistics = sut.getStatistics(YEAR);
+        final OvertimeStatistics statistics = sut.getStatistics(YEAR, SIGNED_IN_USER);
 
         assertThat(statistics.accrued()).isEqualTo(Duration.ofHours(10));
         assertThat(statistics.reduction()).isEqualTo(Duration.ofHours(4));
@@ -236,7 +236,7 @@ class OvertimeStatisticsServiceTest {
     void ensureBalancePerMonthIsAccrualMinusReduction() {
 
         final Person marie = person(1L);
-        when(personService.getAllPersonsHavingAccountInYear(YEAR)).thenReturn(List.of(marie));
+        when(overtimeStatisticsPersons.relevantPersonsOfYear(SIGNED_IN_USER, YEAR)).thenReturn(List.of(marie));
 
         when(overtimeService.getOvertimeForPersonsInDateRange(any(), any(), any())).thenReturn(Map.of(
             marie.getIdAsPersonId(), List.of(
@@ -245,7 +245,7 @@ class OvertimeStatisticsServiceTest {
             )
         ));
 
-        final OvertimeStatistics statistics = sut.getStatistics(YEAR);
+        final OvertimeStatistics statistics = sut.getStatistics(YEAR, SIGNED_IN_USER);
 
         assertThat(statistics.balanceByMonth().get(0)).isEqualTo(Duration.ofHours(3).negated());
     }
@@ -254,13 +254,13 @@ class OvertimeStatisticsServiceTest {
     void ensureOvertimeReductionApplicationsCountAsReduction() {
 
         final Person marie = person(1L);
-        personsHavingAccount(marie);
+        relevantPersons(marie);
         noOvertimeRecords();
 
         // 05.01. and 06.01., two full workdays, eight hours reduction means four hours per day
         overtimeReductionApplications(marie, application(marie, "2026-01-05", "2026-01-06", Duration.ofHours(8)));
 
-        final OvertimeStatistics statistics = sut.getStatistics(YEAR);
+        final OvertimeStatistics statistics = sut.getStatistics(YEAR, SIGNED_IN_USER);
 
         assertThat(statistics.reductionByMonth().get(0)).isEqualTo(Duration.ofHours(8));
         assertThat(statistics.accruedByMonth().get(0)).isEqualTo(ZERO);
@@ -270,14 +270,14 @@ class OvertimeStatisticsServiceTest {
     void ensureReductionCombinesNegativeRecordsAndApplications() {
 
         final Person marie = person(1L);
-        personsHavingAccount(marie);
+        relevantPersons(marie);
 
         when(overtimeService.getOvertimeForPersonsInDateRange(any(), any(), any())).thenReturn(Map.of(
             marie.getIdAsPersonId(), List.of(overtime(marie, "2026-01-20", "2026-01-20", Duration.ofHours(3).negated()))
         ));
         overtimeReductionApplications(marie, application(marie, "2026-01-05", "2026-01-05", Duration.ofHours(2)));
 
-        final OvertimeStatistics statistics = sut.getStatistics(YEAR);
+        final OvertimeStatistics statistics = sut.getStatistics(YEAR, SIGNED_IN_USER);
 
         assertThat(statistics.reductionByMonth().get(0)).isEqualTo(Duration.ofHours(5));
     }
@@ -286,11 +286,11 @@ class OvertimeStatisticsServiceTest {
     void ensureOnlyApplicationsInActiveStatusesAreConsidered() {
 
         final Person marie = person(1L);
-        personsHavingAccount(marie);
+        relevantPersons(marie);
         noOvertimeRecords();
         overtimeReductionApplications(marie);
 
-        sut.getStatistics(YEAR);
+        sut.getStatistics(YEAR, SIGNED_IN_USER);
 
         final ArgumentCaptor<List<ApplicationStatus>> captor = ArgumentCaptor.captor();
         verify(applicationService).getForStatesAndPerson(captor.capture(), any(), any(), any());
@@ -301,14 +301,14 @@ class OvertimeStatisticsServiceTest {
     void ensureApplicationsOfOtherVacationCategoriesAreIgnored() {
 
         final Person marie = person(1L);
-        personsHavingAccount(marie);
+        relevantPersons(marie);
         noOvertimeRecords();
 
         final Application holiday = application(marie, "2026-01-05", "2026-01-06", Duration.ofHours(8));
         holiday.setVacationType(createVacationType(2L, HOLIDAY, new StaticMessageSource()));
         when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of(holiday));
 
-        final OvertimeStatistics statistics = sut.getStatistics(YEAR);
+        final OvertimeStatistics statistics = sut.getStatistics(YEAR, SIGNED_IN_USER);
 
         assertThat(statistics.reductionByMonth()).containsOnly(ZERO);
     }
@@ -317,13 +317,13 @@ class OvertimeStatisticsServiceTest {
     void ensureApplicationSpanningTwoMonthsIsSplitProRata() {
 
         final Person marie = person(1L);
-        personsHavingAccount(marie);
+        relevantPersons(marie);
         noOvertimeRecords();
 
         // 30.01. - 02.02., four full workdays, eight hours means two hours per day
         overtimeReductionApplications(marie, application(marie, "2026-01-30", "2026-02-02", Duration.ofHours(8)));
 
-        final OvertimeStatistics statistics = sut.getStatistics(YEAR);
+        final OvertimeStatistics statistics = sut.getStatistics(YEAR, SIGNED_IN_USER);
 
         assertThat(statistics.reductionByMonth().get(0)).isEqualTo(Duration.ofHours(4));
         assertThat(statistics.reductionByMonth().get(1)).isEqualTo(Duration.ofHours(4));
@@ -333,13 +333,13 @@ class OvertimeStatisticsServiceTest {
     void ensureApplicationSpanningTheYearBoundaryOnlyCountsItsShareOfTheSelectedYear() {
 
         final Person marie = person(1L);
-        personsHavingAccount(marie);
+        relevantPersons(marie);
         noOvertimeRecords();
 
         // 30.12.2025 - 02.01.2026, four full workdays, only the two days in 2026 belong to the selected year
         overtimeReductionApplications(marie, application(marie, "2025-12-30", "2026-01-02", Duration.ofHours(8)));
 
-        final OvertimeStatistics statistics = sut.getStatistics(YEAR);
+        final OvertimeStatistics statistics = sut.getStatistics(YEAR, SIGNED_IN_USER);
 
         assertThat(statistics.reductionByMonth().get(0)).isEqualTo(Duration.ofHours(4));
         assertThat(statistics.reduction()).isEqualTo(Duration.ofHours(4));
@@ -350,7 +350,7 @@ class OvertimeStatisticsServiceTest {
 
         final Person marie = person(1L);
         final Person klaus = person(2L);
-        personsHavingAccount(marie, klaus);
+        relevantPersons(marie, klaus);
         noOvertimeRecords();
 
         overtimeReductionApplications(
@@ -359,7 +359,7 @@ class OvertimeStatisticsServiceTest {
             application(marie, "2026-11-02", "2026-11-03", Duration.ofHours(4))
         );
 
-        sut.getStatistics(YEAR);
+        sut.getStatistics(YEAR, SIGNED_IN_USER);
 
         // one query for everyone, spanning every application - not one per person and not one per application
         verify(workingTimeCalendarService).getWorkingTimesByPersons(
@@ -372,11 +372,11 @@ class OvertimeStatisticsServiceTest {
     void ensureNoWorkingTimeCalendarIsLoadedWithoutAnyReductionApplication() {
 
         final Person marie = person(1L);
-        personsHavingAccount(marie);
+        relevantPersons(marie);
         noOvertimeRecords();
         when(applicationService.getForStatesAndPerson(any(), any(), any(), any())).thenReturn(List.of());
 
-        sut.getStatistics(YEAR);
+        sut.getStatistics(YEAR, SIGNED_IN_USER);
 
         verify(workingTimeCalendarService, never()).getWorkingTimesByPersons(any(), any(DateRange.class));
     }
@@ -389,7 +389,7 @@ class OvertimeStatisticsServiceTest {
 
             final Person marie = person(1L);
             final Person klaus = person(2L);
-            when(personService.getActivePersons()).thenReturn(List.of(marie, klaus));
+            when(overtimeStatisticsPersons.relevantPersonsOfWholeHistory(SIGNED_IN_USER)).thenReturn(List.of(marie, klaus));
 
             when(overtimeService.getAllOvertimesByPersonIds(any())).thenReturn(Map.of(
                 marie.getIdAsPersonId(), List.of(
@@ -400,7 +400,7 @@ class OvertimeStatisticsServiceTest {
             ));
             when(applicationService.getTotalOvertimeReductionOfPersons(any())).thenReturn(Duration.ofHours(4));
 
-            final OvertimeTotals totals = sut.getTotals();
+            final OvertimeTotals totals = sut.getTotals(SIGNED_IN_USER);
 
             assertThat(totals.accrued()).isEqualTo(Duration.ofHours(50));
             assertThat(totals.reduction()).isEqualTo(Duration.ofHours(10));
@@ -411,24 +411,24 @@ class OvertimeStatisticsServiceTest {
         void ensureReductionApplicationsAreCountedWithoutAnyDateRestriction() {
 
             final Person marie = person(1L);
-            when(personService.getActivePersons()).thenReturn(List.of(marie));
+            when(overtimeStatisticsPersons.relevantPersonsOfWholeHistory(SIGNED_IN_USER)).thenReturn(List.of(marie));
             when(overtimeService.getAllOvertimesByPersonIds(any())).thenReturn(Map.of());
             when(applicationService.getTotalOvertimeReductionOfPersons(List.of(marie))).thenReturn(Duration.ofHours(3));
 
-            assertThat(sut.getTotals().reduction()).isEqualTo(Duration.ofHours(3));
+            assertThat(sut.getTotals(SIGNED_IN_USER).reduction()).isEqualTo(Duration.ofHours(3));
         }
 
         @Test
         void ensureTheCurrentWorkforceIsUsedAndNotTheCohortOfAnyYear() {
 
             final Person marie = person(1L);
-            when(personService.getActivePersons()).thenReturn(List.of(marie));
+            when(overtimeStatisticsPersons.relevantPersonsOfWholeHistory(SIGNED_IN_USER)).thenReturn(List.of(marie));
             when(overtimeService.getAllOvertimesByPersonIds(any())).thenReturn(Map.of());
             when(applicationService.getTotalOvertimeReductionOfPersons(any())).thenReturn(ZERO);
 
-            sut.getTotals();
+            sut.getTotals(SIGNED_IN_USER);
 
-            verify(personService, never()).getAllPersonsHavingAccountInYear(any());
+            verify(overtimeStatisticsPersons, never()).relevantPersonsOfYear(any(), any());
         }
 
         @Test
@@ -436,22 +436,22 @@ class OvertimeStatisticsServiceTest {
 
             final Person marie = person(1L);
             final Person klaus = person(2L);
-            when(personService.getActivePersons()).thenReturn(List.of(marie, klaus));
+            when(overtimeStatisticsPersons.relevantPersonsOfWholeHistory(SIGNED_IN_USER)).thenReturn(List.of(marie, klaus));
             when(overtimeService.getAllOvertimesByPersonIds(any())).thenReturn(Map.of());
             when(applicationService.getTotalOvertimeReductionOfPersons(any())).thenReturn(ZERO);
 
-            sut.getTotals();
+            sut.getTotals(SIGNED_IN_USER);
 
             verify(overtimeService).getAllOvertimesByPersonIds(List.of(marie.getIdAsPersonId(), klaus.getIdAsPersonId()));
             verify(applicationService).getTotalOvertimeReductionOfPersons(List.of(marie, klaus));
         }
 
         @Test
-        void ensureEmptyCompanyIsZeroEverywhereWithoutQueryingAnything() {
+        void ensureNoRelevantPersonsIsZeroEverywhereWithoutQueryingAnything() {
 
-            when(personService.getActivePersons()).thenReturn(List.of());
+            when(overtimeStatisticsPersons.relevantPersonsOfWholeHistory(SIGNED_IN_USER)).thenReturn(List.of());
 
-            final OvertimeTotals totals = sut.getTotals();
+            final OvertimeTotals totals = sut.getTotals(SIGNED_IN_USER);
 
             assertThat(totals.accrued()).isEqualTo(ZERO);
             assertThat(totals.reduction()).isEqualTo(ZERO);
@@ -465,13 +465,13 @@ class OvertimeStatisticsServiceTest {
         void ensureBalanceIsNegativeWhenMoreWasReducedThanAccrued() {
 
             final Person marie = person(1L);
-            when(personService.getActivePersons()).thenReturn(List.of(marie));
+            when(overtimeStatisticsPersons.relevantPersonsOfWholeHistory(SIGNED_IN_USER)).thenReturn(List.of(marie));
             when(overtimeService.getAllOvertimesByPersonIds(any())).thenReturn(Map.of(
                 marie.getIdAsPersonId(), List.of(overtime(marie, "2026-01-05", "2026-01-05", Duration.ofHours(2)))
             ));
             when(applicationService.getTotalOvertimeReductionOfPersons(any())).thenReturn(Duration.ofHours(9));
 
-            assertThat(sut.getTotals().balance()).isEqualTo(Duration.ofHours(7).negated());
+            assertThat(sut.getTotals(SIGNED_IN_USER).balance()).isEqualTo(Duration.ofHours(7).negated());
         }
 
         /**
@@ -482,7 +482,7 @@ class OvertimeStatisticsServiceTest {
         void ensureBalanceEqualsAllOvertimeRecordsMinusAllReductionApplications() {
 
             final Person marie = person(1L);
-            when(personService.getActivePersons()).thenReturn(List.of(marie));
+            when(overtimeStatisticsPersons.relevantPersonsOfWholeHistory(SIGNED_IN_USER)).thenReturn(List.of(marie));
 
             final List<Overtime> records = List.of(
                 overtime(marie, "2024-02-01", "2024-02-01", Duration.ofHours(12)),
@@ -496,12 +496,12 @@ class OvertimeStatisticsServiceTest {
             final Duration sumOfAllRecords = records.stream().map(Overtime::duration).reduce(ZERO, Duration::plus);
             final Duration leftOvertime = sumOfAllRecords.minus(Duration.ofHours(6));
 
-            assertThat(sut.getTotals().balance()).isEqualTo(leftOvertime);
+            assertThat(sut.getTotals(SIGNED_IN_USER).balance()).isEqualTo(leftOvertime);
         }
     }
 
-    private void personsHavingAccount(Person... persons) {
-        when(personService.getAllPersonsHavingAccountInYear(YEAR)).thenReturn(List.of(persons));
+    private void relevantPersons(Person... persons) {
+        when(overtimeStatisticsPersons.relevantPersonsOfYear(SIGNED_IN_USER, YEAR)).thenReturn(List.of(persons));
     }
 
     private void noOvertimeRecords() {

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsViewControllerSecurityIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsViewControllerSecurityIT.java
@@ -40,8 +40,8 @@ class OvertimeStatisticsViewControllerSecurityIT extends SingleTenantTestContain
     private SettingsService settingsService;
 
     @ParameterizedTest
-    @ValueSource(strings = {"USER", "INACTIVE", "DEPARTMENT_HEAD", "SECOND_STAGE_AUTHORITY"})
-    void ensureNoAccessForRolesWithoutCompanyWidePermission(final String role) throws Exception {
+    @ValueSource(strings = {"USER", "INACTIVE"})
+    void ensureNoAccessForRolesWithoutPermission(final String role) throws Exception {
 
         signedInUser();
         overtimeFeature(true);
@@ -52,8 +52,8 @@ class OvertimeStatisticsViewControllerSecurityIT extends SingleTenantTestContain
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"OFFICE", "BOSS"})
-    void ensureAccessAndRenderedPageForOfficeAndBoss(final String role) throws Exception {
+    @ValueSource(strings = {"OFFICE", "BOSS", "DEPARTMENT_HEAD", "SECOND_STAGE_AUTHORITY"})
+    void ensureAccessAndRenderedPageForPermittedRoles(final String role) throws Exception {
 
         signedInUser();
         overtimeFeature(true);
@@ -71,7 +71,7 @@ class OvertimeStatisticsViewControllerSecurityIT extends SingleTenantTestContain
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"OFFICE", "BOSS"})
+    @ValueSource(strings = {"OFFICE", "BOSS", "DEPARTMENT_HEAD", "SECOND_STAGE_AUTHORITY"})
     void ensureNotFoundWhenOvertimeFeatureIsDeactivated(final String role) throws Exception {
 
         signedInUser();
@@ -86,7 +86,8 @@ class OvertimeStatisticsViewControllerSecurityIT extends SingleTenantTestContain
         final Person person = new Person("user", "Reichenbach", "Marie", "person@example.org");
         person.setId(1L);
         when(personService.getSignedInUser()).thenReturn(person);
-        // the real statistics service runs here, an empty company renders the page with zeros everywhere
+        // the real statistics service and the real department service run here - no persons and no department
+        // memberships in the test database render the page with zeros everywhere, for every role
         when(personService.getAllPersonsHavingAccountInYear(any())).thenReturn(List.of());
     }
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/overtime/statistics/OvertimeStatisticsViewControllerTest.java
@@ -10,6 +10,8 @@ import org.springframework.context.support.StaticMessageSource;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.synyx.urlaubsverwaltung.person.Person;
+import org.synyx.urlaubsverwaltung.person.PersonService;
 import org.synyx.urlaubsverwaltung.search.PersonSearchUiFragmentSupplier;
 import org.synyx.urlaubsverwaltung.search.PersonSuggestionUrlStrategy;
 import org.synyx.urlaubsverwaltung.settings.Settings;
@@ -29,6 +31,7 @@ import static java.util.Collections.nCopies;
 import static java.util.Locale.GERMAN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -46,6 +49,8 @@ class OvertimeStatisticsViewControllerTest {
     @Mock
     private OvertimeStatisticsService statisticsService;
     @Mock
+    private PersonService personService;
+    @Mock
     private SettingsService settingsService;
     @Mock
     private PersonSuggestionUrlStrategy defaultPersonSuggestionUrlStrategy;
@@ -53,6 +58,7 @@ class OvertimeStatisticsViewControllerTest {
     private PersonSearchUiFragmentSupplier personSearchUiFragmentSupplier;
 
     private final Clock clock = Clock.fixed(Instant.parse("2026-07-31T10:15:00Z"), UTC);
+    private final Person signedInUser = person();
 
     @BeforeEach
     void setUp() {
@@ -61,13 +67,15 @@ class OvertimeStatisticsViewControllerTest {
         messageSource.addMessage("minutes.abbr", GERMAN, "Min.");
         messageSource.addMessage("overtime.person.zero", GERMAN, "keine");
 
-        sut = new OvertimeStatisticsViewController(statisticsService, settingsService, messageSource,
+        sut = new OvertimeStatisticsViewController(statisticsService, personService, settingsService, messageSource,
             defaultPersonSuggestionUrlStrategy, personSearchUiFragmentSupplier, clock);
 
-        // most tests are about the selected year, so an empty company wide history is the default
-        lenient().when(statisticsService.getTotals()).thenReturn(OvertimeTotals.empty());
+        // the page is rendered for the signed-in person, every request needs them
+        lenient().when(personService.getSignedInUser()).thenReturn(signedInUser);
+        // most tests are about the selected year, so an empty history is the default
+        lenient().when(statisticsService.getTotals(signedInUser)).thenReturn(OvertimeTotals.empty());
         // every request also loads the previous year for the comparison curve
-        lenient().when(statisticsService.getStatistics(any()))
+        lenient().when(statisticsService.getStatistics(any(), eq(signedInUser)))
             .thenAnswer(invocation -> OvertimeStatistics.empty(invocation.getArgument(0)));
     }
 
@@ -303,7 +311,7 @@ class OvertimeStatisticsViewControllerTest {
 
         overtimeFeature(true);
         statisticsOf(Year.of(2026), months(ZERO), months(ZERO));
-        when(statisticsService.getTotals()).thenReturn(new OvertimeTotals(Duration.ofHours(427), Duration.ofMinutes(21030)));
+        when(statisticsService.getTotals(signedInUser)).thenReturn(new OvertimeTotals(Duration.ofHours(427), Duration.ofMinutes(21030)));
 
         final MvcResult result = perform(get("/web/overtime/statistics")).andExpect(status().isOk()).andReturn();
 
@@ -319,7 +327,7 @@ class OvertimeStatisticsViewControllerTest {
 
         overtimeFeature(true);
         statisticsOf(Year.of(2024), months(ZERO), months(ZERO));
-        when(statisticsService.getTotals()).thenReturn(new OvertimeTotals(Duration.ofHours(427), Duration.ofHours(350)));
+        when(statisticsService.getTotals(signedInUser)).thenReturn(new OvertimeTotals(Duration.ofHours(427), Duration.ofHours(350)));
 
         final MvcResult result = perform(get("/web/overtime/statistics").param("year", "2024"))
             .andExpect(status().isOk())
@@ -327,7 +335,7 @@ class OvertimeStatisticsViewControllerTest {
 
         assertThat(totalsOf(result).accrued()).isEqualTo("427 Std.");
         // the totals are fetched without handing over any year
-        verify(statisticsService).getTotals();
+        verify(statisticsService).getTotals(signedInUser);
     }
 
     @Test
@@ -335,7 +343,7 @@ class OvertimeStatisticsViewControllerTest {
 
         overtimeFeature(true);
         statisticsOf(Year.of(2026), months(ZERO), months(ZERO));
-        when(statisticsService.getTotals()).thenReturn(new OvertimeTotals(ZERO, ZERO));
+        when(statisticsService.getTotals(signedInUser)).thenReturn(new OvertimeTotals(ZERO, ZERO));
 
         final MvcResult result = perform(get("/web/overtime/statistics")).andExpect(status().isOk()).andReturn();
 
@@ -429,7 +437,7 @@ class OvertimeStatisticsViewControllerTest {
     }
 
     private void statisticsOf(Year year, List<Duration> accrued, List<Duration> reduction) {
-        when(statisticsService.getStatistics(year)).thenReturn(new OvertimeStatistics(year, accrued, reduction));
+        when(statisticsService.getStatistics(year, signedInUser)).thenReturn(new OvertimeStatistics(year, accrued, reduction));
     }
 
     private static List<Duration> months(Duration duration) {
@@ -448,6 +456,12 @@ class OvertimeStatisticsViewControllerTest {
         final Settings settings = new Settings();
         settings.getOvertimeSettings().setOvertimeActive(active);
         when(settingsService.getSettings()).thenReturn(settings);
+    }
+
+    private static Person person() {
+        final Person person = new Person("user", "Reichenbach", "Marie", "person@example.org");
+        person.setId(1L);
+        return person;
     }
 
     private ResultActions perform(MockHttpServletRequestBuilder builder) throws Exception {

--- a/src/test/java/org/synyx/urlaubsverwaltung/person/web/PersonsViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/person/web/PersonsViewControllerTest.java
@@ -487,7 +487,7 @@ class PersonsViewControllerTest {
         john.setFirstName("John");
 
         final PageImpl<Person> page = new PageImpl<>(List.of(john));
-        when(departmentService.getManagedMembersOfPersonAndDepartment(signedInUser, 1L, defaultPageRequest(), "")).thenReturn(page);
+        when(departmentService.getManagedActiveMembersOfPersonAndDepartment(signedInUser, 1L, defaultPageRequest(), "")).thenReturn(page);
 
         when(departmentService.isPersonAllowedToManageDepartment(signedInUser, department)).thenReturn(true);
 
@@ -523,7 +523,7 @@ class PersonsViewControllerTest {
         john.setFirstName("John");
 
         final PageImpl<Person> page = new PageImpl<>(List.of(john));
-        when(departmentService.getManagedMembersOfPersonAndDepartment(signedInUser, 1L, defaultPageRequest(), "")).thenReturn(page);
+        when(departmentService.getManagedActiveMembersOfPersonAndDepartment(signedInUser, 1L, defaultPageRequest(), "")).thenReturn(page);
 
         when(departmentService.isPersonAllowedToManageDepartment(signedInUser, department)).thenReturn(true);
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/person/web/PersonsViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/person/web/PersonsViewControllerTest.java
@@ -193,7 +193,7 @@ class PersonsViewControllerTest {
         when(personService.getSignedInUser()).thenReturn(signedInUser);
 
         final PageImpl<Person> page = new PageImpl<>(List.of());
-        when(departmentService.getManagedMembersOfPerson(signedInUser, defaultPageRequest(), "")).thenReturn(page);
+        when(departmentService.getManagedActiveMembersOfPerson(signedInUser, defaultPageRequest(), "")).thenReturn(page);
 
         perform(get("/web/person"))
             .andExpect(model().attribute("personsPagination", hasProperty("page", hasProperty("content", hasSize(0)))));
@@ -206,7 +206,7 @@ class PersonsViewControllerTest {
         when(personService.getSignedInUser()).thenReturn(signedInUser);
 
         final PageImpl<Person> page = new PageImpl<>(List.of());
-        when(departmentService.getManagedMembersOfPerson(signedInUser, defaultPageRequest(), "")).thenReturn(page);
+        when(departmentService.getManagedActiveMembersOfPerson(signedInUser, defaultPageRequest(), "")).thenReturn(page);
 
         perform(get("/web/person"))
             .andExpect(model().attribute("personsPagination", hasProperty("page", hasProperty("content", hasSize(0)))));
@@ -219,7 +219,7 @@ class PersonsViewControllerTest {
         when(personService.getSignedInUser()).thenReturn(signedInUser);
 
         final PageImpl<Person> page = new PageImpl<>(List.of());
-        when(departmentService.getManagedMembersOfPerson(signedInUser, defaultPageRequest(), "")).thenReturn(page);
+        when(departmentService.getManagedActiveMembersOfPerson(signedInUser, defaultPageRequest(), "")).thenReturn(page);
 
         perform(get("/web/person"))
             .andExpect(model().attribute("personsPagination", hasProperty("page", hasProperty("content", hasSize(0)))));
@@ -235,7 +235,7 @@ class PersonsViewControllerTest {
         person.setId(2L);
 
         final PageImpl<Person> page = new PageImpl<>(List.of(person));
-        when(departmentService.getManagedMembersOfPerson(signedInUser, defaultPageRequest(), "")).thenReturn(page);
+        when(departmentService.getManagedActiveMembersOfPerson(signedInUser, defaultPageRequest(), "")).thenReturn(page);
 
         perform(get("/web/person"))
             .andExpect(model().attribute("personsPagination",
@@ -556,7 +556,7 @@ class PersonsViewControllerTest {
         john.setFirstName("John");
 
         final PageImpl<Person> page = new PageImpl<>(List.of(john));
-        when(departmentService.getManagedMembersOfPerson(signedInUser, defaultPageRequest(), "")).thenReturn(page);
+        when(departmentService.getManagedActiveMembersOfPerson(signedInUser, defaultPageRequest(), "")).thenReturn(page);
 
         when(departmentService.isPersonAllowedToManageDepartment(signedInUser, department)).thenReturn(false);
 
@@ -1189,7 +1189,7 @@ class PersonsViewControllerTest {
 
     private void mockDefaultPageRequest(Person signedInUser) {
         final PageImpl<Person> page = new PageImpl<>(List.of());
-        when(departmentService.getManagedMembersOfPerson(signedInUser, defaultPageRequest(), "")).thenReturn(page);
+        when(departmentService.getManagedActiveMembersOfPerson(signedInUser, defaultPageRequest(), "")).thenReturn(page);
     }
 
     private static Person personWithRole(Role... role) {

--- a/src/test/java/org/synyx/urlaubsverwaltung/search/PersonSearchSuggestionsProviderTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/search/PersonSearchSuggestionsProviderTest.java
@@ -85,7 +85,7 @@ class PersonSearchSuggestionsProviderTest {
         final Person departmentHead = person(1L, "Department", "Head", DEPARTMENT_HEAD);
         final Person hit = person(2L, "Marlene", "Muster");
 
-        when(departmentService.getManagedMembersOfPerson(eq(departmentHead), any(PersonPageable.class), eq("mar")))
+        when(departmentService.getManagedActiveMembersOfPerson(eq(departmentHead), any(PersonPageable.class), eq("mar")))
             .thenReturn(new PageImpl<>(List.of(hit)));
 
         final List<PersonSuggestion> suggestions = sut.personSuggestions(departmentHead, "mar", MAIN_LINK);
@@ -188,7 +188,7 @@ class PersonSearchSuggestionsProviderTest {
 
         final Person departmentHead = person(1L, "Department", "Head", DEPARTMENT_HEAD);
 
-        when(departmentService.getManagedMembersOfPerson(eq(departmentHead), any(PersonPageable.class), eq("dep")))
+        when(departmentService.getManagedActiveMembersOfPerson(eq(departmentHead), any(PersonPageable.class), eq("dep")))
             .thenReturn(new PageImpl<>(List.of(departmentHead)));
 
         final List<PersonSuggestion> suggestions = sut.personSuggestions(departmentHead, "dep", MAIN_LINK);
@@ -204,7 +204,7 @@ class PersonSearchSuggestionsProviderTest {
         final Person departmentHead = person(1L, "Department", "Head", DEPARTMENT_HEAD);
         final Person hit = person(2L, "Marlene", "Muster");
 
-        when(departmentService.getManagedMembersOfPerson(eq(departmentHead), any(PersonPageable.class), eq("mar")))
+        when(departmentService.getManagedActiveMembersOfPerson(eq(departmentHead), any(PersonPageable.class), eq("mar")))
             .thenReturn(new PageImpl<>(List.of(hit)));
 
         final List<PersonSuggestion> suggestions = sut.personSuggestions(departmentHead, "mar", MAIN_LINK);

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sickdays/SickDaysStatisticsServiceTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sickdays/SickDaysStatisticsServiceTest.java
@@ -83,7 +83,7 @@ class SickDaysStatisticsServiceTest {
             .build();
 
         final PersonPageRequest personPageRequest = PersonPageRequest.of(0, 10, Sort.by("firstName"));
-        when(departmentService.getManagedMembersOfPerson(departmentHead, personPageRequest, ""))
+        when(departmentService.getManagedActiveMembersOfPerson(departmentHead, personPageRequest, ""))
             .thenReturn(new PageImpl<>(List.of(departmentHead, member)));
 
         when(sickNoteService.getForStatesAndPerson(List.of(ACTIVE), List.of(departmentHead, member), startDate, endDate)).thenReturn(List.of(sickNote));
@@ -128,7 +128,7 @@ class SickDaysStatisticsServiceTest {
         departmentHead.setId(42L);
 
         final PersonPageRequest personPageRequest = PersonPageRequest.of(0, 10, Sort.by("firstName"));
-        when(departmentService.getManagedMembersOfPerson(departmentHead, personPageRequest, ""))
+        when(departmentService.getManagedActiveMembersOfPerson(departmentHead, personPageRequest, ""))
             .thenReturn(new PageImpl<>(List.of(departmentHead)));
 
         final PageableSearchQuery pageableSearchQuery = new PageableSearchQuery(PageRequest.of(0, 10, Sort.by("person.firstName")), "");
@@ -162,7 +162,7 @@ class SickDaysStatisticsServiceTest {
             .build();
 
         final PersonPageRequest personPageRequest = PersonPageRequest.of(0, 10, Sort.by("firstName"));
-        when(departmentService.getManagedMembersOfPerson(secondStageAuthority, personPageRequest, ""))
+        when(departmentService.getManagedActiveMembersOfPerson(secondStageAuthority, personPageRequest, ""))
             .thenReturn(new PageImpl<>(List.of(member, secondStageAuthority)));
 
         when(sickNoteService.getForStatesAndPerson(List.of(ACTIVE), List.of(member, secondStageAuthority), startDate, endDate)).thenReturn(List.of(sickNote));
@@ -208,7 +208,7 @@ class SickDaysStatisticsServiceTest {
         secondStageAuthority.setId(42L);
 
         final PersonPageRequest personPageRequest = PersonPageRequest.of(0, 10, Sort.by("firstName"));
-        when(departmentService.getManagedMembersOfPerson(secondStageAuthority, personPageRequest, ""))
+        when(departmentService.getManagedActiveMembersOfPerson(secondStageAuthority, personPageRequest, ""))
             .thenReturn(new PageImpl<>(List.of(secondStageAuthority)));
 
         final PageableSearchQuery pageableSearchQuery = new PageableSearchQuery(PageRequest.of(0, 10, Sort.by("person.firstName")), "");
@@ -416,7 +416,7 @@ class SickDaysStatisticsServiceTest {
         boss.setId(42L);
 
         final PersonPageRequest personPageRequest = PersonPageRequest.of(0, 10, Sort.by("firstName"));
-        when(departmentService.getManagedMembersOfPerson(boss, personPageRequest, "")).thenReturn(new PageImpl<>(List.of(boss)));
+        when(departmentService.getManagedActiveMembersOfPerson(boss, personPageRequest, "")).thenReturn(new PageImpl<>(List.of(boss)));
 
         final PageableSearchQuery pageableSearchQuery = new PageableSearchQuery(PageRequest.of(0, 10, Sort.by("person.firstName")), "");
         final Page<SickDaysDetailedStatistics> allSicknotesPage = sut.getAll(boss, startDate, endDate, pageableSearchQuery);
@@ -449,7 +449,7 @@ class SickDaysStatisticsServiceTest {
             .build();
 
         final PersonPageRequest personPageRequest = PersonPageRequest.of(0, 10, Sort.by("firstName"));
-        when(departmentService.getManagedMembersOfPerson(departmentHead, personPageRequest, ""))
+        when(departmentService.getManagedActiveMembersOfPerson(departmentHead, personPageRequest, ""))
             .thenReturn(new PageImpl<>(List.of(departmentHead, member)));
 
         when(sickNoteService.getForStatesAndPerson(List.of(ACTIVE), List.of(departmentHead, member), startDate, endDate)).thenReturn(List.of(sickNote));
@@ -506,7 +506,7 @@ class SickDaysStatisticsServiceTest {
             .build();
 
         final PersonPageRequest personPageRequest = PersonPageRequest.of(0, 10, Sort.by("firstName"));
-        when(departmentService.getManagedMembersOfPerson(departmentHead, personPageRequest, ""))
+        when(departmentService.getManagedActiveMembersOfPerson(departmentHead, personPageRequest, ""))
             .thenReturn(new PageImpl<>(List.of(departmentHead, member)));
 
         when(sickNoteService.getForStatesAndPerson(List.of(ACTIVE), List.of(departmentHead, member), startDate, endDate)).thenReturn(List.of(sickNote));

--- a/src/test/java/org/synyx/urlaubsverwaltung/web/FrameDataProviderTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/web/FrameDataProviderTest.java
@@ -188,7 +188,7 @@ class FrameDataProviderTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"DEPARTMENT_HEAD", "SECOND_STAGE_AUTHORITY"})
-    void postHandleNoCompanyOvertimeStatisticsLinkForDepartmentRoles(final String role) {
+    void postHandleCompanyOvertimeStatisticsLinkForDepartmentRoles(final String role) {
         mockSettings(true, false, false, false);
 
         final Person person = new Person();
@@ -204,7 +204,7 @@ class FrameDataProviderTest {
 
         assertThat(modelAndView.getModelMap().get("navigation"))
             .isInstanceOfSatisfying(NavigationDto.class, dto ->
-                assertThat(dto.company()).isNotEmpty().doesNotContain(companyOvertimeLink()));
+                assertThat(dto.company()).contains(companyOvertimeLink()));
     }
 
     @Test
@@ -380,7 +380,8 @@ class FrameDataProviderTest {
                 assertThat(dto.company()).containsExactly(
                     companyPersonLink(),
                     companyApplicationsLink(),
-                    companySickNoteLink()
+                    companySickNoteLink(),
+                    companyOvertimeLink()
                 );
                 assertThat(dto.settings()).isEmpty();
             });
@@ -427,7 +428,8 @@ class FrameDataProviderTest {
                 assertThat(dto.company()).containsExactly(
                     companyPersonLink(),
                     companyApplicationsLink(),
-                    companySickNoteLink()
+                    companySickNoteLink(),
+                    companyOvertimeLink()
                 );
                 assertThat(dto.settings()).isEmpty();
             });
@@ -473,7 +475,8 @@ class FrameDataProviderTest {
                 assertThat(dto.company()).containsExactly(
                     companyPersonLink(),
                     companyApplicationsLink(),
-                    companySickNoteLink()
+                    companySickNoteLink(),
+                    companyOvertimeLink()
                 );
                 assertThat(dto.settings()).isEmpty();
             });
@@ -520,7 +523,8 @@ class FrameDataProviderTest {
                 assertThat(dto.company()).containsExactly(
                     companyPersonLink(),
                     companyApplicationsLink(),
-                    companySickNoteLink()
+                    companySickNoteLink(),
+                    companyOvertimeLink()
                 );
                 assertThat(dto.settings()).isEmpty();
             });


### PR DESCRIPTION
The overtime statistics were introduced for Office and Chef only (#6397), while the other three statistics pages under "Unternehmen" have always been open to Abteilungsleiter and Freigabe-Verantwortliche. Those are exactly the people responsible for the overtime of their members - they may already see it per person via `OvertimePermissions#isAllowedToView` - so the aggregate over it was the one thing they could not reach.

The page is company wide in three independent places, and all three are widened:

- **Person resolution.** `OvertimeStatisticsService` picked its own cohort. That moves into a new `OvertimeStatisticsPersons`, alongside `AbsenceStatisticsPersons` and `SickNoteRelevantPersonsService`. Office and boss keep the exact calls they had, so their figures cannot move; a manager gets their managed members. The two blocks of the page ask different questions and therefore get two methods: the year block wants the cohort of that year, the "Gesamtbestand - alle Jahre" block wants whoever is employed and managed right now.
- **Access.** `@PreAuthorize(IS_BOSS_OR_OFFICE)` becomes `IS_PRIVILEGED_USER`, the same set the absence statistics spells out inline.
- **Navigation.** The entry was gated on "may see the overtime of *all* persons". A new `OvertimePermissionEvaluator#isAllowedToViewOvertimeOfOtherPersons` gates it on "of *any* other person", mirroring `SickNotePermissionEvaluator#isAllowedToViewSickNotesOfOtherPersons`. Still switched off entirely while overtime is deactivated.

The page itself is untouched - no template, message bundle, CSS or JavaScript changes. A manager sees the same page with their own numbers and no hint that the scope is narrower, exactly like the other statistics pages behave.

## Who counts as a managed member

Two rules in `DepartmentService#getManagedMembersOfPerson(Person, Year)` are new, and they apply to the absence and sick note statistics too, since all three resolvers call it:

- A member must have been part of the department in the requested year **and still be part of it**. `findAllActiveInYear` matches on `YEAR(validTo) >= :year`, so somebody removed from a department in March still counted for the whole year.
- A department head or second stage authority must **still** lead the department. Handing a department over ends the responsibility for its members, including for the years in which it was led.

Without them the page contradicted itself: in the demo data a Freigabe-Verantwortlicher whose membership had ended showed "Gesamtbestand: keine" directly above "Im Jahr 2026: 216 Std.". The whole-history block asks who is managed now, the year block asked who was managed then - two different cohorts on one screen. Both blocks now describe the same set of people.

`getManagedMembersOfPerson(Person, Year)` remains the only lookup of its family that does not filter by activation, which is deliberate: filtering by `Person::isActive` would make a person deactivated today disappear from 2024. The proper cohort for past years is the person active period, planned separately.

## Fixes on the way

- `DepartmentServiceImpl#getManagedMembersOfPerson(Person, Year)` read the signed-in manager's own memberships out of a `groupingBy` map with `get`, which has no entry for a person without a membership in that year. A department head choosing a year before they joined - the year is a freely editable request parameter - got a `NullPointerException`. The absence statistics has been exposed to this since it started using the method.
- The lookups of the managed member family that always dropped inactive persons say so in their names now: `getManagedActiveMembersOfPerson(Person, PersonPageable, String)` and `getManagedActiveMembersOfPersonAndDepartment(...)`, pairing up with their existing `Inactive` counterparts and no longer sharing a name with the year based lookup that keeps everybody.

## Verified

Beyond the test suites, the page was driven through the real login flow against the demo data, for every role:

| Role | Gesamtbestand | Im Jahr 2026 | Navigation | HTTP |
| --- | --- | --- | --- | --- |
| Office | 938 Std. / 530 Std. / 408 Std. | 395 Std. / 248 Std. / 147 Std. | yes | 200 |
| Abteilungsleiter | 150 Std. 30 Min. / 80 Std. / 70 Std. 30 Min. | 70 Std. / 38 Std. / 32 Std. | yes | 200 |
| Freigabe-Verantwortlicher (no current department) | keine | keine | yes | 200 |
| User | - | - | no | 403 |

A year before any department existed renders zeros instead of an error page, which is the `NullPointerException` above.

closes #6624
