### PR TITLE
Remove the beta hint from the sick note settings

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1112,7 +1112,6 @@ settings.avatar.gravatarEnabled.activation.false=deaktivieren
 settings.avatar.gravatarEnabled.activation.title=Avatare
 settings.avatar.gravatarEnabled.activation.true=aktivieren
 settings.avatar.gravatarEnabled.activation=Avatare über externen Dienst Gravatar darstellen
-settings.betaTag=BETA
 settings.calendar.google.action.authenticate.description=Handshake noch nicht erfolgreich durchgeführt.
 settings.calendar.google.action.authenticate.success=Verbindung zum Google-Kalender ist hergestellt.
 settings.calendar.google.action.authenticate=Zugriff erlauben...
@@ -1166,7 +1165,6 @@ settings.publicHolidays.federalState=Globale Feiertagsregelung
 settings.publicHolidays.title=Einstellungen zu Feiertagen
 settings.publicHolidays.workingDuration.christmasEve=Arbeitsdauer an Heiligabend
 settings.publicHolidays.workingDuration.newYearsEve=Arbeitsdauer an Silvester
-settings.sickDays.betaUserIsAllowedToSubmitSickNotes=Das eigenständige Eintragen von Krankmeldungen durch den Benutzer ist in dieser Version neu dabei. Wir haben hier noch viel vor. Weitere Details dazu findest du unter den <a target="_blank" href="https://urlaubsverwaltung.cloud/neuigkeiten/2024-06-21-selbsteintragen-von-krankmeldungen">Neuigkeiten auf urlaubsverwaltung.cloud</a>.
 settings.sickDays.daysBeforeEndOfSickPayNotification.error=Benachrichtigung über Lohnfortzahlungsende muss vor Ende der Lohnfortzahlung erfolgen.
 settings.sickDays.daysBeforeEndOfSickPayNotification=Wie viele Tage im Voraus soll der Arbeitnehmer über Lohnfortzahlungsende benachrichtigt werden
 settings.sickDays.description=Die Einstellungen zur Lohnfortzahlung bestimmen, wann der erkrankte Mitarbeiter und die Office-Mitarbeitenden per E-Mail über das Ende der Lohnfortzahlung informiert werden.

--- a/src/main/resources/messages_de_AT.properties
+++ b/src/main/resources/messages_de_AT.properties
@@ -1112,7 +1112,6 @@ settings.avatar.gravatarEnabled.activation.false=deaktivieren
 settings.avatar.gravatarEnabled.activation.title=Avatare
 settings.avatar.gravatarEnabled.activation.true=aktivieren
 settings.avatar.gravatarEnabled.activation=Avatare über externen Dienst Gravatar darstellen
-settings.betaTag=BETA
 settings.calendar.google.action.authenticate.description=Handshake noch nicht erfolgreich durchgeführt.
 settings.calendar.google.action.authenticate.success=Verbindung zum Google-Kalender ist hergestellt.
 settings.calendar.google.action.authenticate=Zugriff erlauben...
@@ -1166,7 +1165,6 @@ settings.publicHolidays.federalState=Globale Feiertagsregelung
 settings.publicHolidays.title=Einstellungen zu Feiertagen
 settings.publicHolidays.workingDuration.christmasEve=Arbeitsdauer an Heiligabend
 settings.publicHolidays.workingDuration.newYearsEve=Arbeitsdauer an Silvester
-settings.sickDays.betaUserIsAllowedToSubmitSickNotes=Das eigenständige Eintragen von Krankmeldungen durch den Benutzer ist in dieser Version neu dabei. Wir haben hier noch viel vor. Weitere Details dazu findest du unter den <a target="_blank" href="https://urlaubsverwaltung.cloud/neuigkeiten/2024-06-21-selbsteintragen-von-krankmeldungen">Neuigkeiten auf urlaubsverwaltung.cloud</a>.
 settings.sickDays.daysBeforeEndOfSickPayNotification.error=Benachrichtigung über Lohnfortzahlungsende muss vor Ende der Lohnfortzahlung erfolgen.
 settings.sickDays.daysBeforeEndOfSickPayNotification=Wie viele Tage im Voraus soll der Arbeitnehmer über Lohnfortzahlungsende benachrichtigt werden
 settings.sickDays.description=Die Einstellungen zur Lohnfortzahlung bestimmen, wann der erkrankte Mitarbeiter und die Office-Mitarbeitenden per E-Mail über das Ende der Lohnfortzahlung informiert werden.

--- a/src/main/resources/messages_el.properties
+++ b/src/main/resources/messages_el.properties
@@ -1112,7 +1112,6 @@ settings.avatar.gravatarEnabled.activation.false=Απενεργοποίηση
 settings.avatar.gravatarEnabled.activation.title=Άβαταρ
 settings.avatar.gravatarEnabled.activation.true=Ενεργοποίηση
 settings.avatar.gravatarEnabled.activation=Εμφάνιση άβαταρ χρησιμοποιώντας την εξωτερική υπηρεσία Gravatar
-settings.betaTag=BETA
 settings.calendar.google.action.authenticate.description=Η διαδικασία ταυτοποίησης δεν έχει ολοκληρωθεί με επιτυχία ακόμη.
 settings.calendar.google.action.authenticate.success=Η σύνδεση με το Ημερολόγιο Google έχει πραγματοποιηθεί με επιτυχία.
 settings.calendar.google.action.authenticate=Επίτρεψε την πρόσβαση...
@@ -1166,7 +1165,6 @@ settings.publicHolidays.federalState=Κανονισμός επίσημων αρ�
 settings.publicHolidays.title=Ρυθμίσεις επίσημων αργιών
 settings.publicHolidays.workingDuration.christmasEve=Ωράριο εργασίας την παραμονή των Χριστουγέννων
 settings.publicHolidays.workingDuration.newYearsEve=Ώρα εργασίας την παραμονή της Πρωτοχρονιάς
-settings.sickDays.betaUserIsAllowedToSubmitSickNotes=Ένα νέο χαρακτηριστικό σε αυτή την έκδοση είναι η ανεξάρτητη από τον χρήστη καταχώρηση σημειώσεων ασθενείας. Έχουμε ακόμα πολλά προγραμματισμένα εδώ. Μπορείτε να βρείτε περισσότερες λεπτομέρειες σχετικά με αυτό στο <a target="_blank" href="https://urlaubsverwaltung.cloud/neuigkeiten/2024-06-21-selbsteintragen-von-krankmeldungen">urlaubsverwaltung.cloud Τελευταία νέα</a>.
 settings.sickDays.daysBeforeEndOfSickPayNotification.error=Η ειδοποίηση λήξης πληρωμής μισθού πρέπει να γίνει πριν από τη λήξη της συνέχισης του μισθού.
 settings.sickDays.daysBeforeEndOfSickPayNotification=Πόσες μέρες νωρίτερα θα πρέπει να ειδοποιηθεί ο εργαζόμενος πριν από τη λήξη της αμοιβής ασθενείας.
 settings.sickDays.description=Οι ρυθμίσεις αμοιβής ασθενείας καθορίζουν πότε ο άρρωστος υπάλληλος και το προσωπικό του γραφείου ενημερώνονται μέσω email για τη λήξη της αμοιβής ασθενείας.

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -1113,7 +1113,6 @@ settings.avatar.gravatarEnabled.activation.false=Deactivate
 settings.avatar.gravatarEnabled.activation.title=Avatars
 settings.avatar.gravatarEnabled.activation.true=Activate
 settings.avatar.gravatarEnabled.activation=Display avatars using external service Gravatar
-settings.betaTag=BETA
 settings.calendar.google.action.authenticate.description=Handshake not yet successfully completed.
 settings.calendar.google.action.authenticate.success=Connection to the Google Calendar is established.
 settings.calendar.google.action.authenticate=Allow access...
@@ -1167,7 +1166,6 @@ settings.publicHolidays.federalState=Global public holiday regulation
 settings.publicHolidays.title=Public holidays settings
 settings.publicHolidays.workingDuration.christmasEve=Working hours on Christmas Eve
 settings.publicHolidays.workingDuration.newYearsEve=Working time on New Year's Eve
-settings.sickDays.betaUserIsAllowedToSubmitSickNotes=The independent entry of sick notes by the user is new in this version. We still have a lot planned here. You can find more details on <a target="_blank" href="https://urlaubsverwaltung.cloud/neuigkeiten/2024-06-21-selbsteintragen-von-krankmeldungen">urlaubsverwaltung.cloud News</a>
 settings.sickDays.daysBeforeEndOfSickPayNotification.error=Notification of the end of sick pay must be sent before the sick pay ends.
 settings.sickDays.daysBeforeEndOfSickPayNotification=How many days in advance should the employee be notified before the end of the sick pay.
 settings.sickDays.description=The sick pay settings determine when the sick employee and the office staff are informed by email about the end of the sick pay.

--- a/src/main/resources/templates/settings/absences/sick-days.html
+++ b/src/main/resources/templates/settings/absences/sick-days.html
@@ -64,18 +64,6 @@
       </div>
 
       <div class="uv-form__group">
-        <div class="uv-form__group-info uv-help-block">
-          <p>
-            <span
-              class="px-1.5 no-underline rounded-full bg-blue-100 text-blue-800 dark:border dark:border-blue-600 dark:text-blue-600 dark:bg-transparent"
-              th:text="#{settings.betaTag}"
-            >
-              BETA
-            </span>
-            <span th:utext="#{settings.sickDays.betaUserIsAllowedToSubmitSickNotes}"></span>
-          </p>
-        </div>
-
         <!-- Allow users to submit their own sick notes -->
         <div class="uv-form__input-row">
           <p


### PR DESCRIPTION
Entfernt den BETA-Hinweis über der Einstellung "Benutzer können Krankmeldungen selbst eintragen" (*Einstellungen → Abwesenheiten → Krankmeldungen*).

Der Hinweis kam mit 5.4.0 (Juni 2024) und sagte "in dieser Version neu dabei" — gut ein Jahr später trifft das nicht mehr zu, und das BETA-Label lässt eine etablierte Funktion unfertig wirken.

- `settings/absences/sick-days.html`: `uv-form__group-info`-Block mit BETA-Label und Hinweistext gelöscht
- `settings.betaTag` und `settings.sickDays.betaUserIsAllowedToSubmitSickNotes` aus `messages.properties`, `messages_en`, `messages_de_AT` und `messages_el` entfernt

`settings.betaTag` war nur an dieser einen Stelle verwendet und ist damit projektweit weg. Die Einstellung selbst und ihr Verhalten bleiben unverändert.

closes #6642
