### PR TITLE
Vorschau ohne Datum beantwortet die Erweiterungsseite mit einem Hinweis statt mit einem 500er

### DIFF
--- a/src/main/css/bundles/sick-note-extend.css
+++ b/src/main/css/bundles/sick-note-extend.css
@@ -62,8 +62,15 @@
 }
 
 @variant xs {
+  /*
+  every option is an action followed by its label, so they pair up on their own: one row each.
+  do not place them by hand - the end of the week is not always offered, and a fixed row would
+  leave a hole and tear the label of the datepicker away from it.
+  */
   .extend-action-grid {
     display: grid;
+    grid-auto-flow: row;
+    grid-template-columns: auto auto;
     grid-column-gap: --spacing(4);
     grid-row-gap: --spacing(2);
     align-items: center;
@@ -73,42 +80,6 @@
     margin: unset !important;
   }
 
-  /* buttons */
-  .extend-action-grid > button:nth-of-type(1) {
-    grid-row: 1;
-    grid-column: 1;
-  }
-  .extend-action-grid > button:nth-of-type(2) {
-    grid-row: 2;
-    grid-column: 1;
-  }
-  .extend-action-grid > button:nth-of-type(3) {
-    grid-row: 3;
-    grid-column: 1;
-  }
-  .extend-action-grid > input[type="date"],
-  .extend-action-grid > duet-date-picker {
-    grid-row: 4;
-    grid-column: 1;
-  }
-
-  /* labels */
-  .extend-action-grid > span:nth-of-type(1) {
-    grid-row: 1;
-    grid-column: 2;
-  }
-  .extend-action-grid > span:nth-of-type(2) {
-    grid-row: 2;
-    grid-column: 2;
-  }
-  .extend-action-grid > span:nth-of-type(3) {
-    grid-row: 3;
-    grid-column: 2;
-  }
-  .extend-action-grid > label {
-    grid-row: 4;
-    grid-column: 2;
-  }
   .extend-label {
     margin-left: 0;
     margin-right: 0;
@@ -121,48 +92,13 @@
 }
 
 @variant md {
+  /* the same pairs side by side now, one column each */
   .extend-action-grid {
     display: grid;
+    grid-auto-flow: column;
+    grid-template-rows: auto auto;
     grid-column-gap: --spacing(4);
     grid-row-gap: --spacing(1);
-    grid-template-columns: fit-content(1fr);
-  }
-
-  /* buttons */
-  .extend-action-grid > button:nth-of-type(1) {
-    grid-row: 1;
-    grid-column: 1;
-  }
-  .extend-action-grid > button:nth-of-type(2) {
-    grid-row: 1;
-    grid-column: 2;
-  }
-  .extend-action-grid > button:nth-of-type(3) {
-    grid-row: 1;
-    grid-column: 3;
-  }
-  .extend-action-grid > input[type="date"],
-  .extend-action-grid > duet-date-picker {
-    grid-row: 1;
-    grid-column: 4;
-  }
-
-  /* labels */
-  .extend-action-grid > span:nth-of-type(1) {
-    grid-row: 2;
-    grid-column: 1;
-  }
-  .extend-action-grid > span:nth-of-type(2) {
-    grid-row: 2;
-    grid-column: 2;
-  }
-  .extend-action-grid > span:nth-of-type(3) {
-    grid-row: 2;
-    grid-column: 3;
-  }
-  .extend-action-grid > label {
-    grid-row: 2;
-    grid-column: 4;
   }
 
   .extend-label {

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendDto.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendDto.java
@@ -12,10 +12,12 @@ class SickNoteExtendDto {
     private BigDecimal workingDays;
 
     /**
-     * This field is only required for error styling with {@code `th:errorclass`}.
+     * The custom date of the form as the browser sent it, needed for the error styling with
+     * {@code `th:errorclass`}.
      *
      * <p>
-     * This has no value and does not have to be considered by us.
+     * It is what the date input renders as its value as well - {@code `th:field`} has a higher precedence
+     * than the {@code `th:value`} of the template and therefore wins over it.
      */
     private String extendToDate;
 

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendValidator.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendValidator.java
@@ -36,7 +36,9 @@ class SickNoteExtendValidator implements Validator {
 
     private void validateEndDate(Errors errors, SickNoteExtendDto dto, SickNote sickNote) {
         final LocalDate sickNoteEndDate = sickNote.getEndDate();
-        if (!dto.getEndDate().isAfter(sickNoteEndDate)) {
+        final LocalDate nextEndDate = dto.getEndDate();
+        // a preview can be asked for without a date at all, which is no date after the end of the sick note either
+        if (nextEndDate == null || !nextEndDate.isAfter(sickNoteEndDate)) {
             final Object[] args = { dateFormatAware.format(sickNoteEndDate) };
             // DTO attribute name
             errors.rejectValue("endDate", ERROR_ENDDATE_FUTURE, args, "");

--- a/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendViewController.java
+++ b/src/main/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendViewController.java
@@ -283,7 +283,7 @@ class SickNoteExtendViewController implements HasLaunchpad, HasPersonSearch {
         final SickNoteExtendPreviewDto sickNotePreviewNext;
         final String selectedExtend;
 
-        if (customDateSubmit.isPresent()) {
+        if (customDateSubmit.isPresent() && extendToDate != null) {
             final BigDecimal nextWorkingDays = workingTimeCalendar.workingTime(sickNote.getStartDate(), extendToDate);
             sickNotePreviewNext = new SickNoteExtendPreviewDto(sickNote.getStartDate(), extendToDate, nextWorkingDays);
             selectedExtend = "custom";

--- a/src/main/javascript/bundles/sick-note-extend.js
+++ b/src/main/javascript/bundles/sick-note-extend.js
@@ -1,36 +1,9 @@
 import "../js/common";
-import { Idiomorph } from "idiomorph/dist/idiomorph.esm.js";
-import { createDatepicker } from "../components/datepicker";
+import { createDatepicker, morphKeepingDatepickers } from "../components/datepicker";
 
 document.addEventListener("turbo:before-render", function (event) {
   // morph all the things!
-  event.detail.render = (currentElement, newElement) => {
-    // duet-date-picker is client side only -> the html snippet from the backend contains an `input type=date`.
-    // that input carries the id the hydrated picker handed to its own inner input, so idiomorph matches the
-    // two and moves the input out of the picker instead of adding a new one. that leaves a picker without an
-    // input behind and a second, stale `extendToDate` field in the form.
-    // therefore the server side input is taken out of the new html and its changes are handed to the picker.
-    const datepickers = [];
-    for (const dateInput of newElement.querySelectorAll("input[type=date]")) {
-      const datepicker = document.querySelector(`duet-date-picker[name="${dateInput.getAttribute("name")}"]`);
-      if (datepicker) {
-        datepicker.classList.remove("sicknote-extend-button--selected", "error");
-        // if the datepicker should be selected it will be added now. same for errors
-        datepicker.classList.add(...dateInput.classList);
-        datepickers.push(datepicker);
-        dateInput.remove();
-      }
-    }
-
-    Idiomorph.morph(currentElement, newElement, {
-      callbacks: {
-        beforeNodeRemoved(node) {
-          // the datepicker has no counterpart in the new html, it must survive the morph
-          return !datepickers.includes(node);
-        },
-      },
-    });
-  };
+  event.detail.render = morphKeepingDatepickers;
 });
 
 await createDatepicker("#extend-to-date-input", {

--- a/src/main/javascript/bundles/sick-note-extend.js
+++ b/src/main/javascript/bundles/sick-note-extend.js
@@ -2,45 +2,35 @@ import "../js/common";
 import { Idiomorph } from "idiomorph/dist/idiomorph.esm.js";
 import { createDatepicker } from "../components/datepicker";
 
-// duet-date-picker is client side only -> html snippet from backend contains a `input type=date`.
-// to avoid flickering and complex logic instantiating the duet-date-picker again
-// we simply don't remove it but we update known attributes.
-// this `datepickers` list is to remember nodes that must note be removed after rendering.
-let datepickers = [];
-
 document.addEventListener("turbo:before-render", function (event) {
   // morph all the things!
   event.detail.render = (currentElement, newElement) => {
-    datepickers = [];
+    // duet-date-picker is client side only -> the html snippet from the backend contains an `input type=date`.
+    // that input carries the id the hydrated picker handed to its own inner input, so idiomorph matches the
+    // two and moves the input out of the picker instead of adding a new one. that leaves a picker without an
+    // input behind and a second, stale `extendToDate` field in the form.
+    // therefore the server side input is taken out of the new html and its changes are handed to the picker.
+    const datepickers = [];
+    for (const dateInput of newElement.querySelectorAll("input[type=date]")) {
+      const datepicker = document.querySelector(`duet-date-picker[name="${dateInput.getAttribute("name")}"]`);
+      if (datepicker) {
+        datepicker.classList.remove("sicknote-extend-button--selected", "error");
+        // if the datepicker should be selected it will be added now. same for errors
+        datepicker.classList.add(...dateInput.classList);
+        datepickers.push(datepicker);
+        dateInput.remove();
+      }
+    }
+
     Idiomorph.morph(currentElement, newElement, {
       callbacks: {
-        beforeNodeAdded(node) {
-          if (node.matches && node.matches("[type=date]")) {
-            for (const duet of document.querySelectorAll("duet-date-picker")) {
-              if (duet.getAttribute("name") === node.getAttribute("name")) {
-                duet.classList.remove("sicknote-extend-button--selected", "error");
-                // if the datepicker should be selected it will be added now. same for errors
-                duet.classList.add(...node.classList);
-                // do not add the date input since duet-date-picker is already initialized
-                datepickers.push(duet);
-                return false;
-              }
-            }
-          }
-        },
         beforeNodeRemoved(node) {
-          if (node.matches?.("duet-date-picker")) {
-            // do not remove duet-date-picker when it has been updated before
-            return datepickers.includes(node);
-          }
+          // the datepicker has no counterpart in the new html, it must survive the morph
+          return !datepickers.includes(node);
         },
       },
     });
   };
-});
-
-document.addEventListener("turbo:render", function () {
-  datepickers = [];
 });
 
 await createDatepicker("#extend-to-date-input", {

--- a/src/main/javascript/components/datepicker/__tests__/morph.spec.js
+++ b/src/main/javascript/components/datepicker/__tests__/morph.spec.js
@@ -1,0 +1,135 @@
+import { morphKeepingDatepickers } from "../morph";
+
+describe("morph", () => {
+  afterEach(() => {
+    while (document.body.firstElementChild) {
+      document.body.firstElementChild.remove();
+    }
+  });
+
+  /**
+   * The DOM after `createDatepicker` has replaced the server side `input[type=date]`: the id of that input
+   * now lives on the inner input of the datepicker, the name on a hidden input of it.
+   */
+  function hydratedPage() {
+    document.body.innerHTML = `
+      <form>
+        <duet-date-picker
+          class="sicknote-extend-button hydrated"
+          identifier="extend-to-date-input"
+          name="extendToDate"
+          min="2024-09-30"
+          value="2024-09-30"
+        >
+          <div class="duet-date">
+            <div class="duet-date__input-wrapper">
+              <input id="extend-to-date-input" class="duet-date__input" value="30.9.2024" />
+              <input type="hidden" name="extendToDate" value="2024-09-30" />
+              <button class="duet-date__toggle" type="button"></button>
+            </div>
+          </div>
+        </duet-date-picker>
+        <p id="feedback">no preview yet</p>
+      </form>
+    `;
+    return document.body;
+  }
+
+  /**
+   * The page as the server renders it, with a plain `input[type=date]` instead of the datepicker.
+   */
+  function serverSidePage({ inputClass = "sicknote-extend-button", feedback = "no preview yet" } = {}) {
+    const body = document.createElement("body");
+    body.innerHTML = `
+      <form>
+        <input
+          type="date"
+          id="extend-to-date-input"
+          name="extendToDate"
+          class="${inputClass}"
+          min="2024-09-30"
+          value=""
+          data-iso-value="2024-09-30"
+        />
+        <p id="feedback">${feedback}</p>
+      </form>
+    `;
+    return body;
+  }
+
+  it("keeps the datepicker instead of letting the server side date input replace it", () => {
+    const currentPage = hydratedPage();
+
+    morphKeepingDatepickers(currentPage, serverSidePage({ feedback: "preview until 2. Oktober" }));
+
+    const datepicker = document.querySelector("duet-date-picker");
+    expect(datepicker).not.toBeNull();
+    // the datepicker is useless without the input it renders, which carries the id of the server side one
+    expect(datepicker.querySelector("input#extend-to-date-input")).not.toBeNull();
+    expect(document.querySelector("form").children[0]).toBe(datepicker);
+    // the rest of the page is morphed as usual
+    expect(document.querySelector("#feedback").textContent).toBe("preview until 2. Oktober");
+  });
+
+  it("submits the date of the datepicker only, not a second stale one", () => {
+    const currentPage = hydratedPage();
+
+    morphKeepingDatepickers(currentPage, serverSidePage());
+
+    const submitted = [...document.querySelectorAll("form input[name=extendToDate]")];
+    expect(submitted).toHaveLength(1);
+    expect(submitted[0].value).toBe("2024-09-30");
+  });
+
+  it("hands the css classes of the server side date input to the datepicker", () => {
+    const currentPage = hydratedPage();
+
+    morphKeepingDatepickers(
+      currentPage,
+      serverSidePage({ inputClass: "sicknote-extend-button sicknote-extend-button--selected error" }),
+    );
+
+    const datepicker = document.querySelector("duet-date-picker");
+    expect([...datepicker.classList]).toContain("sicknote-extend-button--selected");
+    expect([...datepicker.classList]).toContain("error");
+  });
+
+  it("takes the css classes away from the datepicker again", () => {
+    const currentPage = hydratedPage();
+    document.querySelector("duet-date-picker").classList.add("sicknote-extend-button--selected", "error");
+
+    morphKeepingDatepickers(currentPage, serverSidePage());
+
+    const classes = [...document.querySelector("duet-date-picker").classList];
+    expect(classes).not.toContain("sicknote-extend-button--selected");
+    expect(classes).not.toContain("error");
+    expect(classes).toContain("sicknote-extend-button");
+  });
+
+  it("leaves the datepicker without classes when the date input has none", () => {
+    const currentPage = hydratedPage();
+
+    morphKeepingDatepickers(currentPage, serverSidePage({ inputClass: "" }));
+
+    expect([...document.querySelector("duet-date-picker").classList]).toEqual(["hydrated"]);
+  });
+
+  it("keeps the class duet marks the element it hydrated with", () => {
+    const currentPage = hydratedPage();
+
+    morphKeepingDatepickers(currentPage, serverSidePage());
+
+    // without it the element duet renders stays invisible
+    expect(document.querySelector("duet-date-picker").classList).toContain("hydrated");
+  });
+
+  it("renders the date input of the server when there is no datepicker for it", () => {
+    document.body.innerHTML = `<form><p id="feedback">no preview yet</p></form>`;
+
+    morphKeepingDatepickers(document.body, serverSidePage());
+
+    const dateInput = document.querySelector("form input[type=date]");
+    expect(dateInput).not.toBeNull();
+    expect(dateInput.getAttribute("name")).toBe("extendToDate");
+  });
+});

--- a/src/main/javascript/components/datepicker/index.js
+++ b/src/main/javascript/components/datepicker/index.js
@@ -1,1 +1,2 @@
 export { createDatepicker } from "./create-datepicker";
+export { morphKeepingDatepickers } from "./morph";

--- a/src/main/javascript/components/datepicker/morph.js
+++ b/src/main/javascript/components/datepicker/morph.js
@@ -1,0 +1,41 @@
+import { Idiomorph } from "idiomorph/dist/idiomorph.esm.js";
+
+// the class duet-date-picker marks the element it has hydrated with. without it the element stays invisible.
+const HYDRATED_CLASS = "hydrated";
+
+/**
+ * Morphs the current page into the new one, keeping the hydrated `duet-date-picker` elements alive.
+ *
+ * duet-date-picker is client side only -> the html of the backend contains an `input type=date`. That input
+ * carries the id the picker handed to its own inner input, so idiomorph matches the two and moves the input
+ * out of the picker instead of adding a new one. That would leave a picker without an input behind and a
+ * second, stale field of the same name in the form. Therefore the server side input is taken out of the new
+ * html and its changes are handed to the picker.
+ *
+ * @param currentElement {Element} element to morph, the current page
+ * @param newElement {Element} the new page
+ */
+export function morphKeepingDatepickers(currentElement, newElement) {
+  const datepickers = [];
+
+  for (const dateInput of newElement.querySelectorAll("input[type=date]")) {
+    const datepicker = currentElement.querySelector(`duet-date-picker[name="${dateInput.getAttribute("name")}"]`);
+    if (datepicker) {
+      // the classes of the server side input say whether the date is selected and whether it has an error
+      const hydrated = datepicker.classList.contains(HYDRATED_CLASS);
+      datepicker.className = dateInput.className;
+      datepicker.classList.toggle(HYDRATED_CLASS, hydrated);
+      datepickers.push(datepicker);
+      dateInput.remove();
+    }
+  }
+
+  Idiomorph.morph(currentElement, newElement, {
+    callbacks: {
+      beforeNodeRemoved(node) {
+        // the datepicker has no counterpart in the new html, it must survive the morph
+        return !datepickers.includes(node);
+      },
+    },
+  });
+}

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendValidatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendValidatorTest.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 import static java.time.Month.AUGUST;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -87,6 +88,22 @@ class SickNoteExtendValidatorTest {
 
         verify(errors).rejectValue("endDate", "sicknote.extend.validation.constraints.end-date.future.message",  new Object[]{"<any-formatted-date>"}, "");
         verify(errors).rejectValue("extendToDate", "sicknote.extend.validation.constraints.end-date.future.message",  new Object[]{"<any-formatted-date>"}, "");
+    }
+
+    @Test
+    void ensureNoErrorWhenTheEndDateIsAfterTheEndOfTheSickNote() {
+
+        final LocalDate sickNoteEndDate = LocalDate.of(2024, AUGUST, 8);
+        final SickNote sickNote = SickNote.builder().id(1L).endDate(sickNoteEndDate).build();
+        when(sickNoteService.getById(1L)).thenReturn(Optional.of(sickNote));
+
+        final SickNoteExtendDto dto = new SickNoteExtendDto();
+        dto.setSickNoteId(1L);
+        dto.setEndDate(LocalDate.of(2024, AUGUST, 9));
+
+        sut.validate(dto, errors);
+
+        verifyNoInteractions(errors);
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendValidatorTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendValidatorTest.java
@@ -88,4 +88,23 @@ class SickNoteExtendValidatorTest {
         verify(errors).rejectValue("endDate", "sicknote.extend.validation.constraints.end-date.future.message",  new Object[]{"<any-formatted-date>"}, "");
         verify(errors).rejectValue("extendToDate", "sicknote.extend.validation.constraints.end-date.future.message",  new Object[]{"<any-formatted-date>"}, "");
     }
+
+    @Test
+    void ensureEndDateMustBeGivenAtAll() {
+
+        final LocalDate sickNoteEndDate = LocalDate.of(2024, AUGUST, 8);
+        final SickNote sickNote = SickNote.builder().id(1L).endDate(sickNoteEndDate).build();
+        when(sickNoteService.getById(1L)).thenReturn(Optional.of(sickNote));
+
+        when(dateFormatAware.format(sickNoteEndDate)).thenReturn("<any-formatted-date>");
+
+        // a preview has been asked for without giving a date, see #6489
+        final SickNoteExtendDto dto = new SickNoteExtendDto();
+        dto.setSickNoteId(1L);
+
+        sut.validate(dto, errors);
+
+        verify(errors).rejectValue("endDate", "sicknote.extend.validation.constraints.end-date.future.message",  new Object[]{"<any-formatted-date>"}, "");
+        verify(errors).rejectValue("extendToDate", "sicknote.extend.validation.constraints.end-date.future.message",  new Object[]{"<any-formatted-date>"}, "");
+    }
 }

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendViewControllerTest.java
@@ -1,5 +1,6 @@
 package org.synyx.urlaubsverwaltung.sicknote.sicknote.extend;
 
+import java.math.BigDecimal;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -334,6 +335,57 @@ class SickNoteExtendViewControllerTest {
         ).hasCauseInstanceOf(AccessDeniedException.class);
 
         verifyNoInteractions(sickNoteExtensionInteractionService);
+    }
+
+    @Test
+    void ensurePreviewOfACustomDateIsTheDateItself() throws Exception {
+
+        final Person person = new Person();
+        person.setId(1L);
+        person.setPermissions(List.of(USER));
+
+        when(personService.getSignedInUser()).thenReturn(person);
+        sickNoteToExtend(person, LocalDate.of(2024, SEPTEMBER, 23), LocalDate.of(2024, SEPTEMBER, 24));
+
+        perform(
+            post("/web/sicknote/extend")
+                .param("sickNoteId", "1")
+                .param("startDate", "2024-09-23")
+                .param("extendToDate", "2024-09-27")
+                .param("custom-date-preview", "")
+        )
+            .andExpect(status().isOk())
+            .andExpect(view().name("sicknote/sick_note_extend"))
+            .andExpect(model().attribute("selectedExtend", "custom"))
+            // monday to friday, all of them work days
+            .andExpect(model().attribute("sickNotePreviewNext", new SickNoteExtendPreviewDto(
+                LocalDate.of(2024, SEPTEMBER, 23), LocalDate.of(2024, SEPTEMBER, 27), BigDecimal.valueOf(5))));
+    }
+
+    @Test
+    void ensurePreviewOfAQuickSelectionIsTheNextWorkDay() throws Exception {
+
+        final Person person = new Person();
+        person.setId(1L);
+        person.setPermissions(List.of(USER));
+
+        when(personService.getSignedInUser()).thenReturn(person);
+        sickNoteToExtend(person, LocalDate.of(2024, SEPTEMBER, 23), LocalDate.of(2024, SEPTEMBER, 24));
+
+        perform(
+            post("/web/sicknote/extend")
+                .param("sickNoteId", "1")
+                .param("startDate", "2024-09-23")
+                // the datepicker submits its date with every submit, a quick selection must not use it
+                .param("extendToDate", "2024-09-27")
+                .param("extend", "1")
+        )
+            .andExpect(status().isOk())
+            .andExpect(view().name("sicknote/sick_note_extend"))
+            .andExpect(model().attribute("selectedExtend", "1"))
+            // monday to wednesday, the work day following the end of the sick note
+            .andExpect(model().attribute("sickNotePreviewNext", new SickNoteExtendPreviewDto(
+                LocalDate.of(2024, SEPTEMBER, 23), LocalDate.of(2024, SEPTEMBER, 25), BigDecimal.valueOf(3))));
     }
 
     @Test

--- a/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendViewControllerTest.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/sicknote/sicknote/extend/SickNoteExtendViewControllerTest.java
@@ -275,7 +275,7 @@ class SickNoteExtendViewControllerTest {
             .andExpect(model().attribute("earliestExtendToDate", LocalDate.of(2024, OCTOBER, 1)));
     }
 
-    private void sickNoteToExtend(Person person, LocalDate startDate, LocalDate endDate) {
+    private SickNote sickNoteToExtend(Person person, LocalDate startDate, LocalDate endDate) {
 
         final SickNoteType sickNoteType = new SickNoteType();
         sickNoteType.setCategory(SICK_NOTE);
@@ -292,6 +292,8 @@ class SickNoteExtendViewControllerTest {
         when(sickNoteService.getSickNoteToExtend(person)).thenReturn(Optional.of(sickNote));
         when(workingTimeCalendarService.getWorkingTimesByPersons(eq(List.of(person)), any(DateRange.class)))
             .thenReturn(Map.of(person, workingTimeCalendarMondayToFriday(startDate.minusDays(7), endDate.plusDays(14))));
+
+        return sickNote;
     }
 
     @Test
@@ -332,6 +334,35 @@ class SickNoteExtendViewControllerTest {
         ).hasCauseInstanceOf(AccessDeniedException.class);
 
         verifyNoInteractions(sickNoteExtensionInteractionService);
+    }
+
+    @Test
+    void ensurePreviewWithoutACustomDateRendersThePageAgain() throws Exception {
+
+        // the real validator, the page fails on the way into it, see #6489
+        final SickNoteExtendViewController sutWithValidator = new SickNoteExtendViewController(personService,
+            workingTimeCalendarService, sickNoteService, sickNoteExtensionService, sickNoteExtensionInteractionService,
+            new SickNotePermissionEvaluator(mock(DepartmentService.class), settingsServiceWith(settings)),
+            new SickNoteExtendValidator(sickNoteService, dateFormatAware), dateFormatAware,
+            defaultPersonSuggestionUrlStrategy, personSearchUiFragmentSupplier, clock);
+
+        final Person person = new Person();
+        person.setId(1L);
+        person.setPermissions(List.of(USER));
+
+        when(personService.getSignedInUser()).thenReturn(person);
+        final SickNote sickNote = sickNoteToExtend(person, LocalDate.of(2024, SEPTEMBER, 23), LocalDate.of(2024, SEPTEMBER, 24));
+        when(sickNoteService.getById(1L)).thenReturn(Optional.of(sickNote));
+
+        standaloneSetup(sutWithValidator).build()
+            .perform(
+                post("/web/sicknote/extend")
+                    .param("sickNoteId", "1")
+                    // the preview button of the custom date, submitted with an empty date field
+                    .param("custom-date-preview", "")
+            )
+            .andExpect(status().isOk())
+            .andExpect(view().name("sicknote/sick_note_extend"));
     }
 
     private ResultActions perform(MockHttpServletRequestBuilder builder) throws Exception {

--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/SickNoteUIIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/SickNoteUIIT.java
@@ -223,6 +223,9 @@ class SickNoteUIIT {
         sickNoteExtensionPage.waitForVisible();
 
         sickNoteExtensionPage.setCustomNextEndDate(nextEndDate);
+        sickNoteExtensionPage.showsExtensionPreview(startDate, nextEndDate);
+        // asking for the preview of the very same date again is no reason to fail, see #6489
+        sickNoteExtensionPage.clickCustomDatePreview();
         submitExtension(page, sickNoteExtensionPage, startDate, nextEndDate);
     }
 

--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/SickNoteUIIT.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/SickNoteUIIT.java
@@ -184,6 +184,8 @@ class SickNoteUIIT {
 
         // the weekend does not interrupt the sick note of the last work day, extending it is offered on monday
         extendSickNoteByOneWorkday(page, friday, monday);
+        // a quick selection re-renders the page, the datepicker of the custom date has to survive that
+        picksACustomDateAfterAQuickSelection(page, friday, monday.plusDays(1), monday.plusDays(3));
         // and the extension may go beyond the end of this week
         extendSickNoteToCustomDate(page, friday, mondayNextWeek);
         // the still running sick note is the one to extend, dates up to its end are no extension and not offered
@@ -213,6 +215,28 @@ class SickNoteUIIT {
 
         sickNoteExtensionPage.clickPlusOneWorkday();
         submitExtension(page, sickNoteExtensionPage, startDate, nextEndDate);
+    }
+
+    /**
+     * Uses a quick selection first and picks a date in the datepicker afterwards, without handing the
+     * extension in. See <a href="https://github.com/urlaubsverwaltung/urlaubsverwaltung/issues/6489">#6489</a>.
+     *
+     * @param quickEndDate end date the quick selection of one work day results in
+     * @param customEndDate date to pick in the datepicker afterwards, in the same month
+     */
+    private void picksACustomDateAfterAQuickSelection(Page page, LocalDate startDate, LocalDate quickEndDate, LocalDate customEndDate) {
+        final NavigationPage navigationPage = new NavigationPage(page);
+        final SickNoteExtensionPage sickNoteExtensionPage = new SickNoteExtensionPage(page, messageSource, GERMAN);
+
+        navigationPage.quickAdd.clickCreateNewSickNote();
+        sickNoteExtensionPage.waitForVisible();
+
+        sickNoteExtensionPage.clickPlusOneWorkday();
+        sickNoteExtensionPage.showsExtensionPreview(startDate, quickEndDate);
+
+        sickNoteExtensionPage.pickCustomNextEndDate(customEndDate);
+        sickNoteExtensionPage.showsCustomNextEndDate(customEndDate);
+        sickNoteExtensionPage.showsExtensionPreview(startDate, customEndDate);
     }
 
     private void extendSickNoteToCustomDate(Page page, LocalDate startDate, LocalDate nextEndDate) {

--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/pages/SickNoteExtensionPage.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/pages/SickNoteExtensionPage.java
@@ -27,6 +27,10 @@ public class SickNoteExtensionPage {
     // pattern does not depend on locale currently. the user cannot customize it.
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd.MM.yyyy");
     private static final DateTimeFormatter DATE_FULL_FORMATTER = DateTimeFormatter.ofPattern("EEEE, d. MMMM yyyy");
+    // the format `duet-date-picker` renders into its input, see the `de` datepicker localisation
+    private static final DateTimeFormatter DATE_PICKER_FORMATTER = DateTimeFormatter.ofPattern("d.M.yyyy");
+    // the screen reader label of a day of the currently shown month, hard coded by duet-date-picker
+    private static final DateTimeFormatter DATE_PICKER_DAY_FORMATTER = DateTimeFormatter.ofPattern("d. MMMM");
 
     public SickNoteExtensionPage(Page page, MessageSource messageSource, Locale locale) {
         this.page = page;
@@ -49,6 +53,27 @@ public class SickNoteExtensionPage {
     public void setCustomNextEndDate(LocalDate nextEndDate) {
         final String nextEndDateValue = DATE_FORMATTER.format(nextEndDate);
         page.locator(DUET_CUSTOM_NEXT_END_DATE_SELECTOR).fill(nextEndDateValue);
+    }
+
+    /**
+     * Picks the next end date in the datepicker instead of typing it. Does not wait for anything, the preview
+     * is rendered asynchronously.
+     *
+     * @param nextEndDate date to pick, has to be in the month the datepicker opens with
+     */
+    public void pickCustomNextEndDate(LocalDate nextEndDate) {
+        page.locator(DUET_CUSTOM_NEXT_END_DATE_PICKER_SELECTOR + " button.duet-date__toggle").click();
+        final String dayLabel = DATE_PICKER_DAY_FORMATTER.withLocale(locale).format(nextEndDate);
+        page.locator("%s .duet-date__day:has(.duet-date__vhidden:text-is('%s'))"
+            .formatted(DUET_CUSTOM_NEXT_END_DATE_PICKER_SELECTOR, dayLabel)).click();
+    }
+
+    /**
+     * Asserts the date the datepicker of the custom next end date shows.
+     */
+    public void showsCustomNextEndDate(LocalDate nextEndDate) {
+        assertThat(page.locator(DUET_CUSTOM_NEXT_END_DATE_SELECTOR))
+            .hasValue(DATE_PICKER_FORMATTER.withLocale(locale).format(nextEndDate));
     }
 
     /**

--- a/src/test/java/org/synyx/urlaubsverwaltung/ui/pages/SickNoteExtensionPage.java
+++ b/src/test/java/org/synyx/urlaubsverwaltung/ui/pages/SickNoteExtensionPage.java
@@ -60,6 +60,14 @@ public class SickNoteExtensionPage {
     }
 
     /**
+     * Asks for the preview of the custom date. Does not wait for anything, the preview is rendered
+     * asynchronously.
+     */
+    public void clickCustomDatePreview() {
+        page.locator("#submit-date-button").click();
+    }
+
+    /**
      * Asserts that extending until the end of the week is not offered, which is the case when the sick note
      * does not end before it.
      */


### PR DESCRIPTION
Der "Vorschau"-Knopf des freien Datums ist ein einfacher Submit-Knopf und das Datumsfeld ist nicht `required`. Er lässt sich also mit leerem Feld drücken – auch nach einer Schnellwahl, deren Enddatum dabei mit dem leeren Datum überschrieben wird. Der Validator hat dieses fehlende Datum dereferenziert, die Seite antwortete mit einem 500er.

Ein fehlendes Datum wird jetzt genauso abgelehnt wie ein Datum, das nicht nach dem Ende der Krankmeldung liegt – das ist es ja auch:

```java
// SickNoteExtendValidator
if (nextEndDate == null || !nextEndDate.isAfter(sickNoteEndDate)) {

// SickNoteExtendViewController
if (customDateSubmit.isPresent() && extendToDate != null) {
```

Die zweite Änderung ist nötig, nicht nur Beifang: mit dem Validator allein wandert die `NullPointerException` in die Vorschau, wo `workingTimeCalendar.workingTime(startDate, null)` über dasselbe fehlende Datum stolpert.

### Woher das leere Datum kommt

Die Oberfläche schickt `extendToDate` zweimal. In Chromium mitgeschnitten, nachdem eine Schnellwahl gedrückt und danach "Vorschau" geklickt wurde:

```
sickNoteId=1&startDate=2022-02-04&endDate=2022-02-07&extendToDate=&extendToDate=2022-02-07&custom-date-preview=
```

Spring bindet den ersten Wert, und der ist leer.

Das zweite Feld entsteht beim Morphen. Nach dem Hydrieren trägt das innere Input des `duet-date-picker` die id des serverseitigen `input[type=date]` – `createDatepicker` reicht sie als `identifier` an duet weiter. Idiomorph findet die beiden über diese id und **morpht** deshalb das vorhandene Element, statt ein neues hinzuzufügen. Dabei zieht es das Input aus dem Datepicker heraus, gemessen direkt nach einer Schnellwahl:

```
#extend-to-date-input → INPUT type=date name=extendToDate value=""
                        parent: DIV.extend-action-grid          ← nicht mehr im Datepicker
duet-date-picker      → <div class="duet-date"><div class="duet-date__input-wrapper">
                          <input type="hidden" name="extendToDate" value="2022-02-07">
                          <button class="duet-date__toggle">    ← das sichtbare Input fehlt
```

`beforeNodeAdded` hat also nie gegriffen, der Guard dort war toter Code. `beforeNodeRemoved` gab `datepickers.includes(node)` zurück, damit `false`, was das Entfernen verhindert – die leere Hülle des Datepickers blieb stehen.

Das erklärt beide Wege aus dem Ticket:

* **Schnellwahl, dann Vorschau.** Der Server rendert das Input nach einer Schnellwahl leer: `th:field="*{extendToDate}"` gewinnt gegen `th:value="${extendToDate}"` (Precedence 1200 gegen 1000), und der Controller setzt das DTO-Feld für jeden Submit ohne freies Datum auf `null`. Das herausgelöste, veraltete Feld steht im Formular vor dem versteckten des Datepickers – der leere Wert kommt zuerst an.
* **Datum wählen, dann zweimal Vorschau.** Nach der ersten Vorschau ist der Datepicker ausgeweidet. Ein im Dialog gewähltes Datum schreibt duet in das herausgelöste `input[type=date]`, das das deutsche Format nicht annimmt – im Feld steht dann `dd.mm.yyyy`, und der nächste Klick schickt es leer mit.

Nebenbei: rendert die Seite danach noch einmal, steht `value=",2022-02-07"` im Input. Spring hat die beiden Parameter zu einem String zusammengezogen. Das Javadoc von `SickNoteExtendDto.extendToDate` behauptete, das Feld habe keinen Wert – es ist das, was das Datumsfeld rendert.

### Der Morph lässt den Datepicker jetzt in Ruhe

`morphKeepingDatepickers` nimmt das serverseitige Input aus dem neuen HTML heraus, nachdem es dessen Klassen an den Datepicker weitergereicht hat. Damit gibt es keine id mehr, über die Idiomorph die beiden zusammenbringen könnte, und kein zweites Feld im Formular. Der Datepicker hat im neuen HTML keine Entsprechung und wird weiterhin über `beforeNodeRemoved` behalten.

Die Logik ist dafür aus dem Bundle in die Datepicker-Komponente gewandert. Ein Bundle lässt sich nicht importieren, ohne turbo zu starten und einen Datepicker zu hydrieren, und war deshalb gar nicht getestet.

### Und das Loch, das die fehlende Schnellwahl im Raster hinterließ

Beim Nachschauen in der Oberfläche noch aufgefallen: das Raster der Optionen wies jeder Option ihren Platz über `nth-of-type` zu. "Ende der Woche" wird aber nur angeboten, wenn das Ende dieser Woche nach dem Ende der Krankmeldung liegt – ohne die Schnellwahl blieb der dritte Platz leer, weil der Datepicker fest auf dem vierten saß, und `span:nth-of-type(3)` griff plötzlich die Beschriftung des freien Datums, die sonst von allein neben ihm landet. "bis anderer Tag" stand damit unter dem leeren Platz statt unter seinem Feld, bei `md` neben und bei `xs` unter der Lücke.

Die Optionen stehen im Markup ohnehin schon als Aktion gefolgt von ihrer Beschriftung, also ordnet das Raster sie jetzt selbst an: ein Paar je Zeile, ab `md` ein Paar je Spalte. Das passt sich von allein an zwei, drei oder vier Optionen an und kommt ohne eine Regel je Option aus. Mit angebotenem "Ende der Woche" ist die Seite Pixel für Pixel dieselbe wie vorher, geprüft bei 1500, 700 und 380 Pixeln Breite – diese Änderung ist nur visuell geprüft, ohne Test.

Zwei Kleinigkeiten fielen dabei mit ab: die beiden Regeln für `.extend-action-grid > label` haben nie gegriffen, weil die Beschriftung des freien Datums zusammen mit dem Vorschau-Knopf in einem `span` steckt, und `grid-template-columns: fit-content(1fr)` war kein gültiger Wert.

### Tests

* `SickNoteExtendValidatorTest.ensureEndDateMustBeGivenAtAll` – dort, wo der Fehler sitzt
* `SickNoteExtendViewControllerTest.ensurePreviewWithoutACustomDateRendersThePageAgain` – baut den Controller mit dem *echten* Validator, der der Testklasse ist ein Mock. Genau deshalb hat kein Test der Seite das je gesehen. Beide Tests waren mit der `NullPointerException` aus dem Ticket rot.
* `SickNoteUIIT.picksACustomDateAfterAQuickSelection` – wählt nach einer Schnellwahl ein Datum im Dialog des Datepickers. Vorher lief der Test in einen Timeout, weil der Datepicker sein Input nicht mehr hatte.
* `morph.spec.js` – sieben Fälle gegen ein Fixture des *hydrierten* Datepickers, dessen inneres Input die id trägt. Nur damit greift die id-Zuordnung von Idiomorph; ein Fixture ohne dieses Input nimmt einen anderen Zweig und wäre auch gegen den kaputten Stand grün. Gegen ein blankes `Idiomorph.morph` melden die Specs die ausgeweidete Hülle und das leere Feld – und einen Fehler, der beim Schreiben entstanden war: die Klasse, mit der duet das hydrierte Element markiert, darf beim Übernehmen der Klassen nicht verloren gehen, sonst ist der Datepicker unsichtbar.
* Die Vorschau war überhaupt nicht getestet, weder die des freien Datums noch die der Schnellwahl, und der Validator hatte keinen Test für ein Datum, das er annimmt: `ensurePreviewOfACustomDateIsTheDateItself`, `ensurePreviewOfAQuickSelectionIsTheNextWorkDay` und `ensureNoErrorWhenTheEndDateIsAfterTheEndOfTheSickNote`. Alle drei sind gegen eine mutierte Bedingung rot.

### Reihenfolge

Der Branch basiert auf #6627, weil die Erweiterungsseite dort umgebaut wird. Der Zielbranch dieses PRs ist entsprechend `4930-sick-note-extend-when-shown`; GitHub zieht ihn nach dem Merge von #6627 automatisch auf `main` um.

closes #6489

