### PR TITLE
Auf der Detailseite einer Krankmeldung klebt die zweite Spalte an der ersten

### DIFF
--- a/src/main/resources/templates/sicknote/sick_note_detail.html
+++ b/src/main/resources/templates/sicknote/sick_note_detail.html
@@ -27,7 +27,7 @@
   <body th:replace="~{_layout::body(content=~{::main})}">
     <main
       th:fragment="main"
-      class="content-container content--max-w @5xl/main:grid @5xl/main:grid-cols-2 @5xl/main:gap-8"
+      class="content-container content--max-w space-y-8 @5xl/main:space-y-0 @5xl/main:grid @5xl/main:grid-cols-2 @5xl/main:gap-8"
     >
       <div>
         <div


### PR DESCRIPTION
Die Detailseite der Krankmeldung legt ihre beiden Spalten über eine Container-Query aus:

```html
<main class="content-container content--max-w @5xl/main:grid @5xl/main:grid-cols-2 @5xl/main:gap-8">
```

Der Abstand zwischen den Spalten kam allein aus `gap-8` und gilt damit nur innerhalb des Grids. Unterhalb von `@5xl` ist `main` ein normaler Block, die beiden `div` stapeln sich, und zwischen ihnen liegt nichts mehr – bei einer beantragten Verlängerung klebt der grüne Knopf "Verlängerung akzeptieren" an der Überschrift "Mitarbeiter".

`space-y-8 @5xl/main:space-y-0` trennt sie gestapelt und nimmt den Abstand im Grid wieder heraus. Genauso macht es die Personen-Detailseite (`person_detail.html`) schon.

### Gemessen

An der laufenden Anwendung, Abstand zwischen dem Knopf und der Überschrift:

| Fensterbreite | Breite von `main` | `display` | vorher | nachher |
| --- | --- | --- | --- | --- |
| 1600 | 1280 | grid | nebeneinander | unverändert |
| 1323 | 1023 | block | 0 px | 32 px |
| 900 | 900 | block | 0 px | 32 px |

Die 32 px entsprechen dem `gap-8` des Grids.

Warum es so lange niemandem auffiel: die Breite von `main` läuft nicht mit der Fensterbreite mit. Bei 1400 Pixeln ist die Navigation ausgeklappt und `main` 1100 breit, bei 1200 Pixeln ist sie eingeklappt und `main` wieder 1200 breit. Es braucht also ungefähr 1250 bis 1330 Pixel, um `main` unter die 1024 der Container-Query zu bringen.

### Kein Test

Reine CSS-Klasse, geprüft an der laufenden Anwendung bei 1600, 1323 und 900 Pixeln Breite.

### Nebenbei geprüft

`application/application-detail.html` und `overtime/overtime_details.html` bauen ihre Spalten genauso auf. Beide haben gestapelt aber schon 32 px zwischen den Spalten, der Fehler tritt dort also nicht auf. Woher der Abstand dort kommt, konnte ich nicht auf eine Regel zurückführen – er scheint aus einem durchschlagenden `margin-bottom` am Ende der ersten Spalte zu stammen und damit eher zufällig zu sein. Angefasst habe ich die beiden nicht.


closes #6640