### PR TITLE
Erweiterung von Krankmeldungen: letzten Arbeitstag korrekt erkennen und die Seite nur der Person selbst anbieten

### DIFF
--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteRepository.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteRepository.java
@@ -54,7 +54,7 @@ interface SickNoteRepository extends CrudRepository<SickNoteEntity, Long> {
 
     List<SickNoteEntity> findByStatusInAndPersonInAndEndDateIsGreaterThanEqualAndStartDateIsLessThanEqual(List<SickNoteStatus> sickNoteStatus, List<Person> persons, LocalDate startDate, LocalDate endDate);
 
-    Optional<SickNoteEntity> findFirstByPersonAndStatusInAndEndDateIsLessThanOrderByEndDateDesc(Person person, List<SickNoteStatus> sickNoteStatus, LocalDate now);
+    Optional<SickNoteEntity> findFirstByPersonAndStatusInAndStartDateIsLessThanEqualOrderByEndDateDesc(Person person, List<SickNoteStatus> sickNoteStatus, LocalDate today);
 
     @Modifying
     List<SickNoteEntity> deleteByPerson(Person person);

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteService.java
@@ -37,6 +37,15 @@ public interface SickNoteService {
      */
     List<SickNote> getByPersonAndPeriod(Person person, LocalDate from, LocalDate to);
 
+    /**
+     * Get the sick note of the given person that ended on the last day the person worked before today, which is
+     * yesterday or, if the person did not work since then, an earlier day - the friday before a weekend for instance.
+     * Only a {@link SickNoteStatus#SUBMITTED} or {@link SickNoteStatus#ACTIVE} sick note is taken into account, a still
+     * ongoing one is not.
+     *
+     * @param person defines the owner of the sick note
+     * @return optional sick note of the last work day of the given person
+     */
     Optional<SickNote> getSickNoteOfYesterdayOrLastWorkDay(Person person);
 
     /**

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteService.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteService.java
@@ -38,15 +38,15 @@ public interface SickNoteService {
     List<SickNote> getByPersonAndPeriod(Person person, LocalDate from, LocalDate to);
 
     /**
-     * Get the sick note of the given person that ended on the last day the person worked before today, which is
-     * yesterday or, if the person did not work since then, an earlier day - the friday before a weekend for instance.
-     * Only a {@link SickNoteStatus#SUBMITTED} or {@link SickNoteStatus#ACTIVE} sick note is taken into account, a still
-     * ongoing one is not.
+     * Get the sick note of the given person that a further sick report would extend: the one that covers today or, if
+     * there is none, the one that ended on the last day the person worked before today - which is yesterday or, if the
+     * person did not work since then, an earlier day like the friday before a weekend. Only a
+     * {@link SickNoteStatus#SUBMITTED} or {@link SickNoteStatus#ACTIVE} sick note is taken into account.
      *
      * @param person defines the owner of the sick note
-     * @return optional sick note of the last work day of the given person
+     * @return optional sick note of the given person to extend
      */
-    Optional<SickNote> getSickNoteOfYesterdayOrLastWorkDay(Person person);
+    Optional<SickNote> getSickNoteToExtend(Person person);
 
     /**
      * Get all the sick notes that are reaching the end of sick pay.

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteServiceImpl.java
@@ -81,11 +81,8 @@ class SickNoteServiceImpl implements SickNoteService {
         if (lastSickNote.isPresent()) {
 
             final SickNoteEntity sickNoteEntity = lastSickNote.get();
-            final boolean isSickNoteOfYesterday = sickNoteEntity.getEndDate().isEqual(now.minusDays(1));
-            final boolean isSickNoteOfLastWorkDay = workingTimeCalendarService.getWorkingTimesByPersons(List.of(person), new DateRange(sickNoteEntity.getEndDate(), now))
-                    .get(person).workingDays().size() == 2;
 
-            if (isSickNoteOfYesterday || isSickNoteOfLastWorkDay) {
+            if (endsOnLastWorkDayBefore(sickNoteEntity, now)) {
                 final WorkingTimeCalendar workingTimes = getWorkingTimeCalendar(sickNoteEntity);
                 return Optional.of(sickNoteMapper.toSickNote(sickNoteEntity, workingTimes));
             }
@@ -189,6 +186,32 @@ class SickNoteServiceImpl implements SickNoteService {
         entity.setEndOfSickPayNotificationSend(sickNote.getEndOfSickPayNotificationSend());
         entity.setStatus(sickNote.getStatus());
         return entity;
+    }
+
+    /**
+     * Whether the given sick note ends on the last day the person worked before the given date. That is the case if the
+     * next work day following the end of the sick note is the given date itself, in other words: every day in between is
+     * a day the person does not work on - a weekend, a public holiday or a day off. A sick note ending on the day before
+     * the given date always does.
+     *
+     * @param sickNoteEntity sick note to check, has to end before the given date
+     * @param date           date to look back from, usually today
+     * @return {@code true} if no work day lies between the end of the sick note and the given date
+     */
+    private boolean endsOnLastWorkDayBefore(SickNoteEntity sickNoteEntity, LocalDate date) {
+
+        final Person person = sickNoteEntity.getPerson();
+        final LocalDate endDate = sickNoteEntity.getEndDate();
+
+        final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarService
+            .getWorkingTimesByPersons(List.of(person), new DateRange(endDate, date))
+            .get(person);
+
+        // the calendar ends with the given date, therefore no next work day at all means the person does not work
+        // on any of the days in between - and not on the given date either.
+        return workingTimeCalendar.nextWorkingFollowingTo(endDate)
+            .map(nextWorkDay -> !nextWorkDay.isBefore(date))
+            .orElse(true);
     }
 
     private WorkingTimeCalendar getWorkingTimeCalendar(SickNoteEntity sickNoteEntity) {

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteServiceImpl.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteServiceImpl.java
@@ -73,16 +73,18 @@ class SickNoteServiceImpl implements SickNoteService {
     }
 
     @Override
-    public Optional<SickNote> getSickNoteOfYesterdayOrLastWorkDay(Person person) {
+    public Optional<SickNote> getSickNoteToExtend(Person person) {
 
         final LocalDate now = LocalDate.now(clock);
-        final Optional<SickNoteEntity> lastSickNote = sickNoteRepository.findFirstByPersonAndStatusInAndEndDateIsLessThanOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), now);
+        final Optional<SickNoteEntity> lastSickNote = sickNoteRepository.findFirstByPersonAndStatusInAndStartDateIsLessThanEqualOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), now);
 
         if (lastSickNote.isPresent()) {
 
             final SickNoteEntity sickNoteEntity = lastSickNote.get();
+            // the sick note starts today or earlier, therefore it covers today if it has not ended yet
+            final boolean coversToday = !sickNoteEntity.getEndDate().isBefore(now);
 
-            if (endsOnLastWorkDayBefore(sickNoteEntity, now)) {
+            if (coversToday || endsOnLastWorkDayBefore(sickNoteEntity, now)) {
                 final WorkingTimeCalendar workingTimes = getWorkingTimeCalendar(sickNoteEntity);
                 return Optional.of(sickNoteMapper.toSickNote(sickNoteEntity, workingTimes));
             }
@@ -194,7 +196,7 @@ class SickNoteServiceImpl implements SickNoteService {
      * a day the person does not work on - a weekend, a public holiday or a day off. A sick note ending on the day before
      * the given date always does.
      *
-     * @param sickNoteEntity sick note to check, has to end before the given date
+     * @param sickNoteEntity sick note to check, has to end before the given date, see {@code coversToday}
      * @param date           date to look back from, usually today
      * @return {@code true} if no work day lies between the end of the sick note and the given date
      */

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewController.java
@@ -244,7 +244,6 @@ class SickNoteViewController implements HasLaunchpad, HasPersonSearch {
     ) throws UnknownPersonException {
 
         final Person signedInUser = personService.getSignedInUser();
-        final boolean userIsAllowedToSubmitSickNotes = isUserAllowedToSubmitSickNotes();
 
         final Person sickNotePerson = personId == null
             ? signedInUser
@@ -259,7 +258,8 @@ class SickNoteViewController implements HasLaunchpad, HasPersonSearch {
             throw new AccessDeniedException("User '%s' has not the correct permissions to create a sick note".formatted(signedInUser.getId()));
         }
 
-        if (userIsAllowedToSubmitSickNotes) {
+        // extending a sick note is handing in a sick note, therefore it is offered to the person itself only
+        if (permissions.isAllowedToSubmit()) {
             final boolean noRedirect = noExtensionRedirect != null && (noExtensionRedirect.isEmpty() || "true".equalsIgnoreCase(noExtensionRedirect));
             final Optional<SickNote> sickNoteOfYesterdayOrLastWorkDay = sickNoteService.getSickNoteOfYesterdayOrLastWorkDay(sickNotePerson);
             if (!noRedirect && (sickNoteOfYesterdayOrLastWorkDay.isPresent() && sickNoteOfYesterdayOrLastWorkDay.get().getDayLength().isFull())) {
@@ -660,9 +660,5 @@ class SickNoteViewController implements HasLaunchpad, HasPersonSearch {
     private SickNoteExtendPreviewDto toSickNoteExtensionPreviewDto(SickNote sickNote, SickNoteExtension extension) {
         final BigDecimal workingDays = sickNote.getWorkDays().add(extension.additionalWorkdays());
         return new SickNoteExtendPreviewDto(sickNote.getStartDate(), extension.nextEndDate(), workingDays);
-    }
-
-    private boolean isUserAllowedToSubmitSickNotes() {
-        return settingsService.getSettings().getSickNoteSettings().getUserIsAllowedToSubmitSickNotes();
     }
 }

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewController.java
@@ -261,12 +261,12 @@ class SickNoteViewController implements HasLaunchpad, HasPersonSearch {
         // extending a sick note is handing in a sick note, therefore it is offered to the person itself only
         if (permissions.isAllowedToSubmit()) {
             final boolean noRedirect = noExtensionRedirect != null && (noExtensionRedirect.isEmpty() || "true".equalsIgnoreCase(noExtensionRedirect));
-            final Optional<SickNote> sickNoteOfYesterdayOrLastWorkDay = sickNoteService.getSickNoteOfYesterdayOrLastWorkDay(sickNotePerson);
-            if (!noRedirect && (sickNoteOfYesterdayOrLastWorkDay.isPresent() && sickNoteOfYesterdayOrLastWorkDay.get().getDayLength().isFull())) {
-                LOG.info("sick note of last work day found");
+            final Optional<SickNote> sickNoteToExtend = sickNoteService.getSickNoteToExtend(sickNotePerson);
+            if (!noRedirect && (sickNoteToExtend.isPresent() && sickNoteToExtend.get().getDayLength().isFull())) {
+                LOG.info("sick note to extend found");
                 return "redirect:/web/sicknote/extend";
             } else {
-                LOG.info("no sick note of last work day found");
+                LOG.info("no sick note to extend found");
             }
         }
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendViewController.java
@@ -101,14 +101,13 @@ class SickNoteExtendViewController implements HasLaunchpad, HasPersonSearch {
         final Person signedInUser = personService.getSignedInUser();
         ensureAllowedToSubmitSickNotes(signedInUser);
 
-        final Optional<SickNote> maybeSickNote = getSickNoteOfYesterdayOrLastWorkDay(signedInUser);
+        final Optional<SickNote> maybeSickNote = getSickNoteToExtend(signedInUser);
         if (maybeSickNote.isEmpty() || maybeSickNote.get().getDayLength().isHalfDay()) {
             return "sicknote/sick_note_extended_not_found";
         }
 
         final SickNote sickNote = maybeSickNote.get();
-        final LocalDate today = LocalDate.now(clock);
-        prepareModel(model, signedInUser, today, sickNote);
+        prepareModel(model, signedInUser, null, sickNote);
 
         final SickNoteExtendDto sickNoteExtension = new SickNoteExtendDto(sickNote.getId(), sickNote.getStartDate());
         model.addAttribute("sickNoteExtension", sickNoteExtension);
@@ -134,7 +133,7 @@ class SickNoteExtendViewController implements HasLaunchpad, HasPersonSearch {
         final Person signedInUser = personService.getSignedInUser();
         ensureAllowedToSubmitSickNotes(signedInUser);
 
-        final Optional<SickNote> maybeSickNote = getSickNoteOfYesterdayOrLastWorkDay(signedInUser);
+        final Optional<SickNote> maybeSickNote = getSickNoteToExtend(signedInUser);
         if (maybeSickNote.isEmpty() || maybeSickNote.get().getDayLength().isHalfDay()) {
             return "sicknote/sick_note_extended_not_found";
         }
@@ -234,8 +233,8 @@ class SickNoteExtendViewController implements HasLaunchpad, HasPersonSearch {
         }
     }
 
-    private Optional<SickNote> getSickNoteOfYesterdayOrLastWorkDay(Person signedInUser) {
-        final Optional<SickNote> maybeSickNote = sickNoteService.getSickNoteOfYesterdayOrLastWorkDay(signedInUser);
+    private Optional<SickNote> getSickNoteToExtend(Person signedInUser) {
+        final Optional<SickNote> maybeSickNote = sickNoteService.getSickNoteToExtend(signedInUser);
         if (maybeSickNote.isPresent()) {
             final SickNote sickNote = maybeSickNote.get();
             if (!sickNote.getPerson().equals(signedInUser)) {
@@ -258,10 +257,14 @@ class SickNoteExtendViewController implements HasLaunchpad, HasPersonSearch {
         final LocalDate plusOneWorkdayDate = nextWorkingDayFollowingTo(signedInUser, workingTimeCalendar, sickNote.getEndDate());
         final LocalDate plusTwoWorkdaysDate = nextWorkingDayFollowingTo(signedInUser, workingTimeCalendar, plusOneWorkdayDate);
 
+        // a sick note can only be extended beyond its end, which is in the future while it is still running
+        final LocalDate earliestExtendToDate = Collections.max(List.of(today, sickNote.getEndDate().plusDays(1)));
+
         model.addAttribute("sickNotePersonId", signedInUser.getId());
-        model.addAttribute("today", today);
+        model.addAttribute("earliestExtendToDate", earliestExtendToDate);
+        model.addAttribute("canExtendUntilEndOfWeek", endOfWeek().isAfter(sickNote.getEndDate()));
         model.addAttribute("sickNoteTypeChild", sickNote.getSickNoteType().getCategory().equals(SICK_NOTE_CHILD));
-        model.addAttribute("extendToDate", extendToDate == null ? today : extendToDate);
+        model.addAttribute("extendToDate", requireNonNullElse(extendToDate, earliestExtendToDate));
         model.addAttribute("sickNoteEndDateWord", dateFormatAware.formatWord(sickNote.getEndDate(), FormatStyle.FULL));
         model.addAttribute("plusOneWorkdayWord", dateFormatAware.formatWord(plusOneWorkdayDate, FormatStyle.FULL));
         model.addAttribute("plusTwoWorkdaysWord", dateFormatAware.formatWord(plusTwoWorkdaysDate, FormatStyle.FULL));

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendViewController.java
@@ -99,6 +99,8 @@ class SickNoteExtendViewController implements HasLaunchpad, HasPersonSearch {
     public String extendSickNoteView(Model model) {
 
         final Person signedInUser = personService.getSignedInUser();
+        ensureAllowedToSubmitSickNotes(signedInUser);
+
         final Optional<SickNote> maybeSickNote = getSickNoteOfYesterdayOrLastWorkDay(signedInUser);
         if (maybeSickNote.isEmpty() || maybeSickNote.get().getDayLength().isHalfDay()) {
             return "sicknote/sick_note_extended_not_found";
@@ -130,6 +132,8 @@ class SickNoteExtendViewController implements HasLaunchpad, HasPersonSearch {
         final boolean isCreateExtendSubmit = !hasUserSelectedCustomDate && !hasUserSelectedDays;
 
         final Person signedInUser = personService.getSignedInUser();
+        ensureAllowedToSubmitSickNotes(signedInUser);
+
         final Optional<SickNote> maybeSickNote = getSickNoteOfYesterdayOrLastWorkDay(signedInUser);
         if (maybeSickNote.isEmpty() || maybeSickNote.get().getDayLength().isHalfDay()) {
             return "sicknote/sick_note_extended_not_found";
@@ -222,6 +226,13 @@ class SickNoteExtendViewController implements HasLaunchpad, HasPersonSearch {
         }
     }
 
+
+    private void ensureAllowedToSubmitSickNotes(Person signedInUser) {
+        // extending a sick note is handing in a sick note, which has to be enabled in the settings
+        if (!sickNotePermissionEvaluator.of(signedInUser, signedInUser).isAllowedToSubmit()) {
+            throw new AccessDeniedException("User '%s' is not allowed to hand in a sick note".formatted(signedInUser.getId()));
+        }
+    }
 
     private Optional<SickNote> getSickNoteOfYesterdayOrLastWorkDay(Person signedInUser) {
         final Optional<SickNote> maybeSickNote = sickNoteService.getSickNoteOfYesterdayOrLastWorkDay(signedInUser);

--- a/src/main/resources/templates/person/overview/section-sick-note.html
+++ b/src/main/resources/templates/person/overview/section-sick-note.html
@@ -18,6 +18,7 @@
               class="icon-link flex items-center flex-row-reverse @2xl/main:flex-row"
               href="#"
               th:href="@{/web/sicknote/new (person=${person.id})}"
+              data-test-id="add-sick-note"
             >
               <svg th:replace="~{icon/plus-square::svg(className='w-5 h-5')}"></svg>&nbsp;
               <span th:text="#{action.apply.sicknote}"></span>

--- a/src/main/resources/templates/sicknote/sick_note_extend.html
+++ b/src/main/resources/templates/sicknote/sick_note_extend.html
@@ -137,22 +137,24 @@
             >
               einschließlich morgen
             </span>
-            <button
-              class="button sicknote-extend-button"
-              th:aria-pressed="${selectedExtend == 'end-of-week'}"
-              th:text="#{sicknote.extend.duration.end-of-week.label}"
-              name="extend"
-              value="end-of-week"
-            >
-              Ende der Woche
-            </button>
-            <span
-              class="extend-label"
-              th:with="word=${'<span class=extend-label_date>' + untilEndOfWeekWord + '</span>'}"
-              th:utext="#{sicknote.extend.duration.hint.label(${word})}"
-            >
-              einschließlich xxx
-            </span>
+            <th:block th:if="${canExtendUntilEndOfWeek}">
+              <button
+                class="button sicknote-extend-button"
+                th:aria-pressed="${selectedExtend == 'end-of-week'}"
+                th:text="#{sicknote.extend.duration.end-of-week.label}"
+                name="extend"
+                value="end-of-week"
+              >
+                Ende der Woche
+              </button>
+              <span
+                class="extend-label"
+                th:with="word=${'<span class=extend-label_date>' + untilEndOfWeekWord + '</span>'}"
+                th:utext="#{sicknote.extend.duration.hint.label(${word})}"
+              >
+                einschließlich xxx
+              </span>
+            </th:block>
             <input
               type="date"
               id="extend-to-date-input"
@@ -165,7 +167,7 @@
               data-auto-submit="submit-date-button"
               data-auto-submit-delay="100"
               th:value="${extendToDate}"
-              th:min="${#temporals.format(today, 'yyyy-MM-dd')}"
+              th:min="${#temporals.format(earliestExtendToDate, 'yyyy-MM-dd')}"
               th:data-iso-value="${#temporals.format(extendToDate, 'yyyy-MM-dd')}"
             />
             <span>

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteRepositoryIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteRepositoryIT.java
@@ -16,6 +16,7 @@ import org.synyx.urlaubsverwaltung.sicknote.sicknotetype.SickNoteTypeService;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import static java.time.Month.FEBRUARY;
 import static java.time.Month.MARCH;
@@ -25,6 +26,7 @@ import static java.time.temporal.TemporalAdjusters.lastDayOfMonth;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteStatus.ACTIVE;
 import static org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteStatus.CANCELLED;
+import static org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteStatus.SUBMITTED;
 
 @SpringBootTest
 @Transactional
@@ -313,6 +315,32 @@ class SickNoteRepositoryIT extends SingleTenantTestContainersBase {
 
         assertThat(sickNotes).hasSize(expectedSickNoteCount);
         return statistics.getPrepareStatementCount();
+    }
+
+    @Test
+    void ensureTheSickNoteToExtendIsTheStillRunningOne() {
+
+        final Person person = personService.create("muster", "Max", "Mustermann", "mustermann@example.org");
+        final LocalDate today = LocalDate.now(UTC);
+
+        final SickNoteEntity ended = createSickNote(person, today.minusDays(10), today.minusDays(8), ACTIVE);
+        sickNoteRepository.save(ended);
+
+        final SickNoteEntity running = createSickNote(person, today.minusDays(1), today.plusDays(2), ACTIVE);
+        sickNoteRepository.save(running);
+
+        // starts after today, therefore nothing to extend yet
+        final SickNoteEntity upcoming = createSickNote(person, today.plusDays(5), today.plusDays(6), ACTIVE);
+        sickNoteRepository.save(upcoming);
+
+        // covers today, but has been cancelled
+        final SickNoteEntity cancelled = createSickNote(person, today, today.plusDays(9), CANCELLED);
+        sickNoteRepository.save(cancelled);
+
+        final Optional<SickNoteEntity> actual = sickNoteRepository
+            .findFirstByPersonAndStatusInAndStartDateIsLessThanEqualOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), today);
+
+        assertThat(actual).hasValue(running);
     }
 
     private SickNoteEntity createSickNote(Person person, LocalDate startDate, LocalDate endDate, SickNoteStatus active) {

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteServiceImplTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.when;
 import static org.synyx.urlaubsverwaltung.person.Role.USER;
 import static org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteStatus.ACTIVE;
 import static org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteStatus.SUBMITTED;
+import static org.synyx.urlaubsverwaltung.workingtime.WorkingTimeCalendarFactory.workingTimeCalendarMondayToFriday;
 import static org.synyx.urlaubsverwaltung.workingtime.WorkingTimeCalendarFactory.workingTimeCalendarMondayToSunday;
 
 @ExtendWith(MockitoExtension.class)
@@ -233,37 +234,107 @@ class SickNoteServiceImplTest {
     }
 
     @Test
-    void ensureSickNoteOfLastWorkDayWithPersonNotWorkingYesterday() {
+    void ensureSickNoteOfLastWorkDayWhenWeekendIsBetweenSickNoteAndToday() {
 
         final Person person = new Person();
         person.setId(1L);
 
-        final LocalDate now = LocalDate.now(fixedClock);
-        final LocalDate startDate = now.minusDays(2);
-        final LocalDate endDate = now.minusDays(2);
+        // 2021-06-28 is a monday, the sick note ended on the friday before
+        final LocalDate monday = LocalDate.now(fixedClock);
+        final LocalDate friday = monday.minusDays(3);
 
         final SickNoteEntity entity = new SickNoteEntity();
         entity.setId(1L);
         entity.setPerson(person);
-        entity.setStartDate(startDate);
-        entity.setEndDate(endDate);
+        entity.setStartDate(friday);
+        entity.setEndDate(friday);
 
-        when(sickNoteRepository.findFirstByPersonAndStatusInAndEndDateIsLessThanOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), now))
+        when(sickNoteRepository.findFirstByPersonAndStatusInAndEndDateIsLessThanOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), monday))
             .thenReturn(Optional.of(entity));
 
-        // TODO fixme... implementation is wrong... since it only checks for map entry size of two, instead of checking actual working days
-        final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(endDate, now.minusDays(1));
-        when(workingTimeCalendarService.getWorkingTimesByPersons(List.of(person), new DateRange(endDate, now)))
+        final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToFriday(friday, monday);
+        when(workingTimeCalendarService.getWorkingTimesByPersons(List.of(person), new DateRange(friday, monday)))
             .thenReturn(Map.of(person, workingTimeCalendar));
 
-        final WorkingTimeCalendar entityWorkingTimeCalendar = workingTimeCalendarMondayToSunday(startDate, endDate);
-        when(workingTimeCalendarService.getWorkingTimesByPersons(List.of(person), new DateRange(startDate, endDate)))
+        final WorkingTimeCalendar entityWorkingTimeCalendar = workingTimeCalendarMondayToFriday(friday, friday);
+        when(workingTimeCalendarService.getWorkingTimesByPersons(List.of(person), new DateRange(friday, friday)))
             .thenReturn(Map.of(person, entityWorkingTimeCalendar));
 
         final SickNote sickNote = SickNote.builder().build();
         when(sickNoteMapper.toSickNote(entity, entityWorkingTimeCalendar)).thenReturn(sickNote);
 
         final Optional<SickNote> actual = sut.getSickNoteOfYesterdayOrLastWorkDay(person);
+        assertThat(actual).isPresent().get().isSameAs(sickNote);
+    }
+
+    @Test
+    void ensureSickNoteOfLastWorkDayWhenPersonDoesNotWorkOnTheDaysInBetween() {
+
+        final Person person = new Person();
+        person.setId(1L);
+
+        // 2021-06-28 is a monday, the sick note ended on the thursday before, the person does not work on fridays
+        final LocalDate monday = LocalDate.now(fixedClock);
+        final LocalDate thursday = monday.minusDays(4);
+
+        final SickNoteEntity entity = new SickNoteEntity();
+        entity.setId(1L);
+        entity.setPerson(person);
+        entity.setStartDate(thursday);
+        entity.setEndDate(thursday);
+
+        when(sickNoteRepository.findFirstByPersonAndStatusInAndEndDateIsLessThanOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), monday))
+            .thenReturn(Optional.of(entity));
+
+        final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(thursday, monday, date -> date.isEqual(thursday) || date.isEqual(monday));
+        when(workingTimeCalendarService.getWorkingTimesByPersons(List.of(person), new DateRange(thursday, monday)))
+            .thenReturn(Map.of(person, workingTimeCalendar));
+
+        final WorkingTimeCalendar entityWorkingTimeCalendar = workingTimeCalendarMondayToSunday(thursday, thursday);
+        when(workingTimeCalendarService.getWorkingTimesByPersons(List.of(person), new DateRange(thursday, thursday)))
+            .thenReturn(Map.of(person, entityWorkingTimeCalendar));
+
+        final SickNote sickNote = SickNote.builder().build();
+        when(sickNoteMapper.toSickNote(entity, entityWorkingTimeCalendar)).thenReturn(sickNote);
+
+        final Optional<SickNote> actual = sut.getSickNoteOfYesterdayOrLastWorkDay(person);
+        assertThat(actual).isPresent().get().isSameAs(sickNote);
+    }
+
+    @Test
+    void ensureSickNoteOfLastWorkDayWhenTodayIsNotAWorkDay() {
+
+        final Person person = new Person();
+        person.setId(1L);
+
+        // 2021-06-27 is a sunday, the sick note ended on the friday before
+        final Clock sundayClock = Clock.fixed(Instant.parse("2021-06-27T00:00:00.00Z"), UTC);
+        final SickNoteServiceImpl sutOnSunday = new SickNoteServiceImpl(sickNoteRepository, settingsService, workingTimeCalendarService, sickNoteMapper, sundayClock);
+
+        final LocalDate sunday = LocalDate.now(sundayClock);
+        final LocalDate friday = sunday.minusDays(2);
+
+        final SickNoteEntity entity = new SickNoteEntity();
+        entity.setId(1L);
+        entity.setPerson(person);
+        entity.setStartDate(friday);
+        entity.setEndDate(friday);
+
+        when(sickNoteRepository.findFirstByPersonAndStatusInAndEndDateIsLessThanOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), sunday))
+            .thenReturn(Optional.of(entity));
+
+        final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToFriday(friday, sunday);
+        when(workingTimeCalendarService.getWorkingTimesByPersons(List.of(person), new DateRange(friday, sunday)))
+            .thenReturn(Map.of(person, workingTimeCalendar));
+
+        final WorkingTimeCalendar entityWorkingTimeCalendar = workingTimeCalendarMondayToFriday(friday, friday);
+        when(workingTimeCalendarService.getWorkingTimesByPersons(List.of(person), new DateRange(friday, friday)))
+            .thenReturn(Map.of(person, entityWorkingTimeCalendar));
+
+        final SickNote sickNote = SickNote.builder().build();
+        when(sickNoteMapper.toSickNote(entity, entityWorkingTimeCalendar)).thenReturn(sickNote);
+
+        final Optional<SickNote> actual = sutOnSunday.getSickNoteOfYesterdayOrLastWorkDay(person);
         assertThat(actual).isPresent().get().isSameAs(sickNote);
     }
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteServiceImplTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteServiceImplTest.java
@@ -30,6 +30,7 @@ import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.synyx.urlaubsverwaltung.person.Role.USER;
@@ -181,7 +182,7 @@ class SickNoteServiceImplTest {
         entity.setStartDate(startDate);
         entity.setEndDate(endDate);
 
-        when(sickNoteRepository.findFirstByPersonAndStatusInAndEndDateIsLessThanOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), now))
+        when(sickNoteRepository.findFirstByPersonAndStatusInAndStartDateIsLessThanEqualOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), now))
             .thenReturn(Optional.of(entity));
 
         final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(endDate, now);
@@ -195,7 +196,7 @@ class SickNoteServiceImplTest {
         final SickNote sickNote = SickNote.builder().id(1L).build();
         when(sickNoteMapper.toSickNote(entity, entityWorkingTimeCalendar)).thenReturn(sickNote);
 
-        final Optional<SickNote> actual = sut.getSickNoteOfYesterdayOrLastWorkDay(person);
+        final Optional<SickNote> actual = sut.getSickNoteToExtend(person);
         assertThat(actual).isPresent().get().isSameAs(sickNote);
     }
 
@@ -214,7 +215,7 @@ class SickNoteServiceImplTest {
         entity.setStartDate(startDate);
         entity.setEndDate(endDate);
 
-        when(sickNoteRepository.findFirstByPersonAndStatusInAndEndDateIsLessThanOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), now))
+        when(sickNoteRepository.findFirstByPersonAndStatusInAndStartDateIsLessThanEqualOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), now))
             .thenReturn(Optional.of(entity));
 
         // person does not work yesterday
@@ -229,7 +230,69 @@ class SickNoteServiceImplTest {
         final SickNote sickNote = SickNote.builder().build();
         when(sickNoteMapper.toSickNote(entity, entityWorkingTimeCalendar)).thenReturn(sickNote);
 
-        final Optional<SickNote> actual = sut.getSickNoteOfYesterdayOrLastWorkDay(person);
+        final Optional<SickNote> actual = sut.getSickNoteToExtend(person);
+        assertThat(actual).isPresent().get().isSameAs(sickNote);
+    }
+
+    @Test
+    void ensureSickNoteEndingTodayIsTheSickNoteToExtend() {
+
+        final Person person = new Person();
+        person.setId(1L);
+
+        final LocalDate now = LocalDate.now(fixedClock);
+        final LocalDate startDate = now.minusDays(3);
+
+        final SickNoteEntity entity = new SickNoteEntity();
+        entity.setId(1L);
+        entity.setPerson(person);
+        entity.setStartDate(startDate);
+        entity.setEndDate(now);
+
+        when(sickNoteRepository.findFirstByPersonAndStatusInAndStartDateIsLessThanEqualOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), now))
+            .thenReturn(Optional.of(entity));
+
+        final WorkingTimeCalendar entityWorkingTimeCalendar = workingTimeCalendarMondayToFriday(startDate, now);
+        when(workingTimeCalendarService.getWorkingTimesByPersons(List.of(person), new DateRange(startDate, now)))
+            .thenReturn(Map.of(person, entityWorkingTimeCalendar));
+
+        final SickNote sickNote = SickNote.builder().build();
+        when(sickNoteMapper.toSickNote(entity, entityWorkingTimeCalendar)).thenReturn(sickNote);
+
+        final Optional<SickNote> actual = sut.getSickNoteToExtend(person);
+        assertThat(actual).isPresent().get().isSameAs(sickNote);
+
+        // a sick note that covers today makes the question for the last work day pointless
+        verify(workingTimeCalendarService, never()).getWorkingTimesByPersons(List.of(person), new DateRange(now, now));
+    }
+
+    @Test
+    void ensureSickNoteEndingInTheFutureIsTheSickNoteToExtend() {
+
+        final Person person = new Person();
+        person.setId(1L);
+
+        final LocalDate now = LocalDate.now(fixedClock);
+        final LocalDate startDate = now.minusDays(1);
+        final LocalDate endDate = now.plusDays(2);
+
+        final SickNoteEntity entity = new SickNoteEntity();
+        entity.setId(1L);
+        entity.setPerson(person);
+        entity.setStartDate(startDate);
+        entity.setEndDate(endDate);
+
+        when(sickNoteRepository.findFirstByPersonAndStatusInAndStartDateIsLessThanEqualOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), now))
+            .thenReturn(Optional.of(entity));
+
+        final WorkingTimeCalendar entityWorkingTimeCalendar = workingTimeCalendarMondayToFriday(startDate, endDate);
+        when(workingTimeCalendarService.getWorkingTimesByPersons(List.of(person), new DateRange(startDate, endDate)))
+            .thenReturn(Map.of(person, entityWorkingTimeCalendar));
+
+        final SickNote sickNote = SickNote.builder().build();
+        when(sickNoteMapper.toSickNote(entity, entityWorkingTimeCalendar)).thenReturn(sickNote);
+
+        final Optional<SickNote> actual = sut.getSickNoteToExtend(person);
         assertThat(actual).isPresent().get().isSameAs(sickNote);
     }
 
@@ -249,7 +312,7 @@ class SickNoteServiceImplTest {
         entity.setStartDate(friday);
         entity.setEndDate(friday);
 
-        when(sickNoteRepository.findFirstByPersonAndStatusInAndEndDateIsLessThanOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), monday))
+        when(sickNoteRepository.findFirstByPersonAndStatusInAndStartDateIsLessThanEqualOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), monday))
             .thenReturn(Optional.of(entity));
 
         final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToFriday(friday, monday);
@@ -263,7 +326,7 @@ class SickNoteServiceImplTest {
         final SickNote sickNote = SickNote.builder().build();
         when(sickNoteMapper.toSickNote(entity, entityWorkingTimeCalendar)).thenReturn(sickNote);
 
-        final Optional<SickNote> actual = sut.getSickNoteOfYesterdayOrLastWorkDay(person);
+        final Optional<SickNote> actual = sut.getSickNoteToExtend(person);
         assertThat(actual).isPresent().get().isSameAs(sickNote);
     }
 
@@ -283,7 +346,7 @@ class SickNoteServiceImplTest {
         entity.setStartDate(thursday);
         entity.setEndDate(thursday);
 
-        when(sickNoteRepository.findFirstByPersonAndStatusInAndEndDateIsLessThanOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), monday))
+        when(sickNoteRepository.findFirstByPersonAndStatusInAndStartDateIsLessThanEqualOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), monday))
             .thenReturn(Optional.of(entity));
 
         final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(thursday, monday, date -> date.isEqual(thursday) || date.isEqual(monday));
@@ -297,7 +360,7 @@ class SickNoteServiceImplTest {
         final SickNote sickNote = SickNote.builder().build();
         when(sickNoteMapper.toSickNote(entity, entityWorkingTimeCalendar)).thenReturn(sickNote);
 
-        final Optional<SickNote> actual = sut.getSickNoteOfYesterdayOrLastWorkDay(person);
+        final Optional<SickNote> actual = sut.getSickNoteToExtend(person);
         assertThat(actual).isPresent().get().isSameAs(sickNote);
     }
 
@@ -320,7 +383,7 @@ class SickNoteServiceImplTest {
         entity.setStartDate(friday);
         entity.setEndDate(friday);
 
-        when(sickNoteRepository.findFirstByPersonAndStatusInAndEndDateIsLessThanOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), sunday))
+        when(sickNoteRepository.findFirstByPersonAndStatusInAndStartDateIsLessThanEqualOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), sunday))
             .thenReturn(Optional.of(entity));
 
         final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToFriday(friday, sunday);
@@ -334,7 +397,7 @@ class SickNoteServiceImplTest {
         final SickNote sickNote = SickNote.builder().build();
         when(sickNoteMapper.toSickNote(entity, entityWorkingTimeCalendar)).thenReturn(sickNote);
 
-        final Optional<SickNote> actual = sutOnSunday.getSickNoteOfYesterdayOrLastWorkDay(person);
+        final Optional<SickNote> actual = sutOnSunday.getSickNoteToExtend(person);
         assertThat(actual).isPresent().get().isSameAs(sickNote);
     }
 
@@ -353,12 +416,12 @@ class SickNoteServiceImplTest {
         entity.setStartDate(startDate);
         entity.setEndDate(endDate);
 
-        when(sickNoteRepository.findFirstByPersonAndStatusInAndEndDateIsLessThanOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), now)).thenReturn(Optional.of(entity));
+        when(sickNoteRepository.findFirstByPersonAndStatusInAndStartDateIsLessThanEqualOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), now)).thenReturn(Optional.of(entity));
 
         final WorkingTimeCalendar workingTimeCalendar = workingTimeCalendarMondayToSunday(endDate, now);
         when(workingTimeCalendarService.getWorkingTimesByPersons(List.of(person), new DateRange(endDate, now))).thenReturn(Map.of(person, workingTimeCalendar));
 
-        assertThat(sut.getSickNoteOfYesterdayOrLastWorkDay(person)).isEmpty();
+        assertThat(sut.getSickNoteToExtend(person)).isEmpty();
     }
 
     @Test
@@ -369,8 +432,8 @@ class SickNoteServiceImplTest {
         final Person person = new Person();
         person.setId(1L);
 
-        when(sickNoteRepository.findFirstByPersonAndStatusInAndEndDateIsLessThanOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), now)).thenReturn(Optional.empty());
-        assertThat(sut.getSickNoteOfYesterdayOrLastWorkDay(person)).isEmpty();
+        when(sickNoteRepository.findFirstByPersonAndStatusInAndStartDateIsLessThanEqualOrderByEndDateDesc(person, List.of(SUBMITTED, ACTIVE), now)).thenReturn(Optional.empty());
+        assertThat(sut.getSickNoteToExtend(person)).isEmpty();
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewControllerTest.java
@@ -221,7 +221,7 @@ class SickNoteViewControllerTest {
 
         when(personService.getSignedInUser()).thenReturn(person);
         when(personService.getPersonByID(1L)).thenReturn(Optional.of(person));
-        when(sickNoteService.getSickNoteOfYesterdayOrLastWorkDay(person)).thenReturn(Optional.of(SickNote.builder().id(1L).dayLength(dayLength).build()));
+        when(sickNoteService.getSickNoteToExtend(person)).thenReturn(Optional.of(SickNote.builder().id(1L).dayLength(dayLength).build()));
 
         perform(get("/web/sicknote/new").param("person", "1"))
             .andExpect(status().isOk())
@@ -238,7 +238,7 @@ class SickNoteViewControllerTest {
 
         when(personService.getSignedInUser()).thenReturn(person);
         when(personService.getPersonByID(1L)).thenReturn(Optional.of(person));
-        when(sickNoteService.getSickNoteOfYesterdayOrLastWorkDay(person)).thenReturn(Optional.of(SickNote.builder().id(1L).dayLength(FULL).build()));
+        when(sickNoteService.getSickNoteToExtend(person)).thenReturn(Optional.of(SickNote.builder().id(1L).dayLength(FULL).build()));
 
         perform(get("/web/sicknote/new").param("person", "1"))
             .andExpect(status().is3xxRedirection())
@@ -263,7 +263,7 @@ class SickNoteViewControllerTest {
             .andExpect(view().name("sicknote/sick_note_form"));
 
         // only the person itself may hand in a sick note, therefore an extension is out of question here
-        verify(sickNoteService, never()).getSickNoteOfYesterdayOrLastWorkDay(any());
+        verify(sickNoteService, never()).getSickNoteToExtend(any());
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/SickNoteViewControllerTest.java
@@ -66,6 +66,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -242,6 +243,27 @@ class SickNoteViewControllerTest {
         perform(get("/web/sicknote/new").param("person", "1"))
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrl("/web/sicknote/extend"));
+    }
+
+    @Test
+    void ensureGetNewSickNoteForAnotherPersonDoesNotRedirectToExtend() throws Exception {
+
+        userIsAllowedToSubmitSickNotes(true);
+
+        final Person office = personWithRole(OFFICE, SICK_NOTE_ADD);
+        office.setId(1L);
+
+        final Person person = personWithId(2L);
+
+        when(personService.getSignedInUser()).thenReturn(office);
+        when(personService.getPersonByID(2L)).thenReturn(Optional.of(person));
+
+        perform(get("/web/sicknote/new").param("person", "2"))
+            .andExpect(status().isOk())
+            .andExpect(view().name("sicknote/sick_note_form"));
+
+        // only the person itself may hand in a sick note, therefore an extension is out of question here
+        verify(sickNoteService, never()).getSickNoteOfYesterdayOrLastWorkDay(any());
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendViewControllerTest.java
@@ -1,8 +1,10 @@
 package org.synyx.urlaubsverwaltung.sicknote.sicknote.extend;
 
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -15,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.synyx.urlaubsverwaltung.absence.DateRange;
 import org.synyx.urlaubsverwaltung.department.DepartmentService;
 import org.synyx.urlaubsverwaltung.period.DayLength;
 import org.synyx.urlaubsverwaltung.person.Person;
@@ -27,12 +30,17 @@ import org.synyx.urlaubsverwaltung.settings.SettingsService;
 import org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNote;
 import org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNotePermissionEvaluator;
 import org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteService;
+import org.synyx.urlaubsverwaltung.sicknote.sicknotetype.SickNoteType;
 import org.synyx.urlaubsverwaltung.web.DateFormatAware;
 import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeCalendarService;
 
+import static java.time.Month.OCTOBER;
 import static java.time.Month.SEPTEMBER;
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -40,6 +48,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
@@ -48,6 +57,8 @@ import static org.synyx.urlaubsverwaltung.period.DayLength.FULL;
 import static org.synyx.urlaubsverwaltung.person.Role.BOSS;
 import static org.synyx.urlaubsverwaltung.person.Role.SICK_NOTE_EDIT;
 import static org.synyx.urlaubsverwaltung.person.Role.USER;
+import static org.synyx.urlaubsverwaltung.sicknote.sicknote.SickNoteCategory.SICK_NOTE;
+import static org.synyx.urlaubsverwaltung.workingtime.WorkingTimeCalendarFactory.workingTimeCalendarMondayToFriday;
 
 @ExtendWith(MockitoExtension.class)
 class SickNoteExtendViewControllerTest {
@@ -73,7 +84,8 @@ class SickNoteExtendViewControllerTest {
     @Mock
     private PersonSearchUiFragmentSupplier personSearchUiFragmentSupplier;
 
-    private final Clock clock = Clock.systemUTC();
+    // 2024-09-25 is a wednesday
+    private final Clock clock = Clock.fixed(Instant.parse("2024-09-25T00:00:00.00Z"), UTC);
     private final Settings settings = new Settings();
 
     @BeforeEach
@@ -122,7 +134,7 @@ class SickNoteExtendViewControllerTest {
             .dayLength(dayLength)
             .build();
 
-        when(sickNoteService.getSickNoteOfYesterdayOrLastWorkDay(person))
+        when(sickNoteService.getSickNoteToExtend(person))
             .thenReturn(Optional.of(currentActiveSickNote));
 
         perform(
@@ -150,7 +162,7 @@ class SickNoteExtendViewControllerTest {
             .dayLength(FULL)
             .build();
 
-        when(sickNoteService.getSickNoteOfYesterdayOrLastWorkDay(person))
+        when(sickNoteService.getSickNoteToExtend(person))
             .thenReturn(Optional.of(currentActiveSickNote));
 
         perform(
@@ -183,7 +195,7 @@ class SickNoteExtendViewControllerTest {
             .dayLength(FULL)
             .build();
 
-        when(sickNoteService.getSickNoteOfYesterdayOrLastWorkDay(person))
+        when(sickNoteService.getSickNoteToExtend(person))
             .thenReturn(Optional.of(currentActiveSickNote));
 
         perform(
@@ -214,7 +226,7 @@ class SickNoteExtendViewControllerTest {
             .dayLength(dayLength)
             .build();
 
-        when(sickNoteService.getSickNoteOfYesterdayOrLastWorkDay(person))
+        when(sickNoteService.getSickNoteToExtend(person))
             .thenReturn(Optional.of(currentActiveSickNote));
 
         perform(
@@ -226,6 +238,60 @@ class SickNoteExtendViewControllerTest {
             .andExpect(view().name("sicknote/sick_note_extended_not_found"));
 
         verifyNoInteractions(sickNoteExtensionService);
+    }
+
+    @Test
+    void ensureExtendViewOffersTheEndOfWeekAndTodayForASickNoteThatHasEnded() throws Exception {
+
+        final Person person = new Person();
+        person.setId(1L);
+        person.setPermissions(List.of(USER));
+
+        when(personService.getSignedInUser()).thenReturn(person);
+        sickNoteToExtend(person, LocalDate.of(2024, SEPTEMBER, 23), LocalDate.of(2024, SEPTEMBER, 24));
+
+        perform(get("/web/sicknote/extend"))
+            .andExpect(status().isOk())
+            .andExpect(view().name("sicknote/sick_note_extend"))
+            .andExpect(model().attribute("canExtendUntilEndOfWeek", true))
+            .andExpect(model().attribute("earliestExtendToDate", LocalDate.of(2024, SEPTEMBER, 25)));
+    }
+
+    @Test
+    void ensureExtendViewOffersNeitherTheEndOfWeekNorTodayForASickNoteRunningBeyondThisWeek() throws Exception {
+
+        final Person person = new Person();
+        person.setId(1L);
+        person.setPermissions(List.of(USER));
+
+        when(personService.getSignedInUser()).thenReturn(person);
+        // the sick note runs until monday next week, the end of this week is behind its end date
+        sickNoteToExtend(person, LocalDate.of(2024, SEPTEMBER, 23), LocalDate.of(2024, SEPTEMBER, 30));
+
+        perform(get("/web/sicknote/extend"))
+            .andExpect(status().isOk())
+            .andExpect(view().name("sicknote/sick_note_extend"))
+            .andExpect(model().attribute("canExtendUntilEndOfWeek", false))
+            .andExpect(model().attribute("earliestExtendToDate", LocalDate.of(2024, OCTOBER, 1)));
+    }
+
+    private void sickNoteToExtend(Person person, LocalDate startDate, LocalDate endDate) {
+
+        final SickNoteType sickNoteType = new SickNoteType();
+        sickNoteType.setCategory(SICK_NOTE);
+
+        final SickNote sickNote = SickNote.builder()
+            .id(1L)
+            .person(person)
+            .dayLength(FULL)
+            .startDate(startDate)
+            .endDate(endDate)
+            .sickNoteType(sickNoteType)
+            .build();
+
+        when(sickNoteService.getSickNoteToExtend(person)).thenReturn(Optional.of(sickNote));
+        when(workingTimeCalendarService.getWorkingTimesByPersons(eq(List.of(person)), any(DateRange.class)))
+            .thenReturn(Map.of(person, workingTimeCalendarMondayToFriday(startDate.minusDays(7), endDate.plusDays(14))));
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendViewControllerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.synyx.urlaubsverwaltung.department.DepartmentService;
@@ -31,6 +32,7 @@ import org.synyx.urlaubsverwaltung.workingtime.WorkingTimeCalendarService;
 
 import static java.time.Month.SEPTEMBER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -72,19 +74,21 @@ class SickNoteExtendViewControllerTest {
     private PersonSearchUiFragmentSupplier personSearchUiFragmentSupplier;
 
     private final Clock clock = Clock.systemUTC();
+    private final Settings settings = new Settings();
 
     @BeforeEach
     void setUp() {
+        settings.getSickNoteSettings().setUserIsAllowedToSubmitSickNotes(true);
         sut = new SickNoteExtendViewController(personService, workingTimeCalendarService,
             sickNoteService, sickNoteExtensionService, sickNoteExtensionInteractionService,
-            new SickNotePermissionEvaluator(mock(DepartmentService.class), settingsServiceWithDefaultSettings()),
+            new SickNotePermissionEvaluator(mock(DepartmentService.class), settingsServiceWith(settings)),
             sickNoteExtendValidator, dateFormatAware, defaultPersonSuggestionUrlStrategy, personSearchUiFragmentSupplier,
             clock);
     }
 
-    private static SettingsService settingsServiceWithDefaultSettings() {
+    private static SettingsService settingsServiceWith(Settings settings) {
         final SettingsService settingsService = mock(SettingsService.class);
-        lenient().when(settingsService.getSettings()).thenReturn(new Settings());
+        lenient().when(settingsService.getSettings()).thenReturn(settings);
         return settingsService;
     }
 
@@ -222,6 +226,46 @@ class SickNoteExtendViewControllerTest {
             .andExpect(view().name("sicknote/sick_note_extended_not_found"));
 
         verifyNoInteractions(sickNoteExtensionService);
+    }
+
+    @Test
+    void ensureExtendViewIsForbiddenWhenSubmissionOfSickNotesIsDisabled() {
+
+        settings.getSickNoteSettings().setUserIsAllowedToSubmitSickNotes(false);
+
+        final Person person = new Person();
+        person.setId(1L);
+        person.setPermissions(List.of(USER));
+
+        when(personService.getSignedInUser()).thenReturn(person);
+
+        assertThatThrownBy(() ->
+            perform(get("/web/sicknote/extend"))
+        ).hasCauseInstanceOf(AccessDeniedException.class);
+
+        verifyNoInteractions(sickNoteService);
+    }
+
+    @Test
+    void ensureExtendingSickNoteIsForbiddenWhenSubmissionOfSickNotesIsDisabled() {
+
+        settings.getSickNoteSettings().setUserIsAllowedToSubmitSickNotes(false);
+
+        final Person person = new Person();
+        person.setId(1L);
+        person.setPermissions(List.of(USER));
+
+        when(personService.getSignedInUser()).thenReturn(person);
+
+        assertThatThrownBy(() ->
+            perform(
+                post("/web/sicknote/extend")
+                    .param("sickNoteId", "1")
+                    .param("endDate", "2024-09-27")
+            )
+        ).hasCauseInstanceOf(AccessDeniedException.class);
+
+        verifyNoInteractions(sickNoteExtensionInteractionService);
     }
 
     private ResultActions perform(MockHttpServletRequestBuilder builder) throws Exception {

--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/SickNoteUIIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/SickNoteUIIT.java
@@ -25,6 +25,7 @@ import org.synyx.urlaubsverwaltung.ui.extension.UiIntegrationTest;
 import org.synyx.urlaubsverwaltung.ui.extension.UiTest;
 import org.synyx.urlaubsverwaltung.ui.pages.LoginPage;
 import org.synyx.urlaubsverwaltung.ui.pages.NavigationPage;
+import org.synyx.urlaubsverwaltung.ui.pages.OverviewPage;
 import org.synyx.urlaubsverwaltung.ui.pages.SickNoteDetailPage;
 import org.synyx.urlaubsverwaltung.ui.pages.SickNoteExtensionPage;
 import org.synyx.urlaubsverwaltung.ui.pages.SickNoteFormPage;
@@ -75,8 +76,10 @@ class SickNoteUIIT {
         @Bean
         @Primary
         public Clock clock() {
-            // use a fixed clock to avoid weekends or public holidays while creating sick notes
-            return Clock.fixed(Instant.parse("2022-02-01T00:00:00.00Z"), ZoneId.systemDefault());
+            // use a fixed clock to avoid weekends or public holidays while creating sick notes.
+            // 2022-02-07 is a monday, therefore the friday before is the last work day of a person
+            // that does not work on weekends.
+            return Clock.fixed(Instant.parse("2022-02-07T00:00:00.00Z"), ZoneId.systemDefault());
         }
 
         @Bean
@@ -85,6 +88,11 @@ class SickNoteUIIT {
             return sessionRepository -> sessionRepository.setCleanupCron(Scheduled.CRON_DISABLED);
         }
     }
+
+    private static final List<Integer> EVERY_DAY_OF_WEEK =
+        Stream.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY).map(DayOfWeek::getValue).toList();
+    private static final List<Integer> MONDAY_TO_FRIDAY =
+        Stream.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY).map(DayOfWeek::getValue).toList();
 
     @LocalServerPort
     private int port;
@@ -150,6 +158,106 @@ class SickNoteUIIT {
         sickNoteExtension(page, user, startDate, LocalDate.now(clock));
 
         navigationPage.logout();
+    }
+
+    @Test
+    void ensureUserCanExtendSickNoteAfterTheWeekendAndWhileItIsRunning(Page page) {
+        final LoginPage loginPage = new LoginPage(page, port);
+        final NavigationPage navigationPage = new NavigationPage(page);
+
+        final Person office = createPerson("Barbara", "Gordon", List.of(USER, OFFICE));
+        // does not work on weekends, therefore the friday is the last work day before the monday
+        final Person user = createPerson("Jason", "Todd", List.of(USER), MONDAY_TO_FRIDAY);
+
+        // 2022-02-07 is a monday
+        final LocalDate monday = LocalDate.now(clock);
+        final LocalDate friday = monday.minusDays(3);
+        final LocalDate mondayNextWeek = monday.plusDays(7);
+
+        login(loginPage, office);
+        navigationPage.settingsMenu.clickAbsence();
+        enableUserSickNoteCreation(page, true);
+        navigationPage.logout();
+
+        login(loginPage, user);
+        createSickNote(page, user, friday);
+
+        // the weekend does not interrupt the sick note of the last work day, extending it is offered on monday
+        extendSickNoteByOneWorkday(page, friday, monday);
+        // and the extension may go beyond the end of this week
+        extendSickNoteToCustomDate(page, friday, mondayNextWeek);
+        // the still running sick note is the one to extend, dates up to its end are no extension and not offered
+        showsExtensionOfRunningSickNote(page, mondayNextWeek.plusDays(1));
+        navigationPage.logout();
+
+        // office creates a sick note for the user instead of extending one of its own
+        login(loginPage, office);
+        addSickNoteForAnotherPerson(page, user);
+
+        // without the permission to hand in sick notes there is no way to the extension page at all
+        navigationPage.settingsMenu.clickAbsence();
+        enableUserSickNoteCreation(page, false);
+        navigationPage.logout();
+
+        login(loginPage, user);
+        navigationPage.quickAdd.showsNoCreateSickNoteLink();
+        navigationPage.logout();
+    }
+
+    private void extendSickNoteByOneWorkday(Page page, LocalDate startDate, LocalDate nextEndDate) {
+        final NavigationPage navigationPage = new NavigationPage(page);
+        final SickNoteExtensionPage sickNoteExtensionPage = new SickNoteExtensionPage(page, messageSource, GERMAN);
+
+        navigationPage.quickAdd.clickCreateNewSickNote();
+        sickNoteExtensionPage.waitForVisible();
+
+        sickNoteExtensionPage.clickPlusOneWorkday();
+        submitExtension(page, sickNoteExtensionPage, startDate, nextEndDate);
+    }
+
+    private void extendSickNoteToCustomDate(Page page, LocalDate startDate, LocalDate nextEndDate) {
+        final NavigationPage navigationPage = new NavigationPage(page);
+        final SickNoteExtensionPage sickNoteExtensionPage = new SickNoteExtensionPage(page, messageSource, GERMAN);
+
+        navigationPage.quickAdd.clickCreateNewSickNote();
+        sickNoteExtensionPage.waitForVisible();
+
+        sickNoteExtensionPage.setCustomNextEndDate(nextEndDate);
+        submitExtension(page, sickNoteExtensionPage, startDate, nextEndDate);
+    }
+
+    private void submitExtension(Page page, SickNoteExtensionPage sickNoteExtensionPage, LocalDate startDate, LocalDate nextEndDate) {
+        final SickNoteDetailPage sickNoteDetailPage = new SickNoteDetailPage(page, messageSource, GERMAN);
+
+        sickNoteExtensionPage.showsExtensionPreview(startDate, nextEndDate);
+        sickNoteExtensionPage.submit();
+
+        // the sick note has been handed in by the user and not been accepted yet, therefore it is edited right away
+        sickNoteDetailPage.waitForVisible();
+        sickNoteDetailPage.showsSickNoteDateFrom(startDate);
+        sickNoteDetailPage.showsSickNoteDateTo(nextEndDate);
+    }
+
+    private void showsExtensionOfRunningSickNote(Page page, LocalDate earliestNextEndDate) {
+        final NavigationPage navigationPage = new NavigationPage(page);
+        final SickNoteExtensionPage sickNoteExtensionPage = new SickNoteExtensionPage(page, messageSource, GERMAN);
+
+        navigationPage.quickAdd.clickCreateNewSickNote();
+        sickNoteExtensionPage.waitForVisible();
+
+        sickNoteExtensionPage.showsNoEndOfWeekOption();
+        sickNoteExtensionPage.showsEarliestSelectableNextEndDate(earliestNextEndDate);
+    }
+
+    private void addSickNoteForAnotherPerson(Page page, Person person) {
+        final OverviewPage overviewPage = new OverviewPage(page, messageSource, GERMAN);
+        final SickNoteFormPage sickNotePage = new SickNoteFormPage(page);
+
+        page.navigate("http://localhost:" + port + "/web/person/" + person.getId() + "/overview");
+        overviewPage.clickAddSickNote();
+
+        sickNotePage.waitForVisible();
+        sickNotePage.personSelected(person.getNiceName());
     }
 
     private void enableUserSickNoteCreation(Page page, boolean enable) {
@@ -314,6 +422,10 @@ class SickNoteUIIT {
     }
 
     private Person createPerson(String firstName, String lastName, List<Role> roles) {
+        return createPerson(firstName, lastName, roles, EVERY_DAY_OF_WEEK);
+    }
+
+    private Person createPerson(String firstName, String lastName, List<Role> roles, List<Integer> workingDays) {
 
         final String email = "%s.%s@example.org".formatted(trimAllWhitespace(firstName), trimAllWhitespace(lastName)).toLowerCase();
         final Optional<Person> personByMailAddress = personService.getPersonByMailAddress(email);
@@ -325,7 +437,6 @@ class SickNoteUIIT {
         final Person savedPerson = personService.create(userId, firstName, lastName, email, List.of(), roles);
 
         final LocalDate validFrom = LocalDate.of(2022, JANUARY, 1);
-        final List<Integer> workingDays = Stream.of(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY).map(DayOfWeek::getValue).toList();
         workingTimeWriteService.touch(workingDays, validFrom, savedPerson);
 
         final LocalDate firstDayOfYear = LocalDate.of(2022, JANUARY, 1);

--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/pages/NavigationPage.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/pages/NavigationPage.java
@@ -3,6 +3,7 @@ package org.synyx.urlaubsverwaltung.ui.pages;
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 import static com.microsoft.playwright.options.LoadState.DOMCONTENTLOADED;
 
 public class NavigationPage {
@@ -100,6 +101,14 @@ public class NavigationPage {
          */
         public void clickCreateNewSickNote() {
             page.locator(SICKNOTE_SELECTOR).click();
+        }
+
+        /**
+         * Asserts that the quick add menu is rendered, but does not offer to create a sick note.
+         */
+        public void showsNoCreateSickNoteLink() {
+            assertThat(page.locator(APPLICATION_SELECTOR)).hasCount(1);
+            assertThat(page.locator(SICKNOTE_SELECTOR)).hasCount(0);
         }
     }
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/pages/OverviewPage.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/pages/OverviewPage.java
@@ -44,6 +44,14 @@ public class OverviewPage {
         page.mouse().up();
     }
 
+    /**
+     * Clicks "add sick note" of the sick note section, which creates a sick note for the person of this overview.
+     * Does not wait for anything. You have to wait for the next visible page yourself!
+     */
+    public void clickAddSickNote() {
+        page.locator("[data-test-id=add-sick-note]").click();
+    }
+
     public void clickDay(LocalDate date) {
         dayLocator(date).click();
     }

--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/pages/SickNoteExtensionPage.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/pages/SickNoteExtensionPage.java
@@ -9,12 +9,16 @@ import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 
 public class SickNoteExtensionPage {
 
     // the `duet-date-picker` prefix matches only the hydrated datepicker, not the plain `input[date]` the server renders.
     private static final String DUET_CUSTOM_NEXT_END_DATE_SELECTOR =
         "duet-date-picker [data-test-id=sicknote-custom-next-end-date-input]";
+    // the datepicker itself carries the boundaries, its inner input carries the test id
+    private static final String DUET_CUSTOM_NEXT_END_DATE_PICKER_SELECTOR =
+        "duet-date-picker:has([data-test-id=sicknote-custom-next-end-date-input])";
 
     private final Page page;
     private final MessageSource messageSource;
@@ -45,6 +49,32 @@ public class SickNoteExtensionPage {
     public void setCustomNextEndDate(LocalDate nextEndDate) {
         final String nextEndDateValue = DATE_FORMATTER.format(nextEndDate);
         page.locator(DUET_CUSTOM_NEXT_END_DATE_SELECTOR).fill(nextEndDateValue);
+    }
+
+    /**
+     * Extends the sick note by one work day following its end date.
+     * Does not wait for anything, the preview is rendered asynchronously.
+     */
+    public void clickPlusOneWorkday() {
+        page.locator("button[name=extend][value='1']").click();
+    }
+
+    /**
+     * Asserts that extending until the end of the week is not offered, which is the case when the sick note
+     * does not end before it.
+     */
+    public void showsNoEndOfWeekOption() {
+        assertThat(page.locator("button[name=extend][value='end-of-week']")).hasCount(0);
+    }
+
+    /**
+     * Asserts the first date the datepicker allows to be picked as the next end date.
+     *
+     * @param earliestNextEndDate first selectable date, the day after the end of the sick note
+     */
+    public void showsEarliestSelectableNextEndDate(LocalDate earliestNextEndDate) {
+        final String earliestValue = ISO_LOCAL_DATE.format(earliestNextEndDate);
+        assertThat(page.locator(DUET_CUSTOM_NEXT_END_DATE_PICKER_SELECTOR)).hasAttribute("min", earliestValue);
     }
 
     public void showsExtensionPreview(LocalDate startDate, LocalDate nextEndDate) {


### PR DESCRIPTION
Drei Fehler rund um die Frage, wann die UI zum Erweitern einer Krankmeldung erscheint – aufgefallen bei der Bestandsaufnahme für #4930.

### 1. Der "letzte Arbeitstag" war nie einer

`getSickNoteOfYesterdayOrLastWorkDay` verglich `workingTimeCalendar.workingDays().size()` mit `2`. Diese Map enthält aber *jeden* Tag des angefragten Zeitraums, Wochenenden und Feiertage als `DayLength.ZERO` inklusive – der Vergleich war damit gleichbedeutend mit "endete gestern", was die Bedingung daneben schon beantwortete. Eine Krankmeldung, die am Freitag endete, wurde am Montag also nicht zur Erweiterung angeboten. Der Test dazu trug ein `// TODO fixme...` und ging nur durch, weil sein Mock einen Kalender lieferte, den der Produktionscode nicht erzeugen kann.

Jetzt beantwortet der Kalender die Frage selbst: der nächste Arbeitstag nach dem Ende der Krankmeldung muss heute oder später sein. Damit greifen Wochenende, Feiertag und freie Tage – auch in Kombination – und ebenso der Aufruf der Seite an einem Sonntag.

### 2. "Krankmeldung anlegen" für eine andere Person landete in der Sackgasse

Die Weiterleitung auf `/web/sicknote/extend` war nur über die Einstellung abgesichert und schaute dabei die Krankmeldung der *Zielperson* nach, während die Erweiterungsseite ausschließlich mit dem angemeldeten Benutzer arbeitet. Office landete deshalb auf der Erweiterungsseite der eigenen letzten Krankmeldung oder auf "Es gibt keine laufende Krankmeldung die erweitert werden könnte" – ohne Weg zur Krankmeldung für die Person, um die es ging. Reproduktion in #6626.

Die Weiterleitung hängt nun an `permissions.isAllowedToSubmit()`, also an derselben Person und der aktivierten Einstellung – genau der Berechtigung, die die Erweiterungsseite verlangt.

### 3. Die Erweiterungsseite prüfte die Einstellung nicht

`/web/sicknote/extend` fragte nie, ob das Einreichen von Krankmeldungen überhaupt erlaubt ist; die Einstellung wurde nur vor der Weiterleitung geprüft. Über die direkt eingegebene URL ließ sich eine Erweiterung also auch dann einreichen, wenn Mitarbeiter keine Krankmeldungen einreichen dürfen. `submitSickNoteExtension` prüft nur, ob die Krankmeldung dem Einreichenden gehört. View und Submit verlangen jetzt `isAllowedToSubmit()`.

### 4. Erweitern erst nach dem Ende der Krankmeldung

Erweitern war nur möglich, nachdem eine Krankmeldung vorbei war: die Abfrage suchte die letzte Krankmeldung, die *vor* heute endete. Wer am Mittwoch wusste, dass die Krankmeldung bis Freitag nicht reichen wird, bekam das Formular für eine neue Krankmeldung.

Die Abfrage sucht nun die letzte Krankmeldung, die heute oder früher begonnen hat – also entweder die noch laufende oder die zuletzt beendete; eine erst in der Zukunft beginnende gibt es noch nicht zu erweitern. Wo Enddatum und "heute" bisher dasselbe waren, folgt die Seite jetzt dem Enddatum: das freie Datum beginnt am Tag nach dem Enddatum, und "Ende der Woche" erscheint nur, wenn das überhaupt eine Verlängerung ist – eine Krankmeldung bis nächsten Montag wird davon nicht verlängert.

`getSickNoteOfYesterdayOrLastWorkDay` heißt jetzt `getSickNoteToExtend`, der alte Name beschreibt das Ergebnis nicht mehr.

---

Damit beantwortet #4930 die Frage, wann welche UI erscheint – das Ticket beschreibt jetzt das umgesetzte Verhalten.

closes #6626
closes #4930

---

Darauf gestapelt: #6628 behebt den 500er der Vorschau ohne Datum (#6489) auf derselben Seite.
